### PR TITLE
Correct dot-reporter glyphs and add to_be_instance_of matcher

### DIFF
--- a/docs/guides/reporters.md
+++ b/docs/guides/reporters.md
@@ -21,9 +21,11 @@ Compact single-character output — one character per test. Useful for large sui
 
 - `.` pass
 - `F` fail
+- `E` error
 - `s` skip
-- `t` todo
+- `T` todo
 - `x` xfail
+- `X` xpassed (an `xfail` test that passed unexpectedly)
 
 ```bash
 tryke test --reporter dot

--- a/docs/guides/writing-tests.md
+++ b/docs/guides/writing-tests.md
@@ -82,6 +82,7 @@ Available matchers:
 | `to_be_truthy()` | `bool(x) is True` |
 | `to_be_falsy()` | `bool(x) is False` |
 | `to_be_none()` | `x is None` |
+| `to_be_instance_of(cls)` | `isinstance(x, cls)` (accepts a tuple of types) |
 | `to_be_greater_than(y)` | `x > y` |
 | `to_be_less_than(y)` | `x < y` |
 | `to_be_greater_than_or_equal(y)` | `x >= y` |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -43,6 +43,7 @@ The `@test` decorator replaces the `test_` prefix convention. Assertions use `ex
 | `assert x` | `expect(x).to_be_truthy()` |
 | `assert not x` | `expect(x).to_be_falsy()` |
 | `assert x is None` | `expect(x).to_be_none()` |
+| `assert isinstance(x, cls)` | `expect(x).to_be_instance_of(cls)` |
 | `assert x > y` | `expect(x).to_be_greater_than(y)` |
 | `assert x < y` | `expect(x).to_be_less_than(y)` |
 | `assert x in y` | `expect(y).to_contain(x)` |

--- a/python/tryke/hooks.py
+++ b/python/tryke/hooks.py
@@ -2,9 +2,7 @@
 
 Provides a single `@fixture` decorator with `per="test"` (default) or
 `per="scope"` granularity. A fixture runs setup before each covered test
-(or once per lexical scope) and — if it ``yield``s — teardown after. This
-replaces the older six-decorator pytest-style surface
-(`before_each`/`after_each`/`before_all`/`after_all`/`wrap_each`/`wrap_all`).
+(or once per lexical scope) and — if it ``yield``s — teardown after.
 
 ``Depends()`` wires typed dependency injection between fixtures and
 tests, FastAPI-style.


### PR DESCRIPTION
## Summary

Audit of the docs, README, and code comments against current behavior. Three fixes:

- **`dot` reporter glyph list** (`docs/guides/reporters.md`). The reporter actually emits `.`, `F`, `E`, `s`, `T`, `x`, and `X` (see `crates/tryke_reporter/src/dot.rs:48-57`); the docs were missing `E` (error) and `X` (xpassed) and listed `T` as lowercase.
- **`to_be_instance_of` matcher**. Shipped in `python/tryke/expect.py:997-1039` but was absent from both the matcher reference in `docs/guides/writing-tests.md` and the pytest-migration cheat sheet in `docs/migration.md`. Added rows to both.
- **`hooks.py` module docstring**. Removed a stale reference to an older "six-decorator pytest-style surface" (`before_each` / `after_each` / `before_all` / `after_all` / `wrap_each` / `wrap_all`) that never shipped in user-facing Tryke — it describes what the current unified `@fixture` design replaces *conceptually*, but the listed decorators are not a real migration path for any reader.

Not changed (verified, but matches code):
- CLI flags, defaults, and the auto-generated `docs/reference/cli.md` are consistent with `crates/tryke/src/cli.rs`.
- Worker defaults differ between `tryke test` (`min(test_count, cpu_count)`) and `tryke watch` (`cpu_count`) — both are already stated accurately in `docs/concepts/concurrency.md` and the respective guides.
- `[tool.tryke]` config section matches `crates/tryke_config/src/lib.rs`. The legacy `[tool.trike]` alias is intentionally undocumented (backwards-compat only).
- JSON-RPC server methods (`run_start`, `test_complete`, `run_complete`, `discover_complete`) match `crates/tryke_server/src/handler.rs`.

## Test plan

- [x] `uvx prek run -a` (trim whitespace, toml/yaml, rust linting, clippy, generate-cli-docs, generate-benchmark-docs, markdownlint, ruff, ty)
- [x] Verified each fix against the source of truth (`dot.rs`, `expect.py`, `hooks.py`)

https://claude.ai/code/session_01615aMTkLuecCuRWSUBrvhY