### PR TITLE
Add doctest support for Python doctests

### DIFF
--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -649,6 +649,7 @@ fn collect_tests_from_body(
                 xfail,
                 tags,
                 groups: groups.to_vec(),
+                ..TestItem::default()
             });
         } else if let Stmt::With(with_stmt) = stmt {
             // Check if this is a `with describe("name")` block
@@ -674,6 +675,96 @@ fn collect_tests_from_body(
     }
 }
 
+/// Returns `true` if the first statement in `body` is a string literal
+/// whose text contains `>>>` (i.e. a docstring with doctest examples).
+fn has_doctest_in_docstring(body: &[Stmt]) -> bool {
+    if let Some(Stmt::Expr(s)) = body.first()
+        && let Expr::StringLiteral(lit) = &*s.value
+    {
+        return lit.value.to_str().contains(">>>");
+    }
+    false
+}
+
+/// Walk the module body and emit a [`TestItem`] for every object whose
+/// docstring contains `>>>` examples.
+fn collect_doctests_from_body(
+    stmts: &[Stmt],
+    root: &Path,
+    file: &Path,
+    line_index: &LineIndex,
+    prefix: &str,
+    out: &mut Vec<TestItem>,
+) {
+    // Module-level docstring (only when prefix is empty, i.e. top-level call).
+    if prefix.is_empty()
+        && has_doctest_in_docstring(stmts)
+        && let Some(Stmt::Expr(s)) = stmts.first()
+    {
+        let line = u32::try_from(line_index.line_index(s.range.start()).get()).unwrap_or(1);
+        out.push(TestItem {
+            name: "__module__".to_owned(),
+            module_path: path_to_module(root, file),
+            file_path: Some(file.strip_prefix(root).unwrap_or(file).to_path_buf()),
+            line_number: Some(line),
+            display_name: Some("doctest: (module)".to_owned()),
+            doctest_object: Some(String::new()),
+            ..TestItem::default()
+        });
+    }
+
+    for stmt in stmts {
+        match stmt {
+            Stmt::FunctionDef(func) => {
+                if has_doctest_in_docstring(&func.body) {
+                    let object_path = if prefix.is_empty() {
+                        func.name.id.as_str().to_owned()
+                    } else {
+                        format!("{prefix}.{}", func.name.id.as_str())
+                    };
+                    let line =
+                        u32::try_from(line_index.line_index(func.range.start()).get()).unwrap_or(1);
+                    out.push(TestItem {
+                        name: object_path.clone(),
+                        module_path: path_to_module(root, file),
+                        file_path: Some(file.strip_prefix(root).unwrap_or(file).to_path_buf()),
+                        line_number: Some(line),
+                        display_name: Some(format!("doctest: {object_path}")),
+                        doctest_object: Some(object_path),
+                        ..TestItem::default()
+                    });
+                }
+            }
+            Stmt::ClassDef(class) => {
+                let class_name = if prefix.is_empty() {
+                    class.name.id.as_str().to_owned()
+                } else {
+                    format!("{prefix}.{}", class.name.id.as_str())
+                };
+
+                // Class-level docstring
+                if has_doctest_in_docstring(&class.body) {
+                    let line = u32::try_from(line_index.line_index(class.range.start()).get())
+                        .unwrap_or(1);
+                    out.push(TestItem {
+                        name: class_name.clone(),
+                        module_path: path_to_module(root, file),
+                        file_path: Some(file.strip_prefix(root).unwrap_or(file).to_path_buf()),
+                        line_number: Some(line),
+                        display_name: Some(format!("doctest: {class_name}")),
+                        doctest_object: Some(class_name.clone()),
+                        ..TestItem::default()
+                    });
+                }
+
+                // Recurse into methods
+                collect_doctests_from_body(&class.body, root, file, line_index, &class_name, out);
+            }
+            _ => {}
+        }
+    }
+}
+
 pub(crate) fn parse_tests_from_source(root: &Path, file: &Path, source: &str) -> Vec<TestItem> {
     trace!(
         "parsing {}",
@@ -688,6 +779,7 @@ pub(crate) fn parse_tests_from_source(root: &Path, file: &Path, source: &str) ->
     let body = &module.body;
     let mut tests = Vec::new();
     collect_tests_from_body(body, body, root, file, source, &line_index, &[], &mut tests);
+    collect_doctests_from_body(body, root, file, &line_index, "", &mut tests);
     tests
 }
 
@@ -1600,5 +1692,114 @@ def test_second():
         for pair in items.windows(2) {
             assert!(pair[0].line_number < pair[1].line_number);
         }
+    }
+
+    #[test]
+    fn discovers_function_doctest() {
+        let source = r#"
+def add(a, b):
+    """Add two numbers.
+
+    >>> add(1, 2)
+    3
+    """
+    return a + b
+"#;
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "add");
+        assert_eq!(items[0].doctest_object, Some("add".to_string()));
+        assert_eq!(items[0].display_name, Some("doctest: add".to_string()));
+    }
+
+    #[test]
+    fn discovers_class_and_method_doctests() {
+        let source = r#"
+class Calc:
+    """A calculator.
+
+    >>> c = Calc()
+    >>> c.value
+    0
+    """
+
+    def __init__(self):
+        self.value = 0
+
+    def add(self, n):
+        """Add n.
+
+        >>> c = Calc()
+        >>> c.add(5)
+        >>> c.value
+        5
+        """
+        self.value += n
+"#;
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].doctest_object, Some("Calc".to_string()));
+        assert_eq!(items[1].doctest_object, Some("Calc.add".to_string()));
+    }
+
+    #[test]
+    fn discovers_module_level_doctest() {
+        let source = r#"
+"""Module with doctest.
+
+>>> 1 + 1
+2
+"""
+
+def helper():
+    pass
+"#;
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "__module__");
+        assert_eq!(items[0].doctest_object, Some(String::new()));
+    }
+
+    #[test]
+    fn no_doctests_without_chevrons() {
+        let source = r#"
+def foo():
+    """Just a plain docstring."""
+    pass
+"#;
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn doctests_and_decorated_tests_coexist() {
+        let source = r#"
+from tryke import test, expect
+
+def add(a, b):
+    """Add two numbers.
+
+    >>> add(1, 2)
+    3
+    """
+    return a + b
+
+@test
+def test_add():
+    expect(add(1, 2)).to_equal(3)
+"#;
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file);
+        assert_eq!(items.len(), 2);
+        // Decorated test comes first (collect_tests_from_body runs first)
+        assert_eq!(items[0].name, "test_add");
+        assert!(items[0].doctest_object.is_none());
+        // Doctest comes second
+        assert_eq!(items[1].name, "add");
+        assert_eq!(items[1].doctest_object, Some("add".to_string()));
     }
 }

--- a/crates/tryke_runner/src/protocol.rs
+++ b/crates/tryke_runner/src/protocol.rs
@@ -33,6 +33,12 @@ pub struct RunTestParams {
 }
 
 #[derive(Debug, Serialize)]
+pub struct RunDoctestParams {
+    pub module: String,
+    pub object_path: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct ReloadParams {
     pub modules: Vec<String>,
 }

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -8,7 +8,8 @@ use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 use tryke_types::{Assertion, ExpectedAssertion, TestItem, TestOutcome, TestResult};
 
 use crate::protocol::{
-    AssertionWire, ReloadParams, RpcRequest, RpcResponse, RunTestParams, RunTestResultWire,
+    AssertionWire, ReloadParams, RpcRequest, RpcResponse, RunDoctestParams, RunTestParams,
+    RunTestResultWire,
 };
 
 pub struct WorkerProcess {
@@ -86,12 +87,24 @@ impl WorkerProcess {
 
     #[expect(clippy::missing_errors_doc)]
     pub async fn run_test(&mut self, test: &TestItem) -> Result<TestResult> {
+        if let Some(object_path) = &test.doctest_object {
+            return self.run_doctest(test, object_path).await;
+        }
         let params = serde_json::to_value(RunTestParams {
             module: test.module_path.clone(),
             function: test.name.clone(),
             xfail: test.xfail.clone(),
         })?;
         let wire: RunTestResultWire = self.call("run_test", Some(params)).await?;
+        Ok(convert_result(test.clone(), wire))
+    }
+
+    async fn run_doctest(&mut self, test: &TestItem, object_path: &str) -> Result<TestResult> {
+        let params = serde_json::to_value(RunDoctestParams {
+            module: test.module_path.clone(),
+            object_path: object_path.to_owned(),
+        })?;
+        let wire: RunTestResultWire = self.call("run_doctest", Some(params)).await?;
         Ok(convert_result(test.clone(), wire))
     }
 

--- a/crates/tryke_types/src/lib.rs
+++ b/crates/tryke_types/src/lib.rs
@@ -64,6 +64,12 @@ pub struct TestItem {
     pub tags: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub groups: Vec<String>,
+    /// When `Some`, this item represents a doctest rather than a normal test.
+    /// The value is the dotted attribute path to the object whose docstring
+    /// should be tested (e.g. `"Foo.bar"`), or an empty string for the
+    /// module-level docstring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub doctest_object: Option<String>,
 }
 
 impl TestItem {

--- a/python/tryke/expect.py
+++ b/python/tryke/expect.py
@@ -290,6 +290,11 @@ class MatchResult:
     def __init__(self, error: ExpectationError | None) -> None:
         self._error = error
 
+    def __repr__(self) -> str:
+        if self._error is None:
+            return "MatchResult(ok)"
+        return "MatchResult(failed)"
+
     def fatal(self) -> None:
         """Stop the test immediately if this assertion failed.
 
@@ -327,10 +332,11 @@ class Expectation[T]:
     Use `.not_` to negate any assertion.
 
     Example:
-        ```python
-        expect(1 + 1).to_equal(2)
-        expect(None).not_.to_be_truthy()
-        ```
+        >>> from tryke import expect
+        >>> expect(1 + 1).to_equal(2)
+        MatchResult(ok)
+        >>> expect(None).not_.to_be_truthy()
+        MatchResult(ok)
     """
 
     def __init__(self, value: T, *, negated: bool = False) -> None:
@@ -342,10 +348,11 @@ class Expectation[T]:
         """Negate the next assertion.
 
         Example:
-            ```python
-            expect(1).not_.to_equal(2)
-            expect(None).not_.to_be_truthy()
-            ```
+            >>> from tryke import expect
+            >>> expect(1).not_.to_equal(2)
+            MatchResult(ok)
+            >>> expect(None).not_.to_be_truthy()
+            MatchResult(ok)
         """
         return Expectation(self._value, negated=not self._negated)
 
@@ -378,10 +385,11 @@ class Expectation[T]:
             other: The value to compare against.
 
         Example:
-            ```python
-            expect(1 + 1).to_equal(2)
-            expect([1, 2]).to_equal([1, 2])
-            ```
+            >>> from tryke import expect
+            >>> expect(1 + 1).to_equal(2)
+            MatchResult(ok)
+            >>> expect([1, 2]).to_equal([1, 2])
+            MatchResult(ok)
         """
         return self._assert(
             self._value == other,
@@ -397,10 +405,10 @@ class Expectation[T]:
             other: The object to compare identity against.
 
         Example:
-            ```python
-            sentinel = object()
-            expect(sentinel).to_be(sentinel)
-            ```
+            >>> from tryke import expect
+            >>> sentinel = object()
+            >>> expect(sentinel).to_be(sentinel)
+            MatchResult(ok)
         """
         return self._assert(
             self._value is other,
@@ -413,10 +421,11 @@ class Expectation[T]:
         """Assert the value is truthy (`bool(value) is True`).
 
         Example:
-            ```python
-            expect(1).to_be_truthy()
-            expect([1]).to_be_truthy()
-            ```
+            >>> from tryke import expect
+            >>> expect(1).to_be_truthy()
+            MatchResult(ok)
+            >>> expect([1]).to_be_truthy()
+            MatchResult(ok)
         """
         return self._assert(
             bool(self._value),
@@ -429,10 +438,11 @@ class Expectation[T]:
         """Assert the value is falsy (`bool(value) is False`).
 
         Example:
-            ```python
-            expect(0).to_be_falsy()
-            expect("").to_be_falsy()
-            ```
+            >>> from tryke import expect
+            >>> expect(0).to_be_falsy()
+            MatchResult(ok)
+            >>> expect("").to_be_falsy()
+            MatchResult(ok)
         """
         return self._assert(
             not bool(self._value),
@@ -445,10 +455,11 @@ class Expectation[T]:
         """Assert the value is `None`.
 
         Example:
-            ```python
-            expect(None).to_be_none()
-            expect(result).not_.to_be_none()
-            ```
+            >>> from tryke import expect
+            >>> expect(None).to_be_none()
+            MatchResult(ok)
+            >>> expect(42).not_.to_be_none()
+            MatchResult(ok)
         """
         return self._assert(
             self._value is None,
@@ -464,9 +475,9 @@ class Expectation[T]:
             n: The value to compare against.
 
         Example:
-            ```python
-            expect(5).to_be_greater_than(3)
-            ```
+            >>> from tryke import expect
+            >>> expect(5).to_be_greater_than(3)
+            MatchResult(ok)
         """
         return self._assert(
             self._value > n,
@@ -482,9 +493,9 @@ class Expectation[T]:
             n: The value to compare against.
 
         Example:
-            ```python
-            expect(3).to_be_less_than(5)
-            ```
+            >>> from tryke import expect
+            >>> expect(3).to_be_less_than(5)
+            MatchResult(ok)
         """
         return self._assert(
             self._value < n,
@@ -500,9 +511,9 @@ class Expectation[T]:
             n: The value to compare against.
 
         Example:
-            ```python
-            expect(5).to_be_greater_than_or_equal(5)
-            ```
+            >>> from tryke import expect
+            >>> expect(5).to_be_greater_than_or_equal(5)
+            MatchResult(ok)
         """
         return self._assert(
             self._value >= n,  # type: ignore[operator]
@@ -518,9 +529,9 @@ class Expectation[T]:
             n: The value to compare against.
 
         Example:
-            ```python
-            expect(4).to_be_less_than_or_equal(5)
-            ```
+            >>> from tryke import expect
+            >>> expect(4).to_be_less_than_or_equal(5)
+            MatchResult(ok)
         """
         return self._assert(
             self._value <= n,  # type: ignore[operator]
@@ -538,10 +549,11 @@ class Expectation[T]:
             item: The item to search for.
 
         Example:
-            ```python
-            expect([1, 2, 3]).to_contain(2)
-            expect("hello world").to_contain("world")
-            ```
+            >>> from tryke import expect
+            >>> expect([1, 2, 3]).to_contain(2)
+            MatchResult(ok)
+            >>> expect("hello world").to_contain("world")
+            MatchResult(ok)
         """
         return self._assert(
             item in self._value,
@@ -557,10 +569,11 @@ class Expectation[T]:
             n: The expected length.
 
         Example:
-            ```python
-            expect([1, 2, 3]).to_have_length(3)
-            expect("hello").to_have_length(5)
-            ```
+            >>> from tryke import expect
+            >>> expect([1, 2, 3]).to_have_length(3)
+            MatchResult(ok)
+            >>> expect("hello").to_have_length(5)
+            MatchResult(ok)
         """
         actual = len(self._value)  # type: ignore[arg-type]
         return self._assert(
@@ -577,10 +590,11 @@ class Expectation[T]:
             pattern: A regular expression pattern.
 
         Example:
-            ```python
-            expect("hello world").to_match(r"hello")
-            expect("foo123").to_match(r"\\d+")
-            ```
+            >>> from tryke import expect
+            >>> expect("hello world").to_match(r"hello")
+            MatchResult(ok)
+            >>> expect("foo123").to_match(r"\\d+")
+            MatchResult(ok)
         """
         return self._assert(
             bool(re.search(pattern, str(self._value))),
@@ -604,11 +618,13 @@ class Expectation[T]:
             match: Regex pattern to match against the exception message.
 
         Example:
-            ```python
-            expect(lambda: int("abc")).to_raise(ValueError)
-            expect(lambda: 1 / 0).to_raise(ZeroDivisionError, match="division")
-            expect(lambda: None).not_.to_raise()
-            ```
+            >>> from tryke import expect
+            >>> expect(lambda: int("abc")).to_raise(ValueError)
+            MatchResult(ok)
+            >>> expect(lambda: 1 / 0).to_raise(ZeroDivisionError, match="division")
+            MatchResult(ok)
+            >>> expect(lambda: None).not_.to_raise()
+            MatchResult(ok)
         """
         if not callable(self._value):
             msg = "to_raise() requires a callable; wrap the expression in a lambda"
@@ -663,11 +679,10 @@ def expect[T](expr: T, name: str | None = None) -> Expectation[T]:  # noqa: ARG0
         An `Expectation` with chainable assertion methods.
 
     Example:
-        ```python
-        from tryke import expect
-
-        expect(1 + 1).to_equal(2)
-        expect("hello").to_contain("ell")
-        ```
+        >>> from tryke import expect
+        >>> expect(1 + 1).to_equal(2)
+        MatchResult(ok)
+        >>> expect("hello").to_contain("ell")
+        MatchResult(ok)
     """
     return Expectation(expr)

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import doctest
 import importlib
 import inspect
 import io
@@ -73,6 +74,12 @@ def _dispatch(method: str, params: dict, modules: dict[str, object]) -> object:
             params["function"],
             modules,
             xfail=params.get("xfail"),
+        )
+    if method == "run_doctest":
+        return _run_doctest(
+            params["module"],
+            params.get("object_path", ""),
+            modules,
         )
     if method == "reload":
         return _reload(params.get("modules", []), modules)
@@ -300,6 +307,64 @@ def _extract_assertions(exc: AssertionError) -> list[dict]:
                 }
             ]
     return []
+
+
+def _run_doctest(
+    module_name: str,
+    object_path: str,
+    modules: dict[str, object],
+) -> dict:
+    if module_name not in modules:
+        mod = importlib.import_module(module_name)
+        modules[module_name] = mod
+    else:
+        mod = modules[module_name]
+
+    # Resolve the target object whose docstring we want to test.
+    obj = mod
+    if object_path:
+        for attr in object_path.split("."):
+            obj = getattr(obj, attr)
+
+    finder = doctest.DocTestFinder(verbose=False, recurse=False)
+    tests = finder.find(obj, name=object_path or module_name)
+
+    output_buf = io.StringIO()
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+
+    runner = doctest.DocTestRunner(
+        verbose=False,
+        optionflags=doctest.ELLIPSIS,
+    )
+
+    start = time.monotonic()
+    with (
+        contextlib.redirect_stdout(stdout_buf),
+        contextlib.redirect_stderr(stderr_buf),
+    ):
+        for dt in tests:
+            runner.run(dt, out=output_buf.write, clear_globs=False)
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    summary = runner.summarize(verbose=False)
+
+    if summary.failed > 0:
+        return {
+            "outcome": "failed",
+            "message": output_buf.getvalue(),
+            "traceback": None,
+            "assertions": [],
+            "duration_ms": duration_ms,
+            "stdout": stdout_buf.getvalue(),
+            "stderr": stderr_buf.getvalue(),
+        }
+    return {
+        "outcome": "passed",
+        "duration_ms": duration_ms,
+        "stdout": stdout_buf.getvalue(),
+        "stderr": stderr_buf.getvalue(),
+    }
 
 
 def _reload(module_names: list[str], modules: dict[str, object]) -> None:

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,0 +1,70 @@
+"""Tests that tryke discovers and runs doctests correctly."""
+
+from __future__ import annotations
+
+from tryke import expect, test
+from tryke.expect import ExpectationError, MatchResult
+
+
+@test(name="MatchResult repr shows ok for passing assertion")
+def test_match_result_repr_ok() -> None:
+    result = expect(1).to_equal(1)
+    expect(repr(result)).to_equal("MatchResult(ok)")
+
+
+@test(name="MatchResult repr shows failed for failing assertion")
+def test_match_result_repr_failed() -> None:
+    # MatchResult(failed) is only observable in soft-assertion context;
+    # outside soft context, a failing assertion raises immediately.
+    result = MatchResult(None)
+    expect(repr(result)).to_equal("MatchResult(ok)")
+    err = ExpectationError("x", expected="1", received="2")
+    result_failed = MatchResult(err)
+    expect(repr(result_failed)).to_equal("MatchResult(failed)")
+
+
+@test(name="MatchResult __repr__ is defined")
+def test_match_result_has_repr() -> None:
+    expect(hasattr(MatchResult, "__repr__")).to_be_truthy()
+
+
+def add(a: int, b: int) -> int:
+    """Add two numbers.
+
+    >>> add(1, 2)
+    3
+    >>> add(0, 0)
+    0
+    """
+    return a + b
+
+
+def greet(name: str) -> str:
+    """Greet someone.
+
+    >>> greet("world")
+    'hello, world'
+    """
+    return f"hello, {name}"
+
+
+class Counter:
+    """A simple counter.
+
+    >>> c = Counter()
+    >>> c.value
+    0
+    """
+
+    def __init__(self) -> None:
+        self.value = 0
+
+    def increment(self) -> None:
+        """Increment the counter.
+
+        >>> c = Counter()
+        >>> c.increment()
+        >>> c.value
+        1
+        """
+        self.value += 1


### PR DESCRIPTION
Tryke now discovers `>>>` patterns in docstrings across all Python files
and runs them via Python's `doctest` module. Existing docstring examples
in `expect.py` are converted to executable doctests with `MatchResult`
repr support for deterministic output.

- Add `doctest_object` field to `TestItem` for doctest dispatch
- Add `RunDoctestParams` wire protocol and `run_doctest` RPC method
- Walk AST for module/function/class/method docstrings containing `>>>`
- Add `_run_doctest` handler using `DocTestFinder`/`DocTestRunner`
- Add `MatchResult.__repr__` returning `MatchResult(ok)` or `MatchResult(failed)`
- Convert 16 assertion method docstrings to executable doctests
- Add Rust discovery tests and Python integration tests

https://claude.ai/code/session_01Hpso8Rwz1H9Yj9ginP59Bo