### PR TITLE
Ship python/tryke_guard.py in the built wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ exclude = ["benchmarks/suites", "demo"]
 bindings = "bin"
 manifest-path = "crates/tryke/Cargo.toml"
 python-source = "python"
+include = [{ path = "python/tryke_guard.py", format = ["sdist", "wheel"] }]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]


### PR DESCRIPTION
## Summary

- `python/tryke_guard.py` isn't ending up in published wheels, so downstream projects that follow the docs (`from tryke_guard import __TRYKE_TESTING__`) get `ModuleNotFoundError`.
- Maturin's `python-source = \"python\"` only packages the single Python package matching the project name (`python/tryke/`). Sibling top-level modules under the source directory are silently dropped from the wheel.
- Tryke's own test runs work because `crates/tryke_runner/src/pool.rs` prepends `<repo>/python` to the worker's `PYTHONPATH`, masking the packaging gap.
- Adding an explicit `include` entry tells maturin to ship the file. Maturin strips the `python-source` prefix when placing it, so `python/tryke_guard.py` lands at `tryke_guard.py` at the wheel root — the importable location.

```toml
[tool.maturin]
include = [{ path = "python/tryke_guard.py", format = ["sdist", "wheel"] }]
```

## Reproduction (before the fix)

```sh
uv build --wheel
unzip -l target/wheels/tryke-0.0.17-*.whl | grep tryke_guard   # no matches
```

And from a fresh venv:

```sh
uv pip install target/wheels/tryke-0.0.17-*.whl
python -c "from tryke_guard import __TRYKE_TESTING__"
# ModuleNotFoundError: No module named 'tryke_guard'
```

## Test plan

- [x] `uv build --wheel` now logs `📦 Including files matching "python/tryke_guard.py"` and the wheel contains `tryke_guard.py` at the root.
- [x] `uv pip install <wheel>` into a clean venv, then `from tryke_guard import __TRYKE_TESTING__` resolves and evaluates to `False` by default (production mode).
- [ ] CI `release` workflow produces wheels containing `tryke_guard.py` on all three OS builders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)