### PR TITLE
Add to_be_instance_of matcher for type checking

### DIFF
--- a/python/tryke/expect.py
+++ b/python/tryke/expect.py
@@ -993,11 +993,23 @@ class Expectation[T]:
             received=repr(self._value),
         )
 
+    @overload
+    def to_be_instance_of[C](self: Expectation[C], cls: type[C]) -> MatchResult: ...
+    @overload
+    def to_be_instance_of(self, cls: tuple[type, ...]) -> MatchResult: ...
     def to_be_instance_of(self, cls: type | tuple[type, ...]) -> MatchResult:
         """Assert the value is an instance of `cls`.
 
         Accepts either a single class or a tuple of classes, mirroring
-        the built-in [`isinstance`][].
+        the built-in [`isinstance`][]. The single-class form is generic
+        over the expectation's value type, so type checkers flag obvious
+        mismatches like `expect(42).to_be_instance_of(str)` statically
+        while still allowing downcasts (for example,
+        `expect(animal).to_be_instance_of(Dog)` when `animal: Animal`).
+        The tuple form falls back to `tuple[type, ...]` because
+        requiring every element to match the value's type would reject
+        legitimate "any of these" checks such as
+        `expect("hi").to_be_instance_of((bytes, str))`.
 
         Args:
             cls: The class (or tuple of classes) to check against.
@@ -1009,7 +1021,7 @@ class Expectation[T]:
             MatchResult(ok)
             >>> expect("hi").to_be_instance_of((bytes, str))
             MatchResult(ok)
-            >>> expect(42).not_.to_be_instance_of(str)
+            >>> expect(42).not_.to_be_instance_of(bool)
             MatchResult(ok)
 
             ```

--- a/python/tryke/expect.py
+++ b/python/tryke/expect.py
@@ -993,6 +993,39 @@ class Expectation[T]:
             received=repr(self._value),
         )
 
+    def to_be_instance_of(self, cls: type | tuple[type, ...]) -> MatchResult:
+        """Assert the value is an instance of `cls`.
+
+        Accepts either a single class or a tuple of classes, mirroring
+        the built-in [`isinstance`][].
+
+        Args:
+            cls: The class (or tuple of classes) to check against.
+
+        Example:
+            ```pycon
+            >>> from tryke import expect
+            >>> expect([1, 2, 3]).to_be_instance_of(list)
+            MatchResult(ok)
+            >>> expect("hi").to_be_instance_of((bytes, str))
+            MatchResult(ok)
+            >>> expect(42).not_.to_be_instance_of(str)
+            MatchResult(ok)
+
+            ```
+        """
+        expected_name = (
+            " | ".join(c.__name__ for c in cls)
+            if isinstance(cls, tuple)
+            else cls.__name__
+        )
+        return self._assert(
+            isinstance(self._value, cls),
+            f"{self._value!r} to be instance of {expected_name}",
+            expected=f"instance of {expected_name}",
+            received=f"instance of {type(self._value).__name__}",
+        )
+
     def to_be_greater_than[C: _SupportsGT](self: Expectation[C], n: C) -> MatchResult:
         """Assert the value is greater than `n`.
 

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -50,6 +50,55 @@ with describe("expectations"):
         expect(None).to_be_none()
         expect(1).not_.to_be_none()
 
+    @test(name="to_be_instance_of")
+    def test_to_be_instance_of() -> None:
+        expect([1, 2, 3]).to_be_instance_of(list)
+        expect("hello").to_be_instance_of(str)
+        expect("hi").to_be_instance_of((bytes, str))
+        expect(42).not_.to_be_instance_of(str)
+        expect(1.5).not_.to_be_instance_of((list, dict))
+
+    @test(name="to_be_instance_of matches subclasses")
+    def test_to_be_instance_of_subclass() -> None:
+        class Base:
+            pass
+
+        class Derived(Base):
+            pass
+
+        expect(Derived()).to_be_instance_of(Base)
+        expect(Base()).not_.to_be_instance_of(Derived)
+
+    @test(name="to_be_instance_of reports class names on failure")
+    def test_to_be_instance_of_error_fields() -> None:
+        ctx = SoftContext()
+        _set_soft_context(ctx)
+        try:
+            expect(42).to_be_instance_of(str).fatal()
+        except ExpectationError as exc:
+            _set_soft_context(None)
+            expect(exc.expected).to_equal("instance of str")
+            expect(exc.received).to_equal("instance of int")
+        else:
+            _set_soft_context(None)
+            msg = "ExpectationError was not raised"
+            raise AssertionError(msg)
+
+    @test(name="to_be_instance_of accepts a tuple of classes")
+    def test_to_be_instance_of_tuple_error_fields() -> None:
+        ctx = SoftContext()
+        _set_soft_context(ctx)
+        try:
+            expect(1.5).to_be_instance_of((list, dict)).fatal()
+        except ExpectationError as exc:
+            _set_soft_context(None)
+            expect(exc.expected).to_equal("instance of list | dict")
+            expect(exc.received).to_equal("instance of float")
+        else:
+            _set_soft_context(None)
+            msg = "ExpectationError was not raised"
+            raise AssertionError(msg)
+
     @test(name="to_be_greater_than")
     def test_to_be_greater_than() -> None:
         expect(5).to_be_greater_than(3)

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -55,10 +55,13 @@ with describe("expectations"):
         expect([1, 2, 3]).to_be_instance_of(list)
         expect("hello").to_be_instance_of(str)
         expect("hi").to_be_instance_of((bytes, str))
-        expect(42).not_.to_be_instance_of(str)
+        # `bool` is a subclass of `int`, so `type[bool]` is assignable
+        # to `type[int]` and this stays type-clean while still failing
+        # at runtime (42 is an int, not a bool).
+        expect(42).not_.to_be_instance_of(bool)
         expect(1.5).not_.to_be_instance_of((list, dict))
 
-    @test(name="to_be_instance_of matches subclasses")
+    @test(name="to_be_instance_of narrows subclasses")
     def test_to_be_instance_of_subclass() -> None:
         class Base:
             pass
@@ -66,18 +69,23 @@ with describe("expectations"):
         class Derived(Base):
             pass
 
-        expect(Derived()).to_be_instance_of(Base)
-        expect(Base()).not_.to_be_instance_of(Derived)
+        # Downcast: the static type is Base, so asking "is it a Derived?"
+        # is a real runtime question and `type[Derived]` is assignable to
+        # the expected `type[Base]` via covariance.
+        derived_as_base: Base = Derived()
+        expect(derived_as_base).to_be_instance_of(Derived)
+        plain_base: Base = Base()
+        expect(plain_base).not_.to_be_instance_of(Derived)
 
     @test(name="to_be_instance_of reports class names on failure")
     def test_to_be_instance_of_error_fields() -> None:
         ctx = SoftContext()
         _set_soft_context(ctx)
         try:
-            expect(42).to_be_instance_of(str).fatal()
+            expect(42).to_be_instance_of(bool).fatal()
         except ExpectationError as exc:
             _set_soft_context(None)
-            expect(exc.expected).to_equal("instance of str")
+            expect(exc.expected).to_equal("instance of bool")
             expect(exc.received).to_equal("instance of int")
         else:
             _set_soft_context(None)

--- a/tests/typed/test_expect_typing.py
+++ b/tests/typed/test_expect_typing.py
@@ -1,0 +1,60 @@
+"""Type-check sanity cases for ``Expectation.to_be_instance_of``.
+
+The single-class overload binds the expectation's value type (``C``)
+and requires ``cls: type[C]``. Covariance of ``type[...]`` means
+subclasses of the expected type are accepted (downcast checks), while
+unrelated types are rejected by the checker.
+
+**Manual negative verification.** Each mutation below should be
+rejected by ``ty check`` (and by mypy/pyright). Introduce one at a
+time and run ``uvx prek run ty -a`` (or the type checker directly).
+Revert before committing.
+
+1. **Unrelated type** — change
+   ``expect(42).to_be_instance_of(int)`` to
+   ``expect(42).to_be_instance_of(str)``. Expected: ``type[str]`` is
+   not assignable to ``type[int]``.
+
+2. **Sibling subclass** — with
+   ``derived_as_base: Base = Derived()``, change the matcher to
+   ``expect(derived_as_base).to_be_instance_of(Sibling)`` where
+   ``Sibling`` is a second subclass of ``Base`` not related to
+   ``Derived``. Expected: rejected, because ``type[Sibling]`` is
+   assignable to ``type[Base]`` (fine), but if the value is narrowed
+   to ``Expectation[Derived]`` the checker flags the mismatch.
+
+The tuple overload is intentionally permissive: mixing unrelated types
+like ``(bytes, str)`` is a legitimate "any of these" runtime check
+that can't be statically constrained without forcing callers to
+pre-widen their value to the union.
+"""
+
+from __future__ import annotations
+
+from tryke import describe, expect, test
+
+
+class _Base:
+    pass
+
+
+class _Derived(_Base):
+    pass
+
+
+with describe("to_be_instance_of typing"):
+
+    @test(name="single-class form accepts exact type")
+    def single_class_exact() -> None:
+        expect(42).to_be_instance_of(int)
+        expect("hi").to_be_instance_of(str)
+
+    @test(name="single-class form accepts covariant downcast")
+    def single_class_downcast() -> None:
+        value: _Base = _Derived()
+        expect(value).to_be_instance_of(_Derived)
+
+    @test(name="tuple form accepts unrelated types")
+    def tuple_any_of() -> None:
+        expect("hi").to_be_instance_of((bytes, str))
+        expect(b"x").to_be_instance_of((bytes, str))


### PR DESCRIPTION
## Summary
This PR adds a new `to_be_instance_of()` matcher to the expectation API that allows asserting whether a value is an instance of a given class or tuple of classes.

## Key Changes
- **New matcher method**: `to_be_instance_of(cls)` in `Expectation` class that accepts either a single class or tuple of classes, mirroring Python's built-in `isinstance()` function
- **Error reporting**: Provides clear error messages showing both expected and received types, with support for displaying multiple classes using pipe-separated format (e.g., "list | dict")
- **Subclass support**: Correctly handles inheritance relationships, matching instances of derived classes against base class checks
- **Comprehensive tests**: Added four test cases covering:
  - Basic type checking with single and multiple classes
  - Subclass matching behavior
  - Error message formatting for single class failures
  - Error message formatting for tuple of classes failures

## Implementation Details
- The matcher uses Python's `isinstance()` internally for the actual type checking
- For tuple inputs, class names are joined with " | " separator for readable error messages
- Error fields distinguish between the expected type(s) and the actual type of the received value
- Follows the existing pattern of other matchers in the codebase with proper docstring and examples

https://claude.ai/code/session_01CJpZPMqhD9dsEjZ5rWvS37