### PR TITLE
Share event loop across async fixtures and tests, and accept patch versions

### DIFF
--- a/crates/tryke_runner/src/lib.rs
+++ b/crates/tryke_runner/src/lib.rs
@@ -58,8 +58,14 @@ fn parse_min_version(specifier: &str) -> anyhow::Result<(u32, u32)> {
 }
 
 fn parse_version(s: &str) -> anyhow::Result<(u32, u32)> {
-    let (major, minor) = s
-        .split_once('.')
+    // Accept X.Y and X.Y.Z... — only the first two components are
+    // significant for Python's requires-python floor.
+    let mut parts = s.splitn(3, '.');
+    let major = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("invalid version: {s}"))?;
+    let minor = parts
+        .next()
         .ok_or_else(|| anyhow::anyhow!("invalid version: {s}"))?;
     Ok((major.parse()?, minor.parse()?))
 }
@@ -82,6 +88,14 @@ mod tests {
     fn parse_version_valid() {
         assert_eq!(parse_version("3.12").unwrap(), (3, 12));
         assert_eq!(parse_version("3.9").unwrap(), (3, 9));
+    }
+
+    #[test]
+    fn parse_version_accepts_patch_component() {
+        // PEP 440 allows requires-python with patch-level versions.
+        // Home Assistant declares ">=3.14.2" — we only care about major.minor.
+        assert_eq!(parse_version("3.14.2").unwrap(), (3, 14));
+        assert_eq!(parse_min_version(">=3.14.2").unwrap(), (3, 14));
     }
 
     #[test]

--- a/python/tryke/hooks.py
+++ b/python/tryke/hooks.py
@@ -208,11 +208,8 @@ class DependencyResolver:
         # created on first async need so pure-sync modules pay nothing.
         # Sharing one loop across the resolver's lifetime is what makes
         # `async with`-style fixtures compose with async tests: without
-        # it, a fixture created on loop A returns loop-bound objects
-        # (Futures, HomeAssistant instances, aiohttp sessions, ...) that
+        # it, a fixture created on loop A returns loop-bound objects that
         # the test body — running on a freshly-minted loop B — cannot
-        # await. See the homeassistant/core migration for a real-world
-        # trigger.
         self._shared_loop: asyncio.AbstractEventLoop | None = None
 
     @property

--- a/python/tryke/hooks.py
+++ b/python/tryke/hooks.py
@@ -187,6 +187,7 @@ class _AsyncGenEntry(NamedTuple):
     agen: AsyncGenerator[Any, None]
     loop: asyncio.AbstractEventLoop
     is_scope: bool
+    owns_loop: bool
 
 
 class DependencyResolver:
@@ -203,6 +204,41 @@ class DependencyResolver:
         self._active_generators: list[_SyncGenEntry] = []
         self._active_async_generators: list[_AsyncGenEntry] = []
         self._resolving: set[int] = set()
+        # Shared loop for async fixtures + async test bodies. Lazily
+        # created on first async need so pure-sync modules pay nothing.
+        # Sharing one loop across the resolver's lifetime is what makes
+        # `async with`-style fixtures compose with async tests: without
+        # it, a fixture created on loop A returns loop-bound objects
+        # (Futures, HomeAssistant instances, aiohttp sessions, ...) that
+        # the test body — running on a freshly-minted loop B — cannot
+        # await. See the homeassistant/core migration for a real-world
+        # trigger.
+        self._shared_loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def shared_loop(self) -> asyncio.AbstractEventLoop:
+        """Return the resolver's shared event loop, creating it on demand.
+
+        All async work (fixture setup, async test bodies, async fixture
+        teardown) that goes through this resolver runs on the returned
+        loop. The loop lives until :meth:`close_shared_loop` is called,
+        typically from ``HookExecutor.finalize``.
+        """
+        if self._shared_loop is None or self._shared_loop.is_closed():
+            self._shared_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._shared_loop)
+        return self._shared_loop
+
+    def close_shared_loop(self) -> None:
+        """Close the shared event loop if one was lazily created."""
+        loop = self._shared_loop
+        self._shared_loop = None
+        if loop is None:
+            return
+        with contextlib.suppress(Exception):
+            asyncio.set_event_loop(None)
+        with contextlib.suppress(Exception):
+            loop.close()
 
     def resolve(self, fn: _FixtureFn) -> dict[str, Any]:
         """Inspect *fn*'s signature and resolve all ``Depends()`` defaults.
@@ -245,13 +281,13 @@ class DependencyResolver:
                 self._active_generators.append(_SyncGenEntry(fn, gen, is_scope))
             elif inspect.isasyncgenfunction(fn):
                 agen = fn(**kwargs)
-                loop = asyncio.new_event_loop()
+                loop = self.shared_loop
                 value = loop.run_until_complete(agen.__anext__())
                 self._active_async_generators.append(
-                    _AsyncGenEntry(fn, agen, loop, is_scope)
+                    _AsyncGenEntry(fn, agen, loop, is_scope, owns_loop=False)
                 )
             elif inspect.iscoroutinefunction(fn):
-                value = asyncio.run(fn(**kwargs))
+                value = self.shared_loop.run_until_complete(fn(**kwargs))
             else:
                 value = fn(**kwargs)
 
@@ -306,8 +342,9 @@ class DependencyResolver:
             finally:
                 with contextlib.suppress(Exception):
                     entry.loop.run_until_complete(entry.agen.aclose())
-                with contextlib.suppress(Exception):
-                    entry.loop.close()
+                if entry.owns_loop:
+                    with contextlib.suppress(Exception):
+                        entry.loop.close()
                 self._cache.pop(entry.fn, None)
                 if entry.is_scope:
                     self._scope_fixtures.discard(entry.fn)
@@ -457,7 +494,12 @@ class HookExecutor:
                     raise TypeError(msg)
                 test_kwargs = {**test_kwargs, **case_kwargs}
             if inspect.iscoroutinefunction(test_fn):
-                asyncio.run(test_fn(*case_args, **test_kwargs))
+                # Drive the test on the resolver's shared loop so the
+                # test body awaits on the same loop that ran any async
+                # fixture setup.
+                self._resolver.shared_loop.run_until_complete(
+                    test_fn(*case_args, **test_kwargs)
+                )
             else:
                 test_fn(*case_args, **test_kwargs)
         finally:
@@ -470,3 +512,4 @@ class HookExecutor:
         """Run per-scope teardown. Called by the worker after the last test."""
         self._resolver.teardown_scope_generators()
         self._resolver.clear_all()
+        self._resolver.close_shared_loop()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -709,16 +709,6 @@ with describe("async fixtures in HookExecutor"):
 
     @test(name="async fixture and async test share one event loop")
     def test_async_fixture_and_test_share_loop() -> None:
-        """Regression: loop-bound objects created by an async fixture
-        must be awaitable from the async test body.
-
-        Before the shared-loop fix, the async-gen fixture ran on a loop
-        created by DependencyResolver, while the async test ran on
-        asyncio.run()'s fresh loop. Any Future / Task created during
-        fixture setup was attached to the fixture's loop and raised
-        'attached to a different loop' when the test body awaited it.
-        This mirrors what Home Assistant's hass fixture exposes.
-        """
 
         @fixture
         async def loop_bound_resource() -> AsyncGenerator[asyncio.Future[int], None]:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, assert_type
 
 import tryke
@@ -705,6 +706,41 @@ with describe("async fixtures in HookExecutor"):
             RuntimeError
         )
         expect(log).to_contain("teardown")
+
+    @test(name="async fixture and async test share one event loop")
+    def test_async_fixture_and_test_share_loop() -> None:
+        """Regression: loop-bound objects created by an async fixture
+        must be awaitable from the async test body.
+
+        Before the shared-loop fix, the async-gen fixture ran on a loop
+        created by DependencyResolver, while the async test ran on
+        asyncio.run()'s fresh loop. Any Future / Task created during
+        fixture setup was attached to the fixture's loop and raised
+        'attached to a different loop' when the test body awaited it.
+        This mirrors what Home Assistant's hass fixture exposes.
+        """
+
+        @fixture
+        async def loop_bound_resource() -> AsyncGenerator[asyncio.Future[int], None]:
+            # Future is bound to whatever loop is running right now.
+            fut: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+            fut.set_result(7)
+            yield fut
+
+        received: dict[str, int] = {}
+
+        async def my_test(
+            fut: asyncio.Future[int] = Depends(loop_bound_resource),
+        ) -> None:
+            # If the test's loop differs from the fixture's loop, this
+            # raises "got Future <...> attached to a different loop".
+            received["value"] = await fut
+
+        executor = HookExecutor()
+        executor.register_fixture(loop_bound_resource, groups=[])
+        executor.run_test(my_test, groups=[])
+        executor.finalize()
+        expect(received["value"]).to_equal(7)
 
     @test(name="async generator aclose is called on teardown")
     def test_async_gen_aclose_called() -> None:


### PR DESCRIPTION
Two fixes surfaced while migrating
[home-assistant/core](https://github.com/home-assistant/core)'s test
suite to Tryke (see
[thejchap/core#1](https://github.com/thejchap/core/pull/1)). Bundling
them because both are prerequisites for any nontrivial async pytest
codebase.

## 1. Share one event loop across async fixtures + async tests

### Problem

\`DependencyResolver.resolve_hook\` used to call
\`asyncio.new_event_loop()\` per async-gen fixture, and
\`HookExecutor.run_test\` used \`asyncio.run()\` for async tests —
three separate loops in the common case. Any fixture that yielded a
loop-bound object (\`asyncio.Future\`, aiohttp session,
\`HomeAssistant\` instance, ...) broke the test body with:

\`\`\`
RuntimeError: Task got Future attached to a different loop
\`\`\`

This is the architectural mismatch \`pytest-asyncio\` papers over with
an event-loop fixture scoped above the tests that use it.

### Fix

- \`DependencyResolver\` lazily owns a single shared event loop via
  the new \`shared_loop\` property. The loop lives for the lifetime of
  the resolver — i.e. a \`HookExecutor\`'s lifetime.
- \`_AsyncGenEntry\` now tracks \`owns_loop\`; per-fixture teardown no
  longer closes the resolver's loop.
- \`HookExecutor.run_test\` drives async test bodies on the shared
  loop instead of \`asyncio.run()\`.
- \`HookExecutor.finalize\` closes the loop via the new
  \`close_shared_loop()\`.

### Regression test

\`tests/test_hooks.py::test_async_fixture_and_test_share_loop\` creates
an \`asyncio.Future\` inside an async-gen fixture and awaits it from
the async test — the exact pattern HA's \`hass\` fixture exposes. Fails
on \`main\`, passes with this PR.

## 2. \`parse_version\` accepts \`X.Y.Z\`

\`tryke_runner::parse_version\` split on \`.\` and required exactly
two components, so PEP 440 \`requires-python\` specifiers like
\`>=3.14.2\` (Home Assistant's current floor) errored with
\`invalid digit found in string\`. Widened to \`splitn(3, '.')\` —
only the first two components are significant for the
requires-python floor. \`parse_version_accepts_patch_component\`
regression test added.

## Verification

- \`cargo run test --reporter llm\` — 189 passed, 3 skipped, 3 xfailed, 1 todo.
- \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean.
- \`uvx prek run -a\` — clean.
- Against the HA fork: previously-blocked \`tests/util/test_process.py\`
  (which uses the ported \`hass\` fixture) now passes Gates 3 and 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)