### PR TITLE
Add @test.cases parametrization primitive

### DIFF
--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -193,6 +193,22 @@ fn is_locally_defined(name: &str, body: &[Stmt]) -> bool {
 
 const MARKER_ATTRS: &[&str] = &["skip", "todo", "xfail", "skip_if"];
 
+/// Returns `true` if `expr` is a `@test.cases(...)` call (bare or qualified).
+/// Must be a `Call` expression — the bare `test.cases` attribute form has no
+/// runtime meaning.
+fn is_tryke_test_cases_decorator(expr: &Expr, body: &[Stmt]) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+    let Expr::Attribute(attr) = &*call.func else {
+        return false;
+    };
+    if attr.attr.id.as_str() != "cases" {
+        return false;
+    }
+    is_bare_test_or_qualified(&attr.value, body)
+}
+
 /// Recognises bare `test` / `tryke.test` plus the marker attribute forms
 /// (`test.skip`, `test.xfail`, …) and their call wrappers.
 fn is_tryke_test_decorator(expr: &Expr, body: &[Stmt]) -> bool {
@@ -431,6 +447,78 @@ fn extract_decorator_tags(expr: &Expr) -> Vec<String> {
         }
     }
     vec![]
+}
+
+/// Extract case labels from a `@test.cases(...)` decorator.
+///
+/// Supports two literal forms:
+/// - kwargs: `@test.cases(zero={...}, one={...})` — each keyword name is a label
+/// - list: `@test.cases([("label1", {...}), ("label2", {...})])` — first tuple
+///   element is a string-literal label
+///
+/// Returns `Err(msg)` if the decorator's shape is not statically recognizable
+/// (e.g. `@test.cases(build())` or `@test.cases([dynamic, ...])`).
+fn extract_cases(expr: &Expr) -> Result<Vec<String>, String> {
+    let Expr::Call(call) = expr else {
+        return Err("test.cases decorator must be called, e.g. @test.cases(a=...)".to_owned());
+    };
+
+    let has_args = !call.arguments.args.is_empty();
+    let has_kwargs = !call.arguments.keywords.is_empty();
+
+    if has_args && has_kwargs {
+        return Err(
+            "test.cases() accepts either a positional list or keyword arguments, not both"
+                .to_owned(),
+        );
+    }
+
+    if has_kwargs {
+        let mut labels = Vec::with_capacity(call.arguments.keywords.len());
+        for kw in &call.arguments.keywords {
+            let Some(k) = kw.arg.as_ref() else {
+                return Err("test.cases() does not support **kwargs expansion — \
+                            all labels must be literal keyword arguments"
+                    .to_owned());
+            };
+            labels.push(k.id.as_str().to_owned());
+        }
+        return Ok(labels);
+    }
+
+    if has_args {
+        if call.arguments.args.len() != 1 {
+            return Err("test.cases() positional form takes exactly one list argument".to_owned());
+        }
+        let Expr::List(list) = &call.arguments.args[0] else {
+            return Err(
+                "test.cases() positional argument must be a list literal of (label, args) tuples"
+                    .to_owned(),
+            );
+        };
+        let mut labels = Vec::with_capacity(list.elts.len());
+        for (i, elt) in list.elts.iter().enumerate() {
+            let Expr::Tuple(tup) = elt else {
+                return Err(format!(
+                    "test.cases() list element {i} must be a (label, args) tuple literal"
+                ));
+            };
+            let Some(first) = tup.elts.first() else {
+                return Err(format!(
+                    "test.cases() list element {i} tuple must have a label as its first element"
+                ));
+            };
+            let Expr::StringLiteral(s) = first else {
+                return Err(format!(
+                    "test.cases() list element {i} label must be a string literal"
+                ));
+            };
+            labels.push(s.value.to_str().to_owned());
+        }
+        return Ok(labels);
+    }
+
+    Err("test.cases() requires either keyword arguments or a positional list".to_owned())
 }
 
 fn extract_decorator_name(expr: &Expr) -> Option<String> {
@@ -732,6 +820,92 @@ fn extract_describe_name(expr: &Expr) -> Option<String> {
 }
 
 #[expect(clippy::too_many_arguments)]
+fn collect_cases_from_func(
+    func: &ruff_python_ast::StmtFunctionDef,
+    cases_dec: &ruff_python_ast::Decorator,
+    top_body: &[Stmt],
+    root: &Path,
+    file: &Path,
+    source: &str,
+    line_index: &LineIndex,
+    groups: &[String],
+    tests_out: &mut Vec<TestItem>,
+    errors_out: &mut Vec<String>,
+) {
+    // Forbid `@test` and `@test.cases` on the same function — the runtime
+    // dispatch can only resolve one of them.
+    let plain_test_dec = func.decorator_list.iter().any(|d| {
+        is_tryke_test_decorator(&d.expression, top_body)
+            && !is_tryke_test_cases_decorator(&d.expression, top_body)
+            && matches!(extract_test_modifier(&d.expression), TestModifier::None)
+    });
+    if plain_test_dec {
+        let display_file = file.strip_prefix(root).unwrap_or(file).display();
+        let line = u32::try_from(line_index.line_index(func.range.start()).get()).unwrap_or(0);
+        errors_out.push(format!(
+            "{display_file}:{line}: function '{fn_name}' has both '@test' and \
+             '@test.cases' — use one or the other",
+            fn_name = func.name.id.as_str(),
+        ));
+        return;
+    }
+
+    let labels = match extract_cases(&cases_dec.expression) {
+        Ok(labels) => labels,
+        Err(msg) => {
+            let display_file = file.strip_prefix(root).unwrap_or(file).display();
+            let line = u32::try_from(line_index.line_index(func.range.start()).get()).unwrap_or(0);
+            errors_out.push(format!(
+                "{display_file}:{line}: @test.cases on '{fn_name}': {msg}",
+                fn_name = func.name.id.as_str(),
+            ));
+            return;
+        }
+    };
+
+    // Modifiers (@test.skip / @test.xfail / @test.todo) apply to every
+    // generated case. Look for any marker decorator on the same function.
+    let modifier_dec = func.decorator_list.iter().find(|d| {
+        is_tryke_test_decorator(&d.expression, top_body)
+            && !is_tryke_test_cases_decorator(&d.expression, top_body)
+            && !matches!(extract_test_modifier(&d.expression), TestModifier::None)
+    });
+    let modifier =
+        modifier_dec.map_or(TestModifier::None, |d| extract_test_modifier(&d.expression));
+    let (skip, todo, xfail) = match modifier {
+        TestModifier::Skip(r) => (Some(r), None, None),
+        TestModifier::Todo(d) => (None, Some(d), None),
+        TestModifier::Xfail(r) => (None, None, Some(r)),
+        TestModifier::SkipIf | TestModifier::None => (None, None, None),
+    };
+
+    let display_name = extract_docstring(&func.body);
+    let line_number = u32::try_from(line_index.line_index(func.range.start()).get()).ok();
+    let file_path = Some(file.strip_prefix(root).unwrap_or(file).to_path_buf());
+    let module_path = path_to_module(root, file);
+    let expected_assertions = extract_expected_assertions(&func.body, source, line_index);
+
+    for (i, label) in labels.into_iter().enumerate() {
+        tests_out.push(TestItem {
+            name: func.name.id.as_str().to_owned(),
+            module_path: module_path.clone(),
+            file_path: file_path.clone(),
+            line_number,
+            display_name: display_name.clone(),
+            expected_assertions: expected_assertions.clone(),
+            skip: skip.clone(),
+            todo: todo.clone(),
+            xfail: xfail.clone(),
+            tags: vec![],
+            groups: groups.to_vec(),
+            case_label: Some(label),
+            case_index: u32::try_from(i).ok(),
+            ..TestItem::default()
+        });
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
 fn collect_tests_from_body(
     stmts: &[Stmt],
     top_body: &[Stmt],
@@ -746,12 +920,24 @@ fn collect_tests_from_body(
 ) {
     for stmt in stmts {
         if let Stmt::FunctionDef(func) = stmt {
-            // Check for test decorator
-            if let Some(dec) = func
+            // `@test.cases(...)` and `@test` (or its marker forms) live on
+            // different sub-paths. `@test.cases` emits N items per function;
+            // the plain `@test` path emits exactly one.
+            let cases_dec = func
                 .decorator_list
                 .iter()
-                .find(|d| is_tryke_test_decorator(&d.expression, top_body))
-            {
+                .find(|d| is_tryke_test_cases_decorator(&d.expression, top_body));
+            let test_dec = func
+                .decorator_list
+                .iter()
+                .find(|d| is_tryke_test_decorator(&d.expression, top_body));
+
+            if let Some(cases_dec) = cases_dec {
+                collect_cases_from_func(
+                    func, cases_dec, top_body, root, file, source, line_index, groups, tests_out,
+                    errors_out,
+                );
+            } else if let Some(dec) = test_dec {
                 let display_name = extract_decorator_name(&dec.expression)
                     .or_else(|| extract_docstring(&func.body));
                 let modifier = extract_test_modifier(&dec.expression);
@@ -1179,6 +1365,135 @@ def my_func():
         let items = parse_tests_from_file(dir.path(), &file).tests;
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name, "my_func");
+    }
+
+    #[test]
+    fn cases_kwargs_form_emits_one_item_per_case() {
+        let source = "@test.cases(
+    zero={\"n\": 0},
+    one={\"n\": 1},
+    two={\"n\": 2},
+)
+def square(n, expected):
+    expect(n * n).to_equal(expected)
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file).tests;
+        assert_eq!(items.len(), 3, "expected one item per case");
+        for item in &items {
+            assert_eq!(item.name, "square");
+        }
+        let labels: Vec<_> = items
+            .iter()
+            .map(|i| i.case_label.as_deref().unwrap_or(""))
+            .collect();
+        assert_eq!(labels, vec!["zero", "one", "two"]);
+        let indices: Vec<_> = items.iter().map(|i| i.case_index).collect();
+        assert_eq!(indices, vec![Some(0), Some(1), Some(2)]);
+        // All cases share the same line number (the decorated function's line).
+        assert_eq!(items[0].line_number, items[1].line_number);
+        assert_eq!(items[1].line_number, items[2].line_number);
+    }
+
+    #[test]
+    fn cases_kwargs_form_produces_unique_ids() {
+        let source = "@test.cases(a={}, b={})
+def fn():
+    pass
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file).tests;
+        let ids: Vec<_> = items.iter().map(TestItem::id).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids[0].ends_with("::fn[a]"), "got {}", ids[0]);
+        assert!(ids[1].ends_with("::fn[b]"), "got {}", ids[1]);
+    }
+
+    #[test]
+    fn cases_list_form_emits_one_item_per_entry() {
+        let source = "@test.cases([
+    (\"2 + 3\", {\"a\": 2, \"b\": 3, \"sum\": 5}),
+    (\"-1 + 1\", {\"a\": -1, \"b\": 1, \"sum\": 0}),
+])
+def add(a, b, sum):
+    pass
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file).tests;
+        assert_eq!(items.len(), 2);
+        let labels: Vec<_> = items
+            .iter()
+            .map(|i| i.case_label.as_deref().unwrap_or(""))
+            .collect();
+        assert_eq!(labels, vec!["2 + 3", "-1 + 1"]);
+    }
+
+    #[test]
+    fn cases_inherits_describe_groups() {
+        let source = "from tryke import describe
+with describe(\"math\"):
+    @test.cases(zero={}, one={})
+    def square():
+        pass
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file).tests;
+        assert_eq!(items.len(), 2);
+        for item in &items {
+            assert_eq!(item.groups, vec!["math".to_string()]);
+        }
+    }
+
+    #[test]
+    fn cases_composes_with_skip_modifier() {
+        let source = "@test.skip(\"WIP\")
+@test.cases(a={}, b={})
+def fn():
+    pass
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file).tests;
+        assert_eq!(items.len(), 2);
+        for item in &items {
+            assert_eq!(item.skip.as_deref(), Some("WIP"));
+        }
+    }
+
+    #[test]
+    fn cases_plain_test_unaffected() {
+        // Sanity: pre-existing @test decorator path should still produce
+        // exactly one item with case_label=None.
+        let source = "@test
+def plain():
+    pass
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file).tests;
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].case_label, None);
+        assert_eq!(items[0].case_index, None);
+    }
+
+    #[test]
+    fn cases_non_literal_form_emits_error() {
+        let source = "@test.cases(build_cases())
+def fn():
+    pass
+";
+        let (dir, file) = write_source(source);
+        let parsed = parse_tests_from_file(dir.path(), &file);
+        // Non-literal decorator argument should not silently produce
+        // a test — surface a diagnostic instead.
+        assert!(
+            parsed.tests.is_empty(),
+            "expected no tests for non-literal @test.cases, got {:?}",
+            parsed.tests
+        );
+        assert!(
+            parsed.errors.iter().any(|e| e.contains("test.cases")),
+            "expected an error mentioning test.cases, got {:?}",
+            parsed.errors
+        );
     }
 
     #[test]

--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -449,9 +449,33 @@ fn extract_decorator_tags(expr: &Expr) -> Vec<String> {
     vec![]
 }
 
+/// Returns `true` if `expr` is a call to `test.case(...)` or `tryke.test.case(...)`.
+fn is_test_case_call(expr: &Expr) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+    let Expr::Attribute(attr) = &*call.func else {
+        return false;
+    };
+    if attr.attr.id.as_str() != "case" {
+        return false;
+    }
+    match &*attr.value {
+        Expr::Name(n) => n.id.as_str() == "test",
+        Expr::Attribute(a) => {
+            a.attr.id.as_str() == "test"
+                && matches!(&*a.value, Expr::Name(n) if n.id.as_str() == "tryke")
+        }
+        _ => false,
+    }
+}
+
 /// Extract case labels from a `@test.cases(...)` decorator.
 ///
-/// Supports two literal forms:
+/// Supports three literal forms:
+/// - typed: `@test.cases(test.case("label1", ...), test.case("label2", ...))`
+///   — each positional argument is a `test.case(...)` call with a string
+///   literal label as its first positional argument
 /// - kwargs: `@test.cases(zero={...}, one={...})` — each keyword name is a label
 /// - list: `@test.cases([("label1", {...}), ("label2", {...})])` — first tuple
 ///   element is a string-literal label
@@ -468,7 +492,7 @@ fn extract_cases(expr: &Expr) -> Result<Vec<String>, String> {
 
     if has_args && has_kwargs {
         return Err(
-            "test.cases() accepts either a positional list or keyword arguments, not both"
+            "test.cases() accepts either positional specs/list or keyword arguments, not both"
                 .to_owned(),
         );
     }
@@ -487,12 +511,37 @@ fn extract_cases(expr: &Expr) -> Result<Vec<String>, String> {
     }
 
     if has_args {
+        // Typed form: every positional arg is a `test.case(...)` call.
+        if call.arguments.args.iter().all(is_test_case_call) {
+            let mut labels = Vec::with_capacity(call.arguments.args.len());
+            for (i, elt) in call.arguments.args.iter().enumerate() {
+                let Expr::Call(inner) = elt else {
+                    return Err(format!(
+                        "test.cases() positional arg {i} must be a test.case(...) call"
+                    ));
+                };
+                let Some(first) = inner.arguments.args.first() else {
+                    return Err(format!(
+                        "test.cases() positional arg {i}: test.case() requires a label"
+                    ));
+                };
+                let Expr::StringLiteral(s) = first else {
+                    return Err(format!(
+                        "test.cases() positional arg {i}: test.case() label must be a string literal"
+                    ));
+                };
+                labels.push(s.value.to_str().to_owned());
+            }
+            return Ok(labels);
+        }
+
         if call.arguments.args.len() != 1 {
             return Err("test.cases() positional form takes exactly one list argument".to_owned());
         }
         let Expr::List(list) = &call.arguments.args[0] else {
             return Err(
-                "test.cases() positional argument must be a list literal of (label, args) tuples"
+                "test.cases() positional argument must be a list literal of (label, args) tuples \
+                 or a sequence of test.case(...) calls"
                     .to_owned(),
             );
         };
@@ -518,7 +567,7 @@ fn extract_cases(expr: &Expr) -> Result<Vec<String>, String> {
         return Ok(labels);
     }
 
-    Err("test.cases() requires either keyword arguments or a positional list".to_owned())
+    Err("test.cases() requires at least one case".to_owned())
 }
 
 fn extract_decorator_name(expr: &Expr) -> Option<String> {
@@ -1407,6 +1456,43 @@ def fn():
         assert_eq!(ids.len(), 2);
         assert!(ids[0].ends_with("::fn[a]"), "got {}", ids[0]);
         assert!(ids[1].ends_with("::fn[b]"), "got {}", ids[1]);
+    }
+
+    #[test]
+    fn cases_typed_form_emits_one_item_per_spec() {
+        let source = "@test.cases(
+    test.case(\"zero\", n=0, expected=0),
+    test.case(\"my test\", n=1, expected=1),
+    test.case(\"2 + 3\", n=2, expected=4),
+)
+def square(n, expected):
+    pass
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &file).tests;
+        assert_eq!(items.len(), 3, "expected one item per test.case spec");
+        let labels: Vec<_> = items
+            .iter()
+            .map(|i| i.case_label.as_deref().unwrap_or(""))
+            .collect();
+        assert_eq!(labels, vec!["zero", "my test", "2 + 3"]);
+    }
+
+    #[test]
+    fn cases_typed_form_rejects_non_literal_label() {
+        let source = "label = \"dynamic\"
+@test.cases(test.case(label, n=0))
+def fn(n):
+    pass
+";
+        let (dir, file) = write_source(source);
+        let parsed = parse_tests_from_file(dir.path(), &file);
+        assert!(parsed.tests.is_empty());
+        assert!(
+            parsed.errors.iter().any(|e| e.contains("test.case")),
+            "expected an error mentioning test.case, got {:?}",
+            parsed.errors
+        );
     }
 
     #[test]

--- a/crates/tryke_reporter/src/junit.rs
+++ b/crates/tryke_reporter/src/junit.rs
@@ -77,13 +77,8 @@ impl<W: io::Write> Reporter for JUnitReporter<W> {
         );
 
         for result in &self.results {
-            let name = xml_escape(
-                result
-                    .test
-                    .display_name
-                    .as_deref()
-                    .unwrap_or(&result.test.name),
-            );
+            let display = result.test.display_label();
+            let name = xml_escape(&display);
             let classname = if result.test.groups.is_empty() {
                 xml_escape(&result.test.module_path)
             } else {

--- a/crates/tryke_reporter/src/llm.rs
+++ b/crates/tryke_reporter/src/llm.rs
@@ -57,11 +57,8 @@ impl<W: io::Write> Reporter for LlmReporter<W> {
     fn on_run_start(&mut self, _tests: &[TestItem]) {}
 
     fn on_test_complete(&mut self, result: &TestResult) {
-        let display = result
-            .test
-            .display_name
-            .as_deref()
-            .unwrap_or(&result.test.name);
+        let display = result.test.display_label();
+        let display = display.as_str();
 
         match &result.outcome {
             TestOutcome::Passed

--- a/crates/tryke_reporter/src/text.rs
+++ b/crates/tryke_reporter/src/text.rs
@@ -177,11 +177,8 @@ impl<W: io::Write> Reporter for TextReporter<W> {
             "  ".repeat(test_groups.len() + 1)
         };
 
-        let display = result
-            .test
-            .display_name
-            .as_deref()
-            .unwrap_or(&result.test.name);
+        let display = result.test.display_label();
+        let display = display.as_str();
         match &result.outcome {
             TestOutcome::Passed => {
                 if !matches!(self.verbosity, Verbosity::Quiet) {
@@ -385,7 +382,7 @@ impl<W: io::Write> Reporter for TextReporter<W> {
                 current_groups.clone_from(&test.groups);
             }
             let group_indent = "  ".repeat(test.groups.len());
-            let display = test.display_name.as_deref().unwrap_or(&test.name);
+            let display = test.display_label();
             let _ = writeln!(self.writer, "  {group_indent}{}", display.dimmed());
         }
         let _ = writeln!(self.writer);
@@ -878,6 +875,53 @@ mod tests {
         let out = String::from_utf8_lossy(&r.into_writer()).into_owned();
         assert!(out.contains("✓"));
         assert!(out.contains("expect(x).not_.to_be_none()"));
+    }
+
+    #[test]
+    fn case_label_appended_to_name_in_output() {
+        let mut r = reporter();
+        r.on_test_complete(&TestResult {
+            test: TestItem {
+                name: "square".into(),
+                module_path: "tests.test_math".into(),
+                case_label: Some("zero".into()),
+                case_index: Some(0),
+                ..Default::default()
+            },
+            outcome: TestOutcome::Passed,
+            duration: Duration::from_millis(1),
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+        let out = output(&r);
+        assert!(out.contains("square[zero]"), "out: {out}");
+    }
+
+    #[test]
+    fn case_label_appears_in_collect_only_output() {
+        let mut r = reporter();
+        let tests = vec![
+            TestItem {
+                name: "square".into(),
+                module_path: "tests.test_math".into(),
+                file_path: Some(PathBuf::from("tests/test_math.py")),
+                case_label: Some("zero".into()),
+                case_index: Some(0),
+                ..Default::default()
+            },
+            TestItem {
+                name: "square".into(),
+                module_path: "tests.test_math".into(),
+                file_path: Some(PathBuf::from("tests/test_math.py")),
+                case_label: Some("one".into()),
+                case_index: Some(1),
+                ..Default::default()
+            },
+        ];
+        r.on_collect_complete(&tests);
+        let out = output(&r);
+        assert!(out.contains("square[zero]"), "out: {out}");
+        assert!(out.contains("square[one]"), "out: {out}");
     }
 
     #[test]

--- a/crates/tryke_runner/src/protocol.rs
+++ b/crates/tryke_runner/src/protocol.rs
@@ -59,6 +59,11 @@ pub struct RunTestParams {
     pub xfail: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub groups: Vec<String>,
+    /// For `@test.cases(...)` items, the label of the case to dispatch.
+    /// The worker looks up `fn.__tryke_cases__[case_label]` and passes the
+    /// stored kwargs when invoking the test function.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub case_label: Option<String>,
 }
 
 /// Wire format for a single fixture sent to the Python worker.

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -129,6 +129,7 @@ impl WorkerProcess {
             function: test.name.clone(),
             xfail: test.xfail.clone(),
             groups: test.groups.clone(),
+            case_label: test.case_label.clone(),
         })?;
         let wire: RunTestResultWire = self.call("run_test", Some(params)).await?;
         Ok(convert_result(test.clone(), wire))

--- a/crates/tryke_types/src/lib.rs
+++ b/crates/tryke_types/src/lib.rs
@@ -70,14 +70,41 @@ pub struct TestItem {
     /// module-level docstring.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub doctest_object: Option<String>,
+    /// For tests declared with `@test.cases(...)`, the label of the specific
+    /// case this item represents (e.g. `"zero"` for `@test.cases(zero=...)`).
+    /// `None` for plain `@test` functions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub case_label: Option<String>,
+    /// Zero-based index of this case within its parent function, preserving
+    /// declaration order. `None` when `case_label` is `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub case_index: Option<u32>,
 }
 
 impl TestItem {
     #[must_use]
     pub fn id(&self) -> String {
-        match &self.file_path {
+        let base = match &self.file_path {
             Some(path) => format!("{}::{}", path.display(), self.name),
             None => format!("{}::{}", self.module_path, self.name),
+        };
+        match &self.case_label {
+            Some(label) => format!("{base}[{label}]"),
+            None => base,
+        }
+    }
+
+    /// Human-readable label for reporters.
+    ///
+    /// Returns the `display_name` override if present, otherwise the bare
+    /// function name. For `@test.cases(...)` items, appends `[case_label]`
+    /// so every row in the output is disambiguated.
+    #[must_use]
+    pub fn display_label(&self) -> String {
+        let base = self.display_name.as_deref().unwrap_or(&self.name);
+        match &self.case_label {
+            Some(label) => format!("{base}[{label}]"),
+            None => base.to_owned(),
         }
     }
 }
@@ -311,6 +338,106 @@ mod tests {
         let json = serde_json::to_string(&hook).expect("serialize");
         let back: HookItem = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(hook, back);
+    }
+
+    #[test]
+    fn test_item_id_plain() {
+        let item = TestItem {
+            name: "test_square".into(),
+            module_path: "tests.test_math".into(),
+            file_path: Some(PathBuf::from("tests/test_math.py")),
+            ..Default::default()
+        };
+        assert_eq!(item.id(), "tests/test_math.py::test_square");
+    }
+
+    #[test]
+    fn test_item_id_with_case_label() {
+        let item = TestItem {
+            name: "square".into(),
+            module_path: "tests.test_math".into(),
+            file_path: Some(PathBuf::from("tests/test_math.py")),
+            case_label: Some("zero".into()),
+            case_index: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(item.id(), "tests/test_math.py::square[zero]");
+    }
+
+    #[test]
+    fn test_item_case_label_round_trips_through_serde() {
+        let item = TestItem {
+            name: "square".into(),
+            module_path: "tests.test_math".into(),
+            file_path: Some(PathBuf::from("tests/test_math.py")),
+            case_label: Some("ten".into()),
+            case_index: Some(2),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&item).expect("serialize");
+        assert!(json.contains(r#""case_label":"ten""#), "json: {json}");
+        assert!(json.contains(r#""case_index":2"#), "json: {json}");
+        let back: TestItem = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.case_label.as_deref(), Some("ten"));
+        assert_eq!(back.case_index, Some(2));
+    }
+
+    #[test]
+    fn test_item_display_label_plain() {
+        let item = TestItem {
+            name: "test_square".into(),
+            module_path: "tests.m".into(),
+            ..Default::default()
+        };
+        assert_eq!(item.display_label(), "test_square");
+    }
+
+    #[test]
+    fn test_item_display_label_prefers_display_name() {
+        let item = TestItem {
+            name: "test_square".into(),
+            module_path: "tests.m".into(),
+            display_name: Some("squares a number".into()),
+            ..Default::default()
+        };
+        assert_eq!(item.display_label(), "squares a number");
+    }
+
+    #[test]
+    fn test_item_display_label_with_case_label() {
+        let item = TestItem {
+            name: "square".into(),
+            module_path: "tests.m".into(),
+            case_label: Some("zero".into()),
+            case_index: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(item.display_label(), "square[zero]");
+    }
+
+    #[test]
+    fn test_item_display_label_combines_display_name_and_case_label() {
+        let item = TestItem {
+            name: "square".into(),
+            module_path: "tests.m".into(),
+            display_name: Some("squares a number".into()),
+            case_label: Some("zero".into()),
+            case_index: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(item.display_label(), "squares a number[zero]");
+    }
+
+    #[test]
+    fn test_item_case_label_omitted_when_none() {
+        let item = TestItem {
+            name: "plain".into(),
+            module_path: "tests.test_math".into(),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&item).expect("serialize");
+        assert!(!json.contains("case_label"), "json: {json}");
+        assert!(!json.contains("case_index"), "json: {json}");
     }
 
     #[test]

--- a/docs/concepts/cases.md
+++ b/docs/concepts/cases.md
@@ -1,0 +1,125 @@
+## Parametrized tests with `@test.cases`
+
+`@test.cases` expands a single test function into one test per input row, so you can exercise the same assertions against a table of inputs without copy-pasting (or sneaking a `for`-loop into the module body where tryke's static discovery can't see it).
+
+Each generated case is a first-class test: it has its own ID (`path::fn[label]`), its own row in reporters, and can be filtered, skipped, or re-run independently.
+
+## Two forms
+
+### Kwargs form — identifier labels
+
+The common form. Each keyword is a case label; the value is a dict of arguments passed to the function:
+
+```python
+from tryke import expect, test
+
+@test.cases(
+    zero={"n": 0, "expected": 0},
+    one={"n": 1, "expected": 1},
+    ten={"n": 10, "expected": 100},
+)
+def square(n: int, expected: int):
+    expect(n * n).to_equal(expected)
+```
+
+This collects as three tests: `square[zero]`, `square[one]`, `square[ten]`.
+
+### List form — arbitrary string labels
+
+When you want a label that isn't a valid Python identifier (spaces, operators, punctuation), use a list of `(label, args)` tuples:
+
+```python
+@test.cases([
+    ("2 + 3", {"a": 2, "b": 3, "sum": 5}),
+    ("-1 + 1", {"a": -1, "b": 1, "sum": 0}),
+    ("0 + 0", {"a": 0, "b": 0, "sum": 0}),
+])
+def add(a: int, b: int, sum: int):
+    expect(a + b).to_equal(sum)
+```
+
+## Composition rules
+
+### With `describe()` groups
+
+Cases inherit the group of their enclosing `describe()` block. All cases share the same groups:
+
+```python
+with describe("arithmetic"):
+    @test.cases(
+        small={"x": 1, "doubled": 2},
+        big={"x": 100, "doubled": 200},
+    )
+    def double(x: int, doubled: int):
+        expect(x * 2).to_equal(doubled)
+```
+
+### With `@fixture` and `Depends()`
+
+Case kwargs and fixture-injected kwargs are merged at call time. Declare fixture params with `Depends()` defaults alongside case params:
+
+```python
+from tryke import Depends, expect, fixture, test
+
+@fixture
+def multiplier() -> int:
+    return 10
+
+@test.cases(
+    small={"n": 1, "expected": 10},
+    big={"n": 9, "expected": 90},
+)
+def scaled(n: int, expected: int, factor: int = Depends(multiplier)):
+    expect(n * factor).to_equal(expected)
+```
+
+A case kwarg must not collide with a fixture-injected parameter — tryke raises `TypeError` at call time if it does. Pick a different name for the case argument.
+
+### With `@test.skip` and `@test.xfail`
+
+Modifiers apply to every generated case:
+
+```python
+@test.skip("not ready yet")
+@test.cases(a={"x": 1}, b={"x": 2})
+def pending(x: int):
+    ...
+
+@test.xfail("upstream bug #42")
+@test.cases(a={"x": 1}, b={"x": 2})
+def known_broken(x: int):
+    expect(x).to_equal(-1)
+```
+
+Both cases are skipped (or marked xfail) — there's currently no way to mark individual cases. If you need per-case xfail, split the cases into separate functions.
+
+### With `@test`
+
+`@test` and `@test.cases` are mutually exclusive on the same function. Discovery raises an error if both are present. Use `@test.cases` alone — the framework treats it as its own registration decorator.
+
+## The static-analysis constraint
+
+Tryke discovers tests by walking the AST without importing your code. That means `@test.cases(...)` must be **literal**: labels are string or identifier literals, and the top-level shape (kwargs vs. list of tuples) must be visible in the source.
+
+| Allowed | Rejected |
+|---------|----------|
+| `@test.cases(a={"n": 1})` | `@test.cases(build_cases())` |
+| `@test.cases([("a", {"n": 1})])` | `@test.cases([*generated])` |
+| `@test.cases(a={"n": 10**6})` — values can be expressions | `@test.cases(**labels)` |
+
+Non-literal decorator shapes emit a discovery error and the tests are skipped. This mirrors the same constraint that applies to `describe("name")`.
+
+## Soft assertions and cases
+
+[Soft assertions](soft-assertions.md) apply per-case. Each case runs independently, and a failure inside one case never short-circuits the next — every case runs every assertion and reports every failure.
+
+## Comparison with pytest
+
+| pytest | tryke |
+|--------|-------|
+| `@pytest.mark.parametrize("x,y", [(1, 2), (3, 4)])` | `@test.cases(a={"x": 1, "y": 2}, b={"x": 3, "y": 4})` |
+| `@pytest.mark.parametrize("x", [1, 2], ids=["one", "two"])` | `@test.cases(one={"x": 1}, two={"x": 2})` |
+| Case ID: `test_fn[one-two]` | Case ID: `fn[one]`, `fn[two]` |
+| Parameters match by name positionally | Each case is a dict — names are explicit |
+
+The key difference: tryke cases are discovered statically (no import), so editor plugins, `--collect-only`, and distributed scheduling all see every case as a first-class test up front.

--- a/docs/concepts/cases.md
+++ b/docs/concepts/cases.md
@@ -4,15 +4,40 @@
 
 Each generated case is a first-class test: it has its own ID (`path::fn[label]`), its own row in reporters, and can be filtered, skipped, or re-run independently.
 
-## Two forms
+## Three forms
 
-### Kwargs form — identifier labels
+### Typed form — `test.case(...)` specs (recommended)
 
-The common form. Each keyword is a case label; the value is a dict of arguments passed to the function:
+Pass one `test.case(label, ...)` spec per row. Labels are arbitrary strings (spaces, math operators, punctuation all fine), and the kwargs you pass are checked against the decorated function's signature by `mypy` / `pyright` via a [PEP 612](https://peps.python.org/pep-0612/) `ParamSpec`:
 
 ```python
 from tryke import expect, test
 
+@test.cases(
+    test.case("zero",    n=0,  expected=0),
+    test.case("one",     n=1,  expected=1),
+    test.case("my test", n=10, expected=100),
+)
+def square(n: int, expected: int):
+    expect(n * n).to_equal(expected)
+```
+
+This collects as three tests: `square[zero]`, `square[one]`, `square[my test]`.
+
+Typing caught statically under `mypy` / `pyright`:
+
+- **Unknown kwarg** — `test.case("bad", n=0, expcted=0)` against `square(n, expected)` — `expcted` isn't in the signature.
+- **Wrong value type** — `test.case("bad", n="zero", expected=0)` against `n: int` — `str` doesn't match.
+- **Missing required kwarg** — `test.case("bad", n=0)` — the signature requires `expected`.
+- **Signature drift** — changing `def square(n: int, ...)` to `def square(n: str, ...)` after cases are written — the cases stop unifying with `_P`.
+
+`ty` (Astral's type checker, as of 0.0.21) does not yet fully enforce the PEP 612 `Generic[P]` constructor pattern this API uses — it will accept the above negatives silently. Runtime validation still catches label collisions and inconsistent key sets across cases regardless of the type checker.
+
+### Legacy kwargs form — identifier labels
+
+Each keyword is a case label; the value is a dict of arguments passed to the function. This form loses static case-value typing:
+
+```python
 @test.cases(
     zero={"n": 0, "expected": 0},
     one={"n": 1, "expected": 1},
@@ -22,11 +47,9 @@ def square(n: int, expected: int):
     expect(n * n).to_equal(expected)
 ```
 
-This collects as three tests: `square[zero]`, `square[one]`, `square[ten]`.
+### Legacy list form — arbitrary string labels
 
-### List form — arbitrary string labels
-
-When you want a label that isn't a valid Python identifier (spaces, operators, punctuation), use a list of `(label, args)` tuples:
+For labels that aren't valid Python identifiers. Also loses static case-value typing:
 
 ```python
 @test.cases([
@@ -37,6 +60,8 @@ When you want a label that isn't a valid Python identifier (spaces, operators, p
 def add(a: int, b: int, sum: int):
     expect(a + b).to_equal(sum)
 ```
+
+Prefer the typed form for new code. The legacy forms will continue to work for now but are no longer the recommended API.
 
 ## Composition rules
 
@@ -99,13 +124,16 @@ Both cases are skipped (or marked xfail) — there's currently no way to mark in
 
 ## The static-analysis constraint
 
-Tryke discovers tests by walking the AST without importing your code. That means `@test.cases(...)` must be **literal**: labels are string or identifier literals, and the top-level shape (kwargs vs. list of tuples) must be visible in the source.
+Tryke discovers tests by walking the AST without importing your code. That means `@test.cases(...)` must be **literal**: labels are string or identifier literals, and the top-level shape (typed specs, kwargs, or list of tuples) must be visible in the source.
 
 | Allowed | Rejected |
 |---------|----------|
+| `@test.cases(test.case("a", n=1))` | `@test.cases(*specs)` |
 | `@test.cases(a={"n": 1})` | `@test.cases(build_cases())` |
 | `@test.cases([("a", {"n": 1})])` | `@test.cases([*generated])` |
-| `@test.cases(a={"n": 10**6})` — values can be expressions | `@test.cases(**labels)` |
+| `@test.cases(test.case("big", n=10**6))` — kwarg values can be expressions | `@test.cases(**labels)` |
+
+For the typed form specifically: the label passed to `test.case(...)` must be a string literal. Dynamic labels (`test.case(label_var, ...)`) are rejected at discovery time.
 
 Non-literal decorator shapes emit a discovery error and the tests are skipped. This mirrors the same constraint that applies to `describe("name")`.
 

--- a/docs/concepts/soft-assertions.md
+++ b/docs/concepts/soft-assertions.md
@@ -32,6 +32,8 @@ This is especially valuable when tests are slow (network calls, database setup) 
 
 Each soft assertion produces its own diagnostic output showing the expected and actual values. When multiple assertions fail, you see all of them in the test report — not just the first one.
 
+Soft assertions apply **per-case** for [parametrized tests](cases.md). Each case runs all its assertions independently; a failure inside one case never short-circuits the next case.
+
 ## `.fatal()` for early stopping
 
 Sometimes continuing after a failure doesn't make sense. Chain `.fatal()` to stop the test immediately:

--- a/docs/guides/writing-tests.md
+++ b/docs/guides/writing-tests.md
@@ -314,6 +314,22 @@ Outer scope fixtures wrap inner scope fixtures. Within a scope, fixtures set up 
 
 See [concurrency](../concepts/concurrency.md#fixtures-and-scheduling) for how fixtures interact with `--dist` modes. In short: `per="test"` fixtures preserve full parallelism, while `per="scope"` fixtures force tests in the same scope onto a single worker.
 
+## Parametrized tests
+
+Use `@test.cases` to run the same test against multiple inputs. Each case collects as a distinct test (`fn[label]`) with its own row in reporters:
+
+```python
+@test.cases(
+    zero={"n": 0, "expected": 0},
+    one={"n": 1, "expected": 1},
+    ten={"n": 10, "expected": 100},
+)
+def square(n: int, expected: int):
+    expect(n * n).to_equal(expected)
+```
+
+Cases compose with `describe()`, `@fixture`/`Depends()`, and modifiers. See [the cases concept page](../concepts/cases.md) for the two forms, composition rules, and the static-analysis constraint on decorator arguments.
+
 ## Skipping tests
 
 Skip a test unconditionally:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -230,15 +230,57 @@ Key differences:
 - `Depends()` is fully typed — type checkers see the correct return type
 - No `conftest.py` — fixtures live in the same file as the tests they serve
 
-### No parametrize (yet)
+### Parametrize → `@test.cases`
 
-Use a loop with named tests for now:
+**pytest:**
 
 ```python
-for x, expected in [(1, 2), (2, 3), (3, 4)]:
-    @test(name=f"increment {x}")
-    def _(x=x, expected=expected):
-        expect(x + 1).to_equal(expected)
+import pytest
+
+@pytest.mark.parametrize("n,expected", [(0, 0), (1, 1), (10, 100)])
+def test_square(n, expected):
+    assert n * n == expected
 ```
 
-Parametrize support is on the roadmap.
+**tryke** — kwargs form (labels are identifiers):
+
+```python
+@test.cases(
+    zero={"n": 0, "expected": 0},
+    one={"n": 1, "expected": 1},
+    ten={"n": 10, "expected": 100},
+)
+def square(n: int, expected: int):
+    expect(n * n).to_equal(expected)
+```
+
+**tryke** — list form (labels are arbitrary string literals):
+
+```python
+@test.cases([
+    ("2 + 3", {"a": 2, "b": 3, "sum": 5}),
+    ("-1 + 1", {"a": -1, "b": 1, "sum": 0}),
+])
+def add(a: int, b: int, sum: int):
+    expect(a + b).to_equal(sum)
+```
+
+Each case collects as its own test ID (`fn[label]`), composes with `describe()` blocks, `@fixture`/`Depends()`, and `@test.skip`/`xfail`. See [cases](concepts/cases.md) for the full reference.
+
+#### Runner parametrize (`[asyncio, trio]`)
+
+**pytest** — often seen with `pytest-asyncio` / `anyio`:
+
+```python
+@pytest.mark.parametrize("runner", [asyncio, trio])
+async def test_under_runner(runner):
+    ...
+```
+
+**tryke**:
+
+```python
+@test.cases(asyncio={"runner": asyncio}, trio={"runner": trio})
+async def under_runner(runner):
+    ...
+```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -242,7 +242,21 @@ def test_square(n, expected):
     assert n * n == expected
 ```
 
-**tryke** — kwargs form (labels are identifiers):
+**tryke** — typed form (recommended; statically checked under mypy/pyright):
+
+```python
+@test.cases(
+    test.case("zero", n=0, expected=0),
+    test.case("one",  n=1, expected=1),
+    test.case("ten",  n=10, expected=100),
+)
+def square(n: int, expected: int):
+    expect(n * n).to_equal(expected)
+```
+
+Labels are arbitrary strings — `"my test"`, `"2 + 3"`, `"negative one"` all work and survive `-k` filtering end-to-end.
+
+**tryke** — legacy kwargs form (labels are identifiers; untyped):
 
 ```python
 @test.cases(
@@ -254,7 +268,7 @@ def square(n: int, expected: int):
     expect(n * n).to_equal(expected)
 ```
 
-**tryke** — list form (labels are arbitrary string literals):
+**tryke** — legacy list form (string-literal labels; untyped):
 
 ```python
 @test.cases([

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -7,6 +7,7 @@
       show_root_heading: false
       members:
         - __call__
+        - cases
         - skip_if
 
 ::: tryke.expect._SkipMarker

--- a/python/tryke/__init__.py
+++ b/python/tryke/__init__.py
@@ -12,7 +12,7 @@ The main exports are:
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from .expect import expect, test
+from .expect import CaseArgs, CasesMarked, CaseTable, expect, test
 from .hooks import Depends, fixture
 
 
@@ -45,6 +45,9 @@ def describe(name: str) -> Generator[None, None, None]:
 
 
 __all__ = [
+    "CaseArgs",
+    "CaseTable",
+    "CasesMarked",
     "Depends",
     "describe",
     "expect",

--- a/python/tryke/expect.py
+++ b/python/tryke/expect.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple, Protocol, overload, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
+    from collections.abc import Callable, Coroutine, Mapping
     from typing import Any, ClassVar, Self
 
     class _SupportsGT(Protocol):
@@ -35,10 +35,19 @@ if TYPE_CHECKING:
         def __call__(self) -> object: ...
 
 
-type _Fn = Callable[[], None]
-type _AsyncFn = Callable[[], Coroutine[Any, Any, None]]
+type _Fn = Callable[..., None]
+type _AsyncFn = Callable[..., Coroutine[Any, Any, None]]
 type _AnyTestFn = _Fn | _AsyncFn
 type _Decorator = Callable[[_AnyTestFn], _AnyTestFn]
+
+#: The kwargs a single ``@test.cases`` case passes to its test function.
+#: Values are typed as ``object`` because each test is free to declare its
+#: own parameter types — the worker passes values through unchanged and the
+#: test function's own signature is the source of truth for argument shapes.
+type CaseArgs = Mapping[str, object]
+
+#: Full parametrize table: case label → per-case kwargs.
+type CaseTable = Mapping[str, CaseArgs]
 
 
 @runtime_checkable
@@ -68,9 +77,99 @@ class _XfailMarked(Protocol):
     __tryke_xfail__: str
 
 
+@runtime_checkable
+class CasesMarked(Protocol):
+    """A function stamped with ``__tryke_cases__``.
+
+    The attribute maps case labels to the kwargs dict that should be passed
+    to the function when that case runs.
+    """
+
+    def __call__(self, *args: object, **kwargs: object) -> None: ...
+
+    __tryke_cases__: CaseTable
+
+
 def _stamp(fn: object, attr: str, value: str) -> None:
     """Stamp a marker attribute on a function object."""
     setattr(fn, attr, value)
+
+
+_CASES_ATTR = "__tryke_cases__"
+_CASES_TUPLE_LEN = 2
+
+
+class CaseEntry(NamedTuple):
+    """One row in the positional ``@test.cases([...])`` list form.
+
+    Users pass plain ``(label, args)`` tuples at the call site; the
+    decorator normalizes them into ``CaseEntry`` before building the table,
+    so downstream code can rely on a named shape.
+    """
+
+    label: str
+    args: CaseArgs
+
+
+def _stamp_cases(fn: object, table: CaseTable) -> None:
+    """Stamp the ``__tryke_cases__`` attribute on a function object."""
+    setattr(fn, _CASES_ATTR, table)
+
+
+def _validate_case_entry(index: int, item: object) -> CaseEntry:
+    """Coerce one positional ``@test.cases`` element into a ``CaseEntry``."""
+    if not (isinstance(item, tuple) and len(item) == _CASES_TUPLE_LEN):
+        msg = f"test.cases() list element {index} must be a (label, args) tuple"
+        raise TypeError(msg)
+    label, raw_args = item
+    if not isinstance(label, str):
+        msg = f"test.cases() list element {index} label must be a string"
+        raise TypeError(msg)
+    if not isinstance(raw_args, dict):
+        msg = f"test.cases() list element {index} args must be a dict"
+        raise TypeError(msg)
+    args: dict[str, object] = {}
+    for key, value in raw_args.items():
+        if not isinstance(key, str):
+            msg = (
+                f"test.cases() list element {index} args keys must be strings "
+                f"(got {type(key).__name__})"
+            )
+            raise TypeError(msg)
+        args[key] = value
+    return CaseEntry(label=label, args=args)
+
+
+def _cases_list_to_table(raw: object) -> CaseTable:
+    """Validate and convert a positional ``@test.cases([...])`` list.
+
+    Raises:
+        TypeError: If any element is not a ``(label: str, args: dict)`` tuple.
+    """
+    if not isinstance(raw, list):
+        msg = "test.cases() positional argument must be a list of (label, args) tuples"
+        raise TypeError(msg)
+    entries = [_validate_case_entry(i, item) for i, item in enumerate(raw)]
+    return {entry.label: entry.args for entry in entries}
+
+
+def _build_cases_table(
+    positional: tuple[list[tuple[str, CaseArgs]], ...],
+    kwargs: dict[str, CaseArgs],
+) -> CaseTable:
+    """Resolve ``@test.cases(...)`` arguments to a `{label: args}` table."""
+    if positional and kwargs:
+        msg = "test.cases() accepts either list form or kwargs form, not both"
+        raise TypeError(msg)
+    if kwargs:
+        return dict(kwargs)
+    if positional:
+        if len(positional) != 1:
+            msg = "test.cases() positional form takes exactly one list argument"
+            raise TypeError(msg)
+        return _cases_list_to_table(positional[0])
+    msg = "test.cases() requires at least one case (kwargs or a list)"
+    raise TypeError(msg)
 
 
 class _Marker:
@@ -337,6 +436,54 @@ class _TestBuilder:
             return fn
 
         def decorator(f: Callable[[], None]) -> Callable[[], None]:
+            return f
+
+        return decorator
+
+    def cases(
+        self,
+        *positional: list[tuple[str, CaseArgs]],
+        **kwargs: CaseArgs,
+    ) -> Callable[[_Fn], _Fn]:
+        """Parametrize a test over multiple named cases.
+
+        Two forms are supported:
+
+        - Keyword form — each kwarg name is a case label, each value is a
+          dict of arguments passed to the function:
+
+              @test.cases(
+                  zero={"n": 0, "squared": 0},
+                  one={"n": 1, "squared": 1},
+              )
+              def square(n, squared):
+                  expect(n * n).to_equal(squared)
+
+        - Positional list form — a list of (label, args) tuples. Use this
+          when labels are not valid Python identifiers:
+
+              @test.cases([
+                  ("2 + 3", {"a": 2, "b": 3, "sum": 5}),
+                  ("-1 + 1", {"a": -1, "b": 1, "sum": 0}),
+              ])
+              def add(a, b, sum):
+                  expect(a + b).to_equal(sum)
+
+        Composes with ``@fixture``/``Depends()`` parameters, ``describe(...)``
+        blocks, and ``@test.skip``/``@test.xfail`` modifiers.
+
+        Args:
+            positional: A single positional list of (label, args) tuples.
+            kwargs: Case-label → args-dict mapping.
+
+        Raises:
+            TypeError: If neither form is provided, both are mixed, or the
+                positional argument is not a list of (str, dict) tuples.
+        """
+        table = _build_cases_table(positional, kwargs)
+
+        def decorator(f: _Fn) -> _Fn:
+            _stamp_cases(f, table)
             return f
 
         return decorator

--- a/python/tryke/expect.py
+++ b/python/tryke/expect.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import re
 import traceback
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, Protocol, overload, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    NamedTuple,
+    Protocol,
+    overload,
+    runtime_checkable,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Mapping
@@ -46,8 +52,10 @@ type _Decorator = Callable[[_AnyTestFn], _AnyTestFn]
 #: test function's own signature is the source of truth for argument shapes.
 type CaseArgs = Mapping[str, object]
 
-#: Full parametrize table: case label → per-case kwargs.
-type CaseTable = Mapping[str, CaseArgs]
+#: Full parametrize table: a tuple of one :class:`CaseEntry` per case. A
+#: tuple (rather than a mapping) preserves insertion order and the concrete
+#: element type, and lets the worker do strict identity-level lookups.
+type CaseTable = tuple["CaseEntry", ...]
 
 
 @runtime_checkable
@@ -81,8 +89,10 @@ class _XfailMarked(Protocol):
 class CasesMarked(Protocol):
     """A function stamped with ``__tryke_cases__``.
 
-    The attribute maps case labels to the kwargs dict that should be passed
-    to the function when that case runs.
+    The attribute is a tuple of :class:`CaseEntry` rows describing each
+    case: its label, positional args, and keyword args. The worker looks
+    up the row whose ``label`` matches the dispatched case and splats
+    both ``args`` and ``kwargs`` into the function call.
     """
 
     def __call__(self, *args: object, **kwargs: object) -> None: ...
@@ -100,15 +110,65 @@ _CASES_TUPLE_LEN = 2
 
 
 class CaseEntry(NamedTuple):
-    """One row in the positional ``@test.cases([...])`` list form.
+    """One row in a ``@test.cases(...)`` table.
 
-    Users pass plain ``(label, args)`` tuples at the call site; the
-    decorator normalizes them into ``CaseEntry`` before building the table,
-    so downstream code can rely on a named shape.
+    Attributes:
+        label: Human-readable name shown in reports; survives ``-k``
+            filtering and may contain arbitrary characters (spaces, math
+            operators, etc.).
+        args: Positional arguments the decorated function receives for
+            this case. Typically empty — the typed form prefers kwargs —
+            but supported so positional-only signatures compose cleanly.
+        kwargs: Keyword arguments the decorated function receives for
+            this case. Merged with any fixture-injected kwargs by the
+            hook executor; collisions raise ``TypeError``.
     """
 
     label: str
-    args: CaseArgs
+    args: tuple[object, ...]
+    kwargs: CaseArgs
+
+
+class _CaseSpec[**P]:
+    """Type-carrying case descriptor produced by :meth:`_TestBuilder.case`.
+
+    The ``P`` ParamSpec is bound at construction time from the
+    positional and keyword arguments the caller passes after the label.
+    When a batch of specs is handed to :meth:`_TestBuilder.cases`, the
+    type checker is expected to unify ``P`` across every element and
+    match it against the decorated function's signature.
+
+    The object is intentionally opaque at runtime — it holds one
+    :class:`CaseEntry` and nothing else. Users should never construct
+    it directly; go through ``test.case(label, ...)``.
+
+    Note:
+        PEP 612 support for ParamSpec-carrying classes is uneven across
+        type checkers. mypy and pyright bind ``P`` correctly here; ty
+        (as of 0.0.21) infers the class as gradual ``_CaseSpec[...]``
+        and does not enforce per-kwarg typing. Once ty gains full PEP
+        612 support this design will start rejecting mistyped cases
+        statically with no code change.
+    """
+
+    __slots__ = ("_entry",)
+
+    def __init__(
+        self,
+        label: str,
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> None:
+        self._entry = CaseEntry(
+            label=label,
+            args=tuple(args),
+            kwargs=dict(kwargs),
+        )
+
+    @property
+    def entry(self) -> CaseEntry:
+        return self._entry
 
 
 def _stamp_cases(fn: object, table: CaseTable) -> None:
@@ -117,7 +177,7 @@ def _stamp_cases(fn: object, table: CaseTable) -> None:
 
 
 def _validate_case_entry(index: int, item: object) -> CaseEntry:
-    """Coerce one positional ``@test.cases`` element into a ``CaseEntry``."""
+    """Coerce one positional ``@test.cases([...])`` list element."""
     if not (isinstance(item, tuple) and len(item) == _CASES_TUPLE_LEN):
         msg = f"test.cases() list element {index} must be a (label, args) tuple"
         raise TypeError(msg)
@@ -128,7 +188,7 @@ def _validate_case_entry(index: int, item: object) -> CaseEntry:
     if not isinstance(raw_args, dict):
         msg = f"test.cases() list element {index} args must be a dict"
         raise TypeError(msg)
-    args: dict[str, object] = {}
+    kwargs: dict[str, object] = {}
     for key, value in raw_args.items():
         if not isinstance(key, str):
             msg = (
@@ -136,8 +196,8 @@ def _validate_case_entry(index: int, item: object) -> CaseEntry:
                 f"(got {type(key).__name__})"
             )
             raise TypeError(msg)
-        args[key] = value
-    return CaseEntry(label=label, args=args)
+        kwargs[key] = value
+    return CaseEntry(label=label, args=(), kwargs=kwargs)
 
 
 def _cases_list_to_table(raw: object) -> CaseTable:
@@ -149,26 +209,88 @@ def _cases_list_to_table(raw: object) -> CaseTable:
     if not isinstance(raw, list):
         msg = "test.cases() positional argument must be a list of (label, args) tuples"
         raise TypeError(msg)
-    entries = [_validate_case_entry(i, item) for i, item in enumerate(raw)]
-    return {entry.label: entry.args for entry in entries}
+    return tuple(_validate_case_entry(i, item) for i, item in enumerate(raw))
+
+
+def _cases_from_kwargs(kwargs: dict[str, CaseArgs]) -> CaseTable:
+    """Convert legacy ``@test.cases(label=args_dict, ...)`` kwargs."""
+    return tuple(
+        CaseEntry(label=label, args=(), kwargs=dict(args))
+        for label, args in kwargs.items()
+    )
+
+
+def _validate_cases_table(table: CaseTable) -> None:
+    """Check cross-row invariants: unique labels and consistent key sets.
+
+    Called after every form (typed, legacy kwargs, legacy list) so each
+    form enforces the same shape guarantees at runtime regardless of
+    what the type checker did or did not catch.
+    """
+    if not table:
+        return
+    seen: set[str] = set()
+    for entry in table:
+        if entry.label in seen:
+            msg = f"test.cases(): duplicate case label {entry.label!r}"
+            raise TypeError(msg)
+        seen.add(entry.label)
+
+    reference = table[0]
+    ref_key_count = len(reference.args)
+    ref_kw_keys = frozenset(reference.kwargs)
+    for entry in table[1:]:
+        if len(entry.args) != ref_key_count:
+            msg = (
+                f"test.cases(): case {entry.label!r} has "
+                f"{len(entry.args)} positional arg(s), but case "
+                f"{reference.label!r} has {ref_key_count}"
+            )
+            raise TypeError(msg)
+        kw_keys = frozenset(entry.kwargs)
+        if kw_keys != ref_kw_keys:
+            missing = sorted(ref_kw_keys - kw_keys)
+            extra = sorted(kw_keys - ref_kw_keys)
+            parts: list[str] = []
+            if missing:
+                parts.append(f"missing {missing!r}")
+            if extra:
+                parts.append(f"extra {extra!r}")
+            joined = ", ".join(parts)
+            msg = (
+                f"test.cases(): case {entry.label!r} key set differs "
+                f"from case {reference.label!r} ({joined})"
+            )
+            raise TypeError(msg)
 
 
 def _build_cases_table(
-    positional: tuple[list[tuple[str, CaseArgs]], ...],
+    positional: tuple[object, ...],
     kwargs: dict[str, CaseArgs],
 ) -> CaseTable:
-    """Resolve ``@test.cases(...)`` arguments to a `{label: args}` table."""
+    """Resolve ``@test.cases(...)`` arguments into a :data:`CaseTable`.
+
+    Three input shapes are supported:
+
+    - Typed: ``cases(test.case(...), test.case(...))`` — every positional
+      arg is a :class:`_CaseSpec`.
+    - Legacy kwargs: ``cases(label=args_dict, ...)``.
+    - Legacy list: ``cases([(label, args_dict), ...])``.
+    """
     if positional and kwargs:
-        msg = "test.cases() accepts either list form or kwargs form, not both"
+        msg = "test.cases() accepts either positional or kwargs form, not both"
         raise TypeError(msg)
+    if positional and all(isinstance(p, _CaseSpec) for p in positional):
+        # Narrow tuple[object, ...] to tuple of specs without a cast.
+        return tuple(item.entry for item in positional if isinstance(item, _CaseSpec))
     if kwargs:
-        return dict(kwargs)
+        return _cases_from_kwargs(kwargs)
     if positional:
         if len(positional) != 1:
             msg = "test.cases() positional form takes exactly one list argument"
             raise TypeError(msg)
         return _cases_list_to_table(positional[0])
-    msg = "test.cases() requires at least one case (kwargs or a list)"
+    msg = "test.cases() requires at least one case (kwargs, list, or test.case specs)"
     raise TypeError(msg)
 
 
@@ -440,47 +562,110 @@ class _TestBuilder:
 
         return decorator
 
+    def case[**P](
+        self,
+        label: str,
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> _CaseSpec[P]:
+        """Build one typed case for a :meth:`cases` decorator.
+
+        The ``label`` is an arbitrary string — spaces, math operators,
+        and punctuation are all fine, so ``"my test"`` and ``"2 + 3"``
+        both work and survive ``-k`` filtering end-to-end.
+
+        The ``*args``/``**kwargs`` are typed via PEP 612 ``_P.args`` /
+        ``_P.kwargs`` so that mypy and pyright can match them against
+        the decorated function's signature inside :meth:`cases`. ty
+        does not yet enforce this pattern; see the module docstring for
+        :class:`_CaseSpec` for details.
+
+        Example:
+            ```python
+            @test.cases(
+                test.case("zero", n=0, expected=0),
+                test.case("one",  n=1, expected=1),
+                test.case("ten",  n=10, expected=100),
+            )
+            def square(n: int, expected: int) -> None:
+                expect(n * n).to_equal(expected)
+            ```
+        """
+        return _CaseSpec(label, *args, **kwargs)
+
+    @overload
+    def cases[**P](
+        self,
+        *specs: _CaseSpec[P],
+    ) -> Callable[[Callable[P, None]], Callable[P, None]]: ...
+    @overload
     def cases(
         self,
-        *positional: list[tuple[str, CaseArgs]],
+        positional: list[tuple[str, CaseArgs]],
+        /,
+    ) -> Callable[[_Fn], _Fn]: ...
+    @overload
+    def cases(
+        self,
+        /,
+        **kwargs: CaseArgs,
+    ) -> Callable[[_Fn], _Fn]: ...
+
+    def cases(
+        self,
+        *positional: object,
         **kwargs: CaseArgs,
     ) -> Callable[[_Fn], _Fn]:
         """Parametrize a test over multiple named cases.
 
-        Two forms are supported:
+        Three forms are supported:
 
-        - Keyword form — each kwarg name is a case label, each value is a
-          dict of arguments passed to the function:
+        - **Typed form** (recommended) — one :meth:`case` spec per case.
+          PEP 612 ``ParamSpec`` binds the kwargs against the decorated
+          function's signature so typos and mismatched types become
+          static errors under mypy/pyright:
+
+              @test.cases(
+                  test.case("zero",     n=0,  expected=0),
+                  test.case("one",      n=1,  expected=1),
+                  test.case("ten",      n=10, expected=100),
+              )
+              def square(n: int, expected: int) -> None:
+                  expect(n * n).to_equal(expected)
+
+          ty (as of 0.0.21) does not yet enforce this pattern. Runtime
+          validation below still catches label collisions and
+          inconsistent key sets.
+
+        - **Legacy keyword form** — each kwarg name is a case label,
+          each value is a dict of arguments. Cases lose static typing:
 
               @test.cases(
                   zero={"n": 0, "squared": 0},
                   one={"n": 1, "squared": 1},
               )
-              def square(n, squared):
-                  expect(n * n).to_equal(squared)
+              def square(n, squared): ...
 
-        - Positional list form — a list of (label, args) tuples. Use this
-          when labels are not valid Python identifiers:
+        - **Legacy list form** — a list of ``(label, args_dict)``
+          tuples. Use when a label is not a valid Python identifier
+          and the typed form is unavailable:
 
               @test.cases([
                   ("2 + 3", {"a": 2, "b": 3, "sum": 5}),
                   ("-1 + 1", {"a": -1, "b": 1, "sum": 0}),
               ])
-              def add(a, b, sum):
-                  expect(a + b).to_equal(sum)
+              def add(a, b, sum): ...
 
-        Composes with ``@fixture``/``Depends()`` parameters, ``describe(...)``
-        blocks, and ``@test.skip``/``@test.xfail`` modifiers.
-
-        Args:
-            positional: A single positional list of (label, args) tuples.
-            kwargs: Case-label → args-dict mapping.
+        Composes with ``@fixture``/``Depends()`` parameters,
+        ``describe(...)`` blocks, and ``@test.skip``/``@test.xfail``.
 
         Raises:
-            TypeError: If neither form is provided, both are mixed, or the
-                positional argument is not a list of (str, dict) tuples.
+            TypeError: If no cases are provided, forms are mixed, two
+                cases share a label, or cases disagree on key sets.
         """
         table = _build_cases_table(positional, kwargs)
+        _validate_cases_table(table)
 
         def decorator(f: _Fn) -> _Fn:
             _stamp_cases(f, table)

--- a/python/tryke/hooks.py
+++ b/python/tryke/hooks.py
@@ -401,15 +401,18 @@ class HookExecutor:
         test_fn: _FixtureFn,
         *,
         groups: list[str],
+        case_args: tuple[object, ...] = (),
         case_kwargs: CaseArgs | None = None,
     ) -> None:
         """Execute fixtures in correct order around *test_fn*.
 
-        When *case_kwargs* is provided (from ``@test.cases``), its entries
-        are merged into the kwargs passed to *test_fn* alongside the
-        fixture-injected values. A collision between a case kwarg and a
-        fixture parameter raises ``TypeError`` — case parameters may not
-        shadow ``Depends()`` parameters.
+        When *case_args* / *case_kwargs* are provided (from
+        ``@test.cases``), ``case_args`` is splatted positionally and
+        ``case_kwargs`` entries are merged into the kwargs passed to
+        *test_fn* alongside the fixture-injected values. A collision
+        between a case kwarg and a fixture parameter raises
+        ``TypeError`` — case parameters may not shadow ``Depends()``
+        parameters.
         """
         # Build the scope chain: [], ["a"], ["a", "b"], ...
         scopes: list[tuple[str, ...]] = [
@@ -454,9 +457,9 @@ class HookExecutor:
                     raise TypeError(msg)
                 test_kwargs = {**test_kwargs, **case_kwargs}
             if inspect.iscoroutinefunction(test_fn):
-                asyncio.run(test_fn(**test_kwargs))
+                asyncio.run(test_fn(*case_args, **test_kwargs))
             else:
-                test_fn(**test_kwargs)
+                test_fn(*case_args, **test_kwargs)
         finally:
             # Teardown per-test generator fixtures in reverse setup order.
             self._resolver.teardown_test_generators()

--- a/python/tryke/hooks.py
+++ b/python/tryke/hooks.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
     from typing import Any, Protocol
 
+    from tryke.expect import CaseArgs
+
     class _FixtureFn(Protocol):
         """A named callable — i.e. any real Python function.
 
@@ -399,8 +401,16 @@ class HookExecutor:
         test_fn: _FixtureFn,
         *,
         groups: list[str],
+        case_kwargs: CaseArgs | None = None,
     ) -> None:
-        """Execute fixtures in correct order around *test_fn*."""
+        """Execute fixtures in correct order around *test_fn*.
+
+        When *case_kwargs* is provided (from ``@test.cases``), its entries
+        are merged into the kwargs passed to *test_fn* alongside the
+        fixture-injected values. A collision between a case kwarg and a
+        fixture parameter raises ``TypeError`` — case parameters may not
+        shadow ``Depends()`` parameters.
+        """
         # Build the scope chain: [], ["a"], ["a", "b"], ...
         scopes: list[tuple[str, ...]] = [
             (),
@@ -433,6 +443,16 @@ class HookExecutor:
 
         try:
             test_kwargs = self._resolver.resolve(test_fn)
+            if case_kwargs:
+                conflicts = set(test_kwargs).intersection(case_kwargs)
+                if conflicts:
+                    names = ", ".join(sorted(conflicts))
+                    msg = (
+                        f"@test.cases argument(s) {{{names}}} collide with "
+                        f"fixture-injected parameter(s) of {test_fn.__name__}"
+                    )
+                    raise TypeError(msg)
+                test_kwargs = {**test_kwargs, **case_kwargs}
             if inspect.iscoroutinefunction(test_fn):
                 asyncio.run(test_fn(**test_kwargs))
             else:

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -587,6 +587,7 @@ class Worker:
                 "",
             )
 
+        case_args: tuple[object, ...] = ()
         case_kwargs: CaseArgs | None = None
         if case_label is not None:
             if not isinstance(fn, CasesMarked):
@@ -602,19 +603,22 @@ class Worker:
                     "",
                 )
             cases = fn.__tryke_cases__
-            if case_label not in cases:
+            entry = next((e for e in cases if e.label == case_label), None)
+            if entry is None:
+                known = sorted(e.label for e in cases)
                 return _failed(
                     0,
                     (
                         f"{function_name} has no case labeled "
-                        f"{case_label!r}; known cases: {sorted(cases)}"
+                        f"{case_label!r}; known cases: {known}"
                     ),
                     "",
                     [],
                     "",
                     "",
                 )
-            case_kwargs = cases[case_label]
+            case_args = entry.args
+            case_kwargs = entry.kwargs
 
         # Runtime skip/todo (handles skip_if resolved at import time)
         if isinstance(fn, _SkipMarked):
@@ -645,12 +649,13 @@ class Worker:
                         executor.run_test(
                             fn,
                             groups=groups or [],
+                            case_args=case_args,
                             case_kwargs=case_kwargs,
                         )
                     elif inspect.iscoroutinefunction(fn):
-                        asyncio.run(fn(**(case_kwargs or {})))
+                        asyncio.run(fn(*case_args, **(case_kwargs or {})))
                     else:
-                        fn(**(case_kwargs or {}))
+                        fn(*case_args, **(case_kwargs or {}))
 
                 ms = int((time.monotonic() - start) * 1000)
                 out = stdout_buf.getvalue()

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -65,6 +65,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict
 
 from tryke.expect import (
+    CaseArgs,
+    CasesMarked,
     ExpectationError,
     SoftContext,
     SoftFailure,
@@ -446,11 +448,14 @@ class Worker:
             groups = (
                 [str(g) for g in raw_groups] if isinstance(raw_groups, list) else []
             )
+            case_label_raw = params.get("case_label")
+            case_label = str(case_label_raw) if case_label_raw is not None else None
             return self._run_test(
                 self._require_str(params, "module", method),
                 self._require_str(params, "function", method),
                 xfail=(str(xfail_raw) if xfail_raw is not None else None),
                 groups=groups,
+                case_label=case_label,
             )
         if method == "run_doctest":
             return self._run_doctest(
@@ -560,13 +565,14 @@ class Worker:
         finally:
             _set_soft_context(None)
 
-    def _run_test(  # noqa: C901, PLR0911, PLR0912
+    def _run_test(  # noqa: C901, PLR0911, PLR0912, PLR0915
         self,
         module_name: str,
         function_name: str,
         *,
         xfail: str | None = None,
         groups: list[str] | None = None,
+        case_label: str | None = None,
     ) -> _TestResult:
         try:
             mod = self._get_module(module_name)
@@ -580,6 +586,35 @@ class Worker:
                 "",
                 "",
             )
+
+        case_kwargs: CaseArgs | None = None
+        if case_label is not None:
+            if not isinstance(fn, CasesMarked):
+                return _failed(
+                    0,
+                    (
+                        f"{function_name} was dispatched with case_label="
+                        f"{case_label!r} but has no __tryke_cases__ attribute"
+                    ),
+                    "",
+                    [],
+                    "",
+                    "",
+                )
+            cases = fn.__tryke_cases__
+            if case_label not in cases:
+                return _failed(
+                    0,
+                    (
+                        f"{function_name} has no case labeled "
+                        f"{case_label!r}; known cases: {sorted(cases)}"
+                    ),
+                    "",
+                    [],
+                    "",
+                    "",
+                )
+            case_kwargs = cases[case_label]
 
         # Runtime skip/todo (handles skip_if resolved at import time)
         if isinstance(fn, _SkipMarked):
@@ -607,11 +642,15 @@ class Worker:
                 ):
                     executor = self._get_executor(module_name)
                     if executor is not None:
-                        executor.run_test(fn, groups=groups or [])
+                        executor.run_test(
+                            fn,
+                            groups=groups or [],
+                            case_kwargs=case_kwargs,
+                        )
                     elif inspect.iscoroutinefunction(fn):
-                        asyncio.run(fn())
+                        asyncio.run(fn(**(case_kwargs or {})))
                     else:
-                        fn()
+                        fn(**(case_kwargs or {}))
 
                 ms = int((time.monotonic() - start) * 1000)
                 out = stdout_buf.getvalue()

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
 from tryke import CasesMarked, Depends, describe, expect, fixture, test
+from tryke.expect import _build_cases_table
 from tryke.hooks import HookExecutor
 from tryke.hooks import fixture as _fixture
+
+with describe("test.cases typed form (test.case)"):
+
+    @test.cases(
+        test.case("zero", n=0, expected=0),
+        test.case("one", n=1, expected=1),
+        test.case("ten", n=10, expected=100),
+        test.case("my test", n=2, expected=4),
+        test.case("2 + 3", n=5, expected=25),
+    )
+    def square_typed(n: int, expected: int) -> None:
+        expect(n * n).to_equal(expected)
+
 
 with describe("test.cases kwargs form"):
 
@@ -48,11 +62,12 @@ with describe("test.cases decorator returns function-like object"):
         if not isinstance(fn, CasesMarked):
             msg = "decorator should produce a CasesMarked function"
             raise TypeError(msg)
-        cases = fn.__tryke_cases__
-        expect(isinstance(cases, dict)).to_be_truthy()
-        expect(list(cases.keys())).to_equal(["a", "b"])
-        expect(cases["a"]).to_equal({"x": 1})
-        expect(cases["b"]).to_equal({"x": 2})
+        table = fn.__tryke_cases__
+        expect(isinstance(table, tuple)).to_be_truthy()
+        expect([e.label for e in table]).to_equal(["a", "b"])
+        expect(table[0].kwargs).to_equal({"x": 1})
+        expect(table[1].kwargs).to_equal({"x": 2})
+        expect(table[0].args).to_equal(())
 
     @test
     def cases_list_form_stamps_attribute() -> None:
@@ -63,16 +78,34 @@ with describe("test.cases decorator returns function-like object"):
         if not isinstance(fn, CasesMarked):
             msg = "decorator should produce a CasesMarked function"
             raise TypeError(msg)
-        expect(list(fn.__tryke_cases__.keys())).to_equal(["first", "second"])
+        expect([e.label for e in fn.__tryke_cases__]).to_equal(["first", "second"])
+
+    @test
+    def cases_typed_form_stamps_attribute() -> None:
+        @test.cases(
+            test.case("my test", n=0, expected=0),
+            test.case("other test", n=1, expected=1),
+        )
+        def fn(n: int, expected: int) -> None:  # noqa: ARG001
+            return
+
+        if not isinstance(fn, CasesMarked):
+            msg = "decorator should produce a CasesMarked function"
+            raise TypeError(msg)
+        table = fn.__tryke_cases__
+        expect([e.label for e in table]).to_equal(["my test", "other test"])
+        expect(table[0].kwargs).to_equal({"n": 0, "expected": 0})
+        expect(table[1].kwargs).to_equal({"n": 1, "expected": 1})
 
     @test
     def cases_rejects_mixed_forms() -> None:
+        # ty correctly rejects the overload combination at call sites,
+        # so we exercise the runtime dispatcher directly to verify the
+        # complementary runtime check still raises.
         def attempt() -> None:
-            @test.cases([("a", {})], b={})
-            def _fn() -> None:
-                pass
+            _build_cases_table(([("a", {})],), {"b": {}})
 
-        expect(attempt).to_raise(TypeError, match="list form")
+        expect(attempt).to_raise(TypeError, match="positional or kwargs")
 
     @test
     def cases_rejects_no_args() -> None:
@@ -82,6 +115,30 @@ with describe("test.cases decorator returns function-like object"):
                 pass
 
         expect(attempt).to_raise(TypeError)
+
+    @test
+    def cases_rejects_duplicate_labels_typed_form() -> None:
+        def attempt() -> None:
+            @test.cases(
+                test.case("same", n=0, expected=0),
+                test.case("same", n=1, expected=1),
+            )
+            def _fn(n: int, expected: int) -> None:  # noqa: ARG001
+                return
+
+        expect(attempt).to_raise(TypeError, match="duplicate case label 'same'")
+
+    @test
+    def cases_rejects_inconsistent_key_sets() -> None:
+        def attempt() -> None:
+            @test.cases(
+                test.case("a", n=0, expected=0),
+                test.case("b", n=1),
+            )
+            def _fn(n: int, expected: int = 0) -> None:  # noqa: ARG001
+                return
+
+        expect(attempt).to_raise(TypeError, match="missing")
 
 
 with describe("test.cases composes with fixtures"):

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from tryke import CasesMarked, Depends, describe, expect, fixture, test
+from tryke.hooks import HookExecutor
+from tryke.hooks import fixture as _fixture
+
+with describe("test.cases kwargs form"):
+
+    @test.cases(
+        zero={"n": 0, "squared": 0},
+        one={"n": 1, "squared": 1},
+        two={"n": 2, "squared": 4},
+        ten={"n": 10, "squared": 100},
+    )
+    def square(n: int, squared: int) -> None:
+        expect(n * n).to_equal(squared)
+
+    @test.cases(
+        lowercase={"value": "hi", "upper": "HI"},
+        already_upper={"value": "HI", "upper": "HI"},
+        mixed={"value": "Hi", "upper": "HI"},
+    )
+    def upper_case(value: str, upper: str) -> None:
+        expect(value.upper()).to_equal(upper)
+
+
+with describe("test.cases list form"):
+
+    @test.cases(
+        [
+            ("2 + 3", {"a": 2, "b": 3, "total": 5}),
+            ("-1 + 1", {"a": -1, "b": 1, "total": 0}),
+            ("0 + 0", {"a": 0, "b": 0, "total": 0}),
+        ]
+    )
+    def add(a: int, b: int, total: int) -> None:
+        expect(a + b).to_equal(total)
+
+
+with describe("test.cases decorator returns function-like object"):
+
+    @test
+    def cases_stamps_attribute() -> None:
+        @test.cases(a={"x": 1}, b={"x": 2})
+        def fn(x: int) -> None:  # noqa: ARG001 - body never runs, stamping only
+            return
+
+        if not isinstance(fn, CasesMarked):
+            msg = "decorator should produce a CasesMarked function"
+            raise TypeError(msg)
+        cases = fn.__tryke_cases__
+        expect(isinstance(cases, dict)).to_be_truthy()
+        expect(list(cases.keys())).to_equal(["a", "b"])
+        expect(cases["a"]).to_equal({"x": 1})
+        expect(cases["b"]).to_equal({"x": 2})
+
+    @test
+    def cases_list_form_stamps_attribute() -> None:
+        @test.cases([("first", {"x": 1}), ("second", {"x": 2})])
+        def fn(x: int) -> None:  # noqa: ARG001 - body never runs, stamping only
+            return
+
+        if not isinstance(fn, CasesMarked):
+            msg = "decorator should produce a CasesMarked function"
+            raise TypeError(msg)
+        expect(list(fn.__tryke_cases__.keys())).to_equal(["first", "second"])
+
+    @test
+    def cases_rejects_mixed_forms() -> None:
+        def attempt() -> None:
+            @test.cases([("a", {})], b={})
+            def _fn() -> None:
+                pass
+
+        expect(attempt).to_raise(TypeError, match="list form")
+
+    @test
+    def cases_rejects_no_args() -> None:
+        def attempt() -> None:
+            @test.cases()
+            def _fn() -> None:
+                pass
+
+        expect(attempt).to_raise(TypeError)
+
+
+with describe("test.cases composes with fixtures"):
+
+    @fixture
+    def multiplier() -> int:
+        return 10
+
+    @test.cases(
+        small={"n": 1, "expected": 10},
+        medium={"n": 5, "expected": 50},
+        big={"n": 9, "expected": 90},
+    )
+    def scaled(n: int, expected: int, factor: int = Depends(multiplier)) -> None:
+        expect(n * factor).to_equal(expected)
+
+
+with describe("test.cases composes with describe groups"), describe("nested"):
+
+    @test.cases(a={"x": 1}, b={"x": 2})
+    def nested_case(x: int) -> None:
+        expect(x).to_be_greater_than(0)
+
+
+with describe("test.cases composes with modifiers"):
+
+    @test.skip("intentionally skipped — all cases")
+    @test.cases(a={"x": 1}, b={"x": 2})
+    def skipped_cases(x: int) -> None:  # noqa: ARG001 - body never runs, skip marks it
+        msg = "should not run"
+        raise AssertionError(msg)
+
+    @test.xfail("known failure — all cases")
+    @test.cases(a={"x": 1}, b={"x": 2})
+    def xfail_cases(x: int) -> None:
+        expect(x).to_equal(-1)
+
+
+with describe("test.cases rejects kwarg / fixture collision"):
+
+    @test
+    def collision_with_fixture_param_raises() -> None:
+        @_fixture
+        def v() -> int:
+            return 42
+
+        def conflict(v: int = Depends(v)) -> None:
+            expect(v).to_equal(1)
+
+        executor = HookExecutor()
+
+        def invoke() -> None:
+            executor.run_test(conflict, groups=[], case_kwargs={"v": 1})
+
+        expect(invoke).to_raise(TypeError, match="collide")

--- a/tests/typed/test_cases_typing.py
+++ b/tests/typed/test_cases_typing.py
@@ -1,0 +1,55 @@
+"""Type-check sanity cases for ``@test.cases`` + ``test.case`` typing.
+
+The functions in this file are real, runnable tryke tests that also
+serve as positive samples for the ``test.case(...)`` typed form: they
+must continue to type-check under ``mypy`` and ``pyright``. ty (as of
+0.0.21) does not yet enforce the PEP 612 ``Generic[P]`` constructor
+pattern ``_CaseSpec`` uses, but the positives below pass under ty
+regardless.
+
+**Manual negative verification.** The following mutations of the
+positive cases should all be rejected by mypy and pyright (ty currently
+accepts them silently until its PEP 612 support catches up). To verify,
+introduce one mutation at a time in this file and run
+``uvx mypy tests/typed/test_cases_typing.py``:
+
+1. **Unknown kwarg** — change ``test.case("zero", n=0, expected=0)`` to
+   ``test.case("zero", n=0, expcted=0)``. Expected: mypy rejects the
+   call because ``expcted`` is not in the decorated function's
+   signature.
+
+2. **Wrong value type** — change ``n=0`` to ``n="zero"`` in any typed
+   case. Expected: mypy rejects because ``n: int`` on ``square``
+   doesn't match ``str``.
+
+3. **Missing required kwarg** — drop ``expected=0`` from any typed
+   case. Expected: mypy rejects because ``expected`` is a required
+   parameter.
+
+4. **Signature drift** — change ``def square(n: int, ...)`` to
+   ``def square(n: str, ...)`` without updating the cases. Expected:
+   mypy rejects the decoration because ``_P`` stops unifying.
+
+Each mutation must be reverted before committing.
+"""
+
+from __future__ import annotations
+
+from tryke import expect, test
+
+
+@test.cases(
+    test.case("zero", n=0, expected=0),
+    test.case("one", n=1, expected=1),
+    test.case("ten", n=10, expected=100),
+)
+def square(n: int, expected: int) -> None:
+    expect(n * n).to_equal(expected)
+
+
+@test.cases(
+    test.case("my test", name="hello", upper="HELLO"),
+    test.case("2 + 3", name="world", upper="WORLD"),
+)
+def upper(name: str, upper: str) -> None:
+    expect(name.upper()).to_equal(upper)

--- a/zensical.toml
+++ b/zensical.toml
@@ -26,6 +26,7 @@ nav = [
   { "Concepts" = [
     "concepts/discovery.md",
     "concepts/soft-assertions.md",
+    "concepts/cases.md",
     "concepts/concurrency.md",
     "concepts/client-server.md",
   ] },


### PR DESCRIPTION
## Summary
- Adds `@test.cases` decorator that expands one Python function into N test items visible to static AST discovery (kwargs form + list form)
- Composes cleanly with `@fixture`/`Depends()`, `describe()` blocks, and `@test.skip`/`@test.xfail`
- New public types `CaseArgs`, `CaseTable`, `CasesMarked` exported from `tryke`

## Changes
- **Rust**: `TestItem` gains `case_label` / `case_index`; discovery walks `@test.cases` decorator and emits one `TestItem` per case. Reporters (`text`, `llm`, `junit`) render `name[label]` via a shared `display_label()` helper.
- **Python**: `_TestBuilder.cases` stamps `__tryke_cases__` on the test function. Worker threads `case_label` through the runner protocol; `HookExecutor.run_test` merges case kwargs with fixture-injected kwargs and raises `TypeError` on collision with `Depends()` params.
- **Docs**: new `concepts/cases.md`, `migration.md` replaces the "no parametrize" row, `writing-tests.md` gains a Parametrized section.
- **Tests**: `tests/test_cases.py` covers both forms, fixture + describe composition, skip/xfail composition, and the kwarg/fixture collision diagnostic.

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo run test --reporter llm` — 167 passed, 2 skipped, 2 xfailed
- [x] `uvx prek run -a` clean
- [ ] Manual: run a 3-case function with `--collect-only` and confirm 3 rows with distinct `[label]` suffixes
- [ ] Manual: confirm `collect_complete` JSON contains `case_label` field per case

🤖 Generated with [Claude Code](https://claude.com/claude-code)