### PR TITLE
Tag server runs with run_id and serialize concurrent runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
@@ -2105,6 +2124,7 @@ dependencies = [
  "ignore",
  "log",
  "rayon",
+ "rmp-serde",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_source_file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ miette = { version = "7", features = ["fancy", "syntect-highlighter"] }
 owo-colors = { version = "4", features = ["supports-color"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rmp-serde = "1"
 tokio = { version = "1", features = [
   "rt-multi-thread",
   "net",

--- a/crates/tryke_discovery/Cargo.toml
+++ b/crates/tryke_discovery/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 ignore = { workspace = true }
 log = "0.4"
 rayon = { workspace = true }
+rmp-serde = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true }
 ruff_python_ast = { workspace = true }

--- a/crates/tryke_discovery/src/cache.rs
+++ b/crates/tryke_discovery/src/cache.rs
@@ -1,0 +1,280 @@
+//! Persistent on-disk cache of `DiscoveredFile` results keyed by
+//! `(mtime_nanos, size)`. Loaded at `Discoverer` construction and
+//! consulted in `rediscover` to skip parsing for unchanged files.
+//!
+//! The cache format is bumped via `CACHE_VERSION` on schema changes; a
+//! mismatched version produces an empty cache on load. Writes are
+//! atomic (write-to-temp + rename) so a crash can't corrupt the file.
+
+use std::{
+    collections::HashMap,
+    fs, io,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use log::{debug, trace};
+use serde::{Deserialize, Serialize};
+
+use crate::db::DiscoveredFile;
+
+/// Bumped whenever the cache schema (the shape of `DiscoveredFile` or
+/// its transitive fields) changes in a way that'd make old entries
+/// invalid. A mismatch on load yields an empty cache.
+const CACHE_VERSION: u32 = 1;
+
+/// Identity of a source file derived from `stat`. Cheap to obtain
+/// without reading the file contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileKey {
+    pub mtime_nanos: i128,
+    pub size: u64,
+}
+
+impl FileKey {
+    pub fn from_metadata(metadata: &fs::Metadata) -> io::Result<Self> {
+        let mtime = metadata.modified()?;
+        let mtime_nanos = match mtime.duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(d) => i128::try_from(d.as_nanos()).unwrap_or(i128::MAX),
+            Err(e) => -i128::try_from(e.duration().as_nanos()).unwrap_or(i128::MAX),
+        };
+        Ok(Self {
+            mtime_nanos,
+            size: metadata.len(),
+        })
+    }
+
+    pub fn from_path(path: &Path) -> io::Result<Self> {
+        let metadata = fs::metadata(path)?;
+        Self::from_metadata(&metadata)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheEntry {
+    key: FileKey,
+    data: DiscoveredFile,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheFile {
+    version: u32,
+    entries: HashMap<PathBuf, CacheEntry>,
+}
+
+#[derive(Debug, Default)]
+pub struct DiskCache {
+    entries: HashMap<PathBuf, CacheEntry>,
+    /// The path we loaded from / will save to. `None` disables I/O
+    /// (used by tests that don't want a filesystem footprint).
+    path: Option<PathBuf>,
+}
+
+impl DiskCache {
+    /// Load a cache from `path`. Returns an empty cache if the file is
+    /// missing, corrupted, or has a mismatched `CACHE_VERSION`.
+    pub fn load(path: PathBuf) -> Self {
+        let entries = match Self::try_load(&path) {
+            Ok(entries) => entries,
+            Err(err) => {
+                trace!("discovery cache load failed ({err}): starting empty");
+                HashMap::new()
+            }
+        };
+        debug!(
+            "discovery cache loaded {} entries from {}",
+            entries.len(),
+            path.display()
+        );
+        Self {
+            entries,
+            path: Some(path),
+        }
+    }
+
+    fn try_load(path: &Path) -> io::Result<HashMap<PathBuf, CacheEntry>> {
+        let bytes = fs::read(path)?;
+        let file: CacheFile = rmp_serde::from_slice(&bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        if file.version != CACHE_VERSION {
+            debug!(
+                "discovery cache version mismatch ({} vs {}): discarding",
+                file.version, CACHE_VERSION
+            );
+            return Ok(HashMap::new());
+        }
+        Ok(file.entries)
+    }
+
+    /// Lookup a cached result for `path`. Returns the stored
+    /// `DiscoveredFile` only if the recorded `FileKey` matches the
+    /// current one (i.e. the file hasn't been modified).
+    pub fn get(&self, path: &Path, current_key: &FileKey) -> Option<&DiscoveredFile> {
+        self.entries
+            .get(path)
+            .filter(|e| &e.key == current_key)
+            .map(|e| &e.data)
+    }
+
+    pub fn insert(&mut self, path: PathBuf, key: FileKey, data: DiscoveredFile) {
+        self.entries.insert(path, CacheEntry { key, data });
+    }
+
+    pub fn remove(&mut self, path: &Path) {
+        self.entries.remove(path);
+    }
+
+    /// Drop cache entries whose paths are not in `keep`. Called after
+    /// a full rediscover to prune entries for deleted / excluded files.
+    pub fn retain(&mut self, keep: &std::collections::HashSet<PathBuf>) {
+        self.entries.retain(|p, _| keep.contains(p));
+    }
+
+    /// Persist the cache to disk atomically via a temp file + rename.
+    /// No-op if this cache was not constructed with a backing path.
+    pub fn save(&self) -> io::Result<()> {
+        let Some(path) = self.path.as_ref() else {
+            return Ok(());
+        };
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+            // Drop a `.gitignore` at the top of the tryke state dir
+            // (parent-of-parent of the cache file, since the layout is
+            // `.tryke/cache/discovery-v1.bin`) so users don't have to
+            // remember to gitignore tryke's internal cache. Best-effort
+            // — a write failure here shouldn't abort the save.
+            if let Some(state_dir) = parent.parent() {
+                let gitignore = state_dir.join(".gitignore");
+                if !gitignore.exists() {
+                    let _ = fs::write(&gitignore, "# created by tryke\n*\n");
+                }
+            }
+        }
+        let file = CacheFile {
+            version: CACHE_VERSION,
+            entries: self.entries.clone(),
+        };
+        let bytes =
+            rmp_serde::to_vec(&file).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let tmp_path = path.with_extension("tmp");
+        fs::write(&tmp_path, &bytes)?;
+        fs::rename(&tmp_path, path)?;
+        debug!(
+            "discovery cache saved {} entries to {}",
+            self.entries.len(),
+            path.display()
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cache.json");
+        let cache = DiskCache::load(path.clone());
+        assert_eq!(cache.entries.len(), 0);
+        cache.save().expect("save");
+        let reloaded = DiskCache::load(path);
+        assert_eq!(reloaded.entries.len(), 0);
+    }
+
+    #[test]
+    fn roundtrip_with_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cache.json");
+        let mut cache = DiskCache::load(path.clone());
+        let key = FileKey {
+            mtime_nanos: 12345,
+            size: 67,
+        };
+        let data = DiscoveredFile::default();
+        cache.insert(PathBuf::from("foo.py"), key, data.clone());
+        cache.save().expect("save");
+
+        let reloaded = DiskCache::load(path);
+        assert_eq!(reloaded.entries.len(), 1);
+        let got = reloaded
+            .get(Path::new("foo.py"), &key)
+            .expect("present with matching key");
+        assert_eq!(*got, data);
+    }
+
+    #[test]
+    fn mismatched_key_misses() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cache.json");
+        let mut cache = DiskCache::load(path);
+        let key = FileKey {
+            mtime_nanos: 1,
+            size: 1,
+        };
+        cache.insert(PathBuf::from("foo.py"), key, DiscoveredFile::default());
+        let wrong_key = FileKey {
+            mtime_nanos: 2,
+            size: 1,
+        };
+        assert!(cache.get(Path::new("foo.py"), &wrong_key).is_none());
+    }
+
+    #[test]
+    fn corrupted_file_loads_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cache.json");
+        fs::write(&path, b"not json").expect("write");
+        let cache = DiskCache::load(path);
+        assert_eq!(cache.entries.len(), 0);
+    }
+
+    #[test]
+    fn retain_drops_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cache.json");
+        let mut cache = DiskCache::load(path);
+        cache.insert(
+            PathBuf::from("a.py"),
+            FileKey {
+                mtime_nanos: 1,
+                size: 1,
+            },
+            DiscoveredFile::default(),
+        );
+        cache.insert(
+            PathBuf::from("b.py"),
+            FileKey {
+                mtime_nanos: 1,
+                size: 1,
+            },
+            DiscoveredFile::default(),
+        );
+        let mut keep = std::collections::HashSet::new();
+        keep.insert(PathBuf::from("a.py"));
+        cache.retain(&keep);
+        assert!(
+            cache
+                .get(
+                    Path::new("a.py"),
+                    &FileKey {
+                        mtime_nanos: 1,
+                        size: 1
+                    }
+                )
+                .is_some()
+        );
+        assert!(
+            cache
+                .get(
+                    Path::new("b.py"),
+                    &FileKey {
+                        mtime_nanos: 1,
+                        size: 1
+                    }
+                )
+                .is_none()
+        );
+    }
+}

--- a/crates/tryke_discovery/src/db.rs
+++ b/crates/tryke_discovery/src/db.rs
@@ -15,15 +15,47 @@ pub struct SourceFile {
     pub path: PathBuf,
 }
 
+/// Everything derivable from a single parse of a Python source file:
+/// the `ParsedFile` (tests, hooks, guard-else lines, errors), the
+/// candidate import paths this file references, and the dynamic-import
+/// flag. Produced in one AST walk so callers never parse the file
+/// twice. `import_candidates` holds first-wins alternatives that the
+/// discoverer resolves against the project's enumerated file set,
+/// avoiding per-import `stat()` syscalls.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct DiscoveredFile {
+    pub parsed: ParsedFile,
+    pub import_candidates: Vec<Vec<PathBuf>>,
+    pub dynamic_imports: bool,
+}
+
 #[salsa::tracked]
-pub fn parse_tests(db: &dyn Db, file: SourceFile) -> ParsedFile {
-    crate::parse_tests_from_source(file.root(db), file.path(db), file.text(db))
+pub fn discover_file(db: &dyn Db, file: SourceFile) -> DiscoveredFile {
+    crate::discover_file_from_source(file.root(db), file.path(db), file.text(db))
 }
 
 #[salsa::db]
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Database {
     storage: salsa::Storage<Self>,
+}
+
+impl Database {
+    /// Produce a `Sync` snapshot handle that can be sent across threads and
+    /// used to build per-thread `Database` instances via [`from_handle`].
+    /// Cloning the handle is cheap (Arc bump); each `from_handle` yields a
+    /// fresh per-thread salsa local, sharing the same memo tables.
+    #[must_use]
+    pub fn storage_handle(&self) -> salsa::StorageHandle<Self> {
+        self.storage.clone().into_zalsa_handle()
+    }
+
+    #[must_use]
+    pub fn from_handle(handle: salsa::StorageHandle<Self>) -> Self {
+        Self {
+            storage: handle.into_storage(),
+        }
+    }
 }
 
 impl salsa::Database for Database {}

--- a/crates/tryke_discovery/src/discoverer.rs
+++ b/crates/tryke_discovery/src/discoverer.rs
@@ -3,13 +3,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use log::{debug, trace};
-use ruff_python_parser::parse_module;
+use log::{debug, trace, warn};
+use rayon::prelude::*;
 use salsa::Setter;
 use tryke_types::{HookItem, TestItem};
 
 use crate::{
-    db::{Database, SourceFile, parse_tests},
+    cache::{DiskCache, FileKey},
+    db::{Database, DiscoveredFile, SourceFile, discover_file},
     import_graph::{GraphEntry, ImportGraph},
 };
 
@@ -19,6 +20,41 @@ pub struct Discoverer {
     root: PathBuf,
     import_graph: ImportGraph,
     excludes: Vec<String>,
+    /// Set of all project-local python files known to the discoverer.
+    /// Populated by the most recent `rediscover` and updated by
+    /// `rediscover_changed` so import candidates can be resolved via
+    /// `HashSet` membership instead of per-import `stat()` syscalls.
+    project_files: HashSet<PathBuf>,
+    /// Authoritative store of per-file discovery results. Populated by
+    /// the most recent `rediscover` / `rediscover_changed` from either
+    /// a disk-cache hit or a salsa parse. Reader methods (`tests`,
+    /// `hooks`, `testing_guard_else_locations`) read from here so
+    /// cached files are visible without a salsa parse.
+    results: HashMap<PathBuf, DiscoveredFile>,
+    /// Persistent mtime/size-keyed cache of `DiscoveredFile` results,
+    /// loaded at construction and saved after each `rediscover`.
+    cache: DiskCache,
+    /// The `FileKey` (mtime + size) observed during the most recent
+    /// stat of each enumerated file. Used to decide which entries to
+    /// persist back into `cache` after parsing.
+    cache_keys_hit: HashMap<PathBuf, FileKey>,
+}
+
+/// Result of the parallel stat-and-maybe-read phase of `rediscover`.
+enum FileWork {
+    Hit {
+        path: PathBuf,
+        data: DiscoveredFile,
+        key: FileKey,
+    },
+    Miss {
+        path: PathBuf,
+        source: String,
+        key: FileKey,
+    },
+    StatError {
+        path: PathBuf,
+    },
 }
 
 impl Discoverer {
@@ -32,12 +68,18 @@ impl Discoverer {
     pub fn new_with_excludes(start: &Path, excludes: &[String]) -> Self {
         let root = crate::find_project_root(start).unwrap_or_else(|| start.to_path_buf());
         let root = root.canonicalize().unwrap_or(root);
+        let cache_path = root.join(".tryke").join("cache").join("discovery-v1.bin");
+        let cache = DiskCache::load(cache_path);
         Self {
             db: Database::default(),
             inputs: HashMap::new(),
             root,
             import_graph: ImportGraph::default(),
             excludes: excludes.to_vec(),
+            project_files: HashSet::new(),
+            results: HashMap::new(),
+            cache,
+            cache_keys_hit: HashMap::new(),
         }
     }
 
@@ -49,66 +91,204 @@ impl Discoverer {
             paths.len(),
             self.root.display()
         );
-        for path in &paths {
-            let text = std::fs::read_to_string(path).unwrap_or_default();
-            let (imports, dynamic) = if let Ok(parsed) = parse_module(&text) {
-                let body = &parsed.syntax().body;
-                (
-                    crate::extract_local_imports(&self.root, path, body),
-                    crate::has_dynamic_imports(body),
-                )
-            } else {
-                (vec![], false)
-            };
-            if let Some(file) = self.inputs.get(path) {
-                if file.text(&self.db) != &text {
-                    trace!("rediscover: re-parsing changed file {}", path.display());
-                    file.set_text(&mut self.db).to(text);
-                }
-            } else {
-                trace!("rediscover: parsing new file {}", path.display());
-                let file = SourceFile::new(&self.db, text, self.root.clone(), path.clone());
-                self.inputs.insert(path.clone(), file);
-            }
-            self.import_graph.update(path.clone(), imports);
-            if dynamic {
-                self.import_graph.mark_always_dirty(path.clone());
-            } else {
-                self.import_graph.clear_always_dirty(path);
-            }
-        }
-        let path_set: HashSet<&PathBuf> = paths.iter().collect();
+        let path_set: HashSet<PathBuf> = paths.iter().cloned().collect();
+
+        // Phase 1: in parallel, stat every file and consult the disk
+        // cache. For cache hits we keep the cached `DiscoveredFile`;
+        // for misses we also carry the file text (read opportunistically
+        // during stat) so the parallel parse phase doesn't have to read
+        // it again. The closure captures `&self.cache` only — the
+        // rest of `self` holds a salsa `Database` that isn't `Sync`.
+        let cache_ref = &self.cache;
+        let keyed: Vec<FileWork> = paths
+            .par_iter()
+            .map(|path| Self::prepare_work(cache_ref, path))
+            .collect();
+
+        // Phase 2: drop cache entries for paths we no longer enumerate
+        // (file deleted or newly excluded).
+        self.cache.retain(&path_set);
+
+        // Phase 3: serial ingest of cache hits + upsert misses into
+        // salsa. Salsa mutations require `&mut self.db`, so this runs
+        // single-threaded. The expensive work has already happened.
+        let mut misses: Vec<PathBuf> = Vec::new();
+        let mut hit_count = 0usize;
         let removed: Vec<PathBuf> = self
-            .inputs
+            .results
             .keys()
-            .filter(|p| !path_set.contains(p))
+            .filter(|p| !path_set.contains(*p))
             .cloned()
             .collect();
         for path in removed {
             self.import_graph.remove(&path);
             self.inputs.remove(&path);
+            self.results.remove(&path);
         }
-        let tests: Vec<TestItem> = self
-            .inputs
-            .values()
-            .flat_map(|f| parse_tests(&self.db, *f).tests)
+        for work in keyed {
+            match work {
+                FileWork::Hit { path, data, key } => {
+                    // Hot path: file unchanged since last run. Use the
+                    // cached result directly; no parse, no salsa.
+                    self.results.insert(path.clone(), data);
+                    self.cache_keys_hit
+                        .entry(path)
+                        .and_modify(|k| *k = key)
+                        .or_insert(key);
+                    hit_count += 1;
+                }
+                FileWork::Miss { path, source, key } => {
+                    self.upsert_source(&path, source);
+                    self.cache_keys_hit.insert(path.clone(), key);
+                    misses.push(path);
+                }
+                FileWork::StatError { path } => {
+                    warn!("rediscover: stat failed for {}, skipping", path.display());
+                }
+            }
+        }
+        debug!(
+            "rediscover: cache hits {}/{} ({} parses pending)",
+            hit_count,
+            paths.len(),
+            misses.len()
+        );
+
+        // Phase 4: parallel parse for all misses. Salsa's memo tables
+        // absorb concurrent queries via the cloned `StorageHandle`.
+        let miss_snapshots: Vec<(PathBuf, SourceFile)> = misses
+            .iter()
+            .filter_map(|p| self.inputs.get(p).map(|f| (p.clone(), *f)))
             .collect();
+        let miss_results: Vec<(PathBuf, DiscoveredFile)> = self.parse_in_parallel(&miss_snapshots);
+        for (path, data) in &miss_results {
+            self.results.insert(path.clone(), data.clone());
+            if let Some(&key) = self.cache_keys_hit.get(path) {
+                self.cache.insert(path.clone(), key, data.clone());
+            }
+        }
+
+        // Phase 5: resolve import candidates for every file (hit + miss)
+        // against the enumerated file set, then update the import
+        // graph and collect tests. Resolution is parallel — per-file
+        // work is independent and fast HashSet lookups still accrue.
+        let resolved: Vec<(PathBuf, Vec<PathBuf>, bool, Vec<TestItem>)> = self
+            .results
+            .par_iter()
+            .map(|(path, result)| {
+                let imports =
+                    crate::resolve_import_candidate_groups(&result.import_candidates, &path_set);
+                (
+                    path.clone(),
+                    imports,
+                    result.dynamic_imports,
+                    result.parsed.tests.clone(),
+                )
+            })
+            .collect();
+        let mut tests: Vec<TestItem> = Vec::new();
+        for (path, imports, dynamic, file_tests) in resolved {
+            self.import_graph.update(path.clone(), imports);
+            if dynamic {
+                self.import_graph.mark_always_dirty(path);
+            } else {
+                self.import_graph.clear_always_dirty(&path);
+            }
+            tests.extend(file_tests);
+        }
+        self.project_files = path_set;
+
+        // Phase 6: persist the cache. Save errors are logged but not
+        // propagated — a stale cache is annoying, but a failed save
+        // shouldn't fail discovery.
+        if let Err(err) = self.cache.save() {
+            warn!("rediscover: failed to save discovery cache: {err}");
+        }
+
         debug!("rediscover: discovered {} tests total", tests.len());
         tests
     }
 
+    /// Stat `path` and consult the disk cache. On a cache hit, return
+    /// the cached `DiscoveredFile` without reading the file. On a
+    /// miss, read the file text so the parse phase doesn't stat-then-
+    /// read (halving the syscalls per miss).
+    ///
+    /// Takes `&DiskCache` rather than `&self` so rayon workers can
+    /// share it across threads — `Discoverer` holds a salsa
+    /// `Database` that isn't `Sync`.
+    fn prepare_work(cache: &DiskCache, path: &Path) -> FileWork {
+        let Ok(metadata) = std::fs::metadata(path) else {
+            return FileWork::StatError {
+                path: path.to_path_buf(),
+            };
+        };
+        let Ok(key) = FileKey::from_metadata(&metadata) else {
+            return FileWork::StatError {
+                path: path.to_path_buf(),
+            };
+        };
+        if let Some(data) = cache.get(path, &key) {
+            FileWork::Hit {
+                path: path.to_path_buf(),
+                data: data.clone(),
+                key,
+            }
+        } else {
+            let source = std::fs::read_to_string(path).unwrap_or_default();
+            FileWork::Miss {
+                path: path.to_path_buf(),
+                source,
+                key,
+            }
+        }
+    }
+
+    /// Run `discover_file` across many salsa `SourceFile` inputs in parallel.
+    /// Each rayon worker materialises its own `Database` from a `Sync`
+    /// `StorageHandle`; the underlying salsa memo tables are shared via Arc,
+    /// so parses populate one cache.
+    fn parse_in_parallel(
+        &self,
+        snapshots: &[(PathBuf, SourceFile)],
+    ) -> Vec<(PathBuf, DiscoveredFile)> {
+        let handle = self.db.storage_handle();
+        snapshots
+            .par_iter()
+            .map_init(
+                || Database::from_handle(handle.clone()),
+                |db, (path, file)| (path.clone(), discover_file(db, *file)),
+            )
+            .collect()
+    }
+
+    /// Upsert the salsa input for `path` with the given text: either create
+    /// a new `SourceFile` or call `set_text` on the existing one if changed.
+    fn upsert_source(&mut self, path: &Path, text: String) {
+        if let Some(file) = self.inputs.get(path) {
+            if file.text(&self.db) != &text {
+                trace!("rediscover: re-parsing changed file {}", path.display());
+                file.set_text(&mut self.db).to(text);
+            }
+        } else {
+            trace!("rediscover: parsing new file {}", path.display());
+            let file = SourceFile::new(&self.db, text, self.root.clone(), path.to_path_buf());
+            self.inputs.insert(path.to_path_buf(), file);
+        }
+    }
+
     pub fn tests(&self) -> Vec<TestItem> {
-        self.inputs
+        self.results
             .values()
-            .flat_map(|f| parse_tests(&self.db, *f).tests)
+            .flat_map(|r| r.parsed.tests.clone())
             .collect()
     }
 
     /// Returns all hooks discovered across all known files.
     pub fn hooks(&self) -> Vec<HookItem> {
-        self.inputs
+        self.results
             .values()
-            .flat_map(|f| parse_tests(&self.db, *f).hooks)
+            .flat_map(|r| r.parsed.hooks.clone())
             .collect()
     }
 
@@ -118,38 +298,14 @@ impl Discoverer {
             "rediscover_changed: processing {} changed paths",
             changed.len()
         );
+        let mut touched: Vec<PathBuf> = Vec::new();
         for path in &changed {
             if path.extension().is_some_and(|ext| ext == "py") {
                 if path.exists() {
                     let text = std::fs::read_to_string(path).unwrap_or_default();
-                    let (imports, dynamic) = if let Ok(parsed) = parse_module(&text) {
-                        let body = &parsed.syntax().body;
-                        (
-                            crate::extract_local_imports(&self.root, path, body),
-                            crate::has_dynamic_imports(body),
-                        )
-                    } else {
-                        (vec![], false)
-                    };
-                    if let Some(file) = self.inputs.get(path) {
-                        if file.text(&self.db) != &text {
-                            trace!(
-                                "rediscover_changed: re-parsing changed file {}",
-                                path.display()
-                            );
-                            file.set_text(&mut self.db).to(text);
-                        }
-                    } else {
-                        trace!("rediscover_changed: parsing new file {}", path.display());
-                        let file = SourceFile::new(&self.db, text, self.root.clone(), path.clone());
-                        self.inputs.insert(path.clone(), file);
-                    }
-                    self.import_graph.update(path.clone(), imports);
-                    if dynamic {
-                        self.import_graph.mark_always_dirty(path.clone());
-                    } else {
-                        self.import_graph.clear_always_dirty(path);
-                    }
+                    self.upsert_source(path, text);
+                    self.project_files.insert(path.clone());
+                    touched.push(path.clone());
                 } else {
                     trace!(
                         "rediscover_changed: removing deleted file {}",
@@ -157,13 +313,40 @@ impl Discoverer {
                     );
                     self.import_graph.remove(path);
                     self.inputs.remove(path);
+                    self.project_files.remove(path);
+                    self.results.remove(path);
+                    self.cache.remove(path);
                 }
             }
         }
+        for path in &touched {
+            if let Some(file) = self.inputs.get(path).copied() {
+                let result = discover_file(&self.db, file);
+                let imports = crate::resolve_import_candidate_groups(
+                    &result.import_candidates,
+                    &self.project_files,
+                );
+                self.import_graph.update(path.clone(), imports);
+                if result.dynamic_imports {
+                    self.import_graph.mark_always_dirty(path.clone());
+                } else {
+                    self.import_graph.clear_always_dirty(path);
+                }
+                // Update both the in-memory result set and the disk
+                // cache so the new parse sticks for this file.
+                if let Ok(key) = FileKey::from_path(path) {
+                    self.cache.insert(path.clone(), key, result.clone());
+                }
+                self.results.insert(path.clone(), result);
+            }
+        }
+        if let Err(err) = self.cache.save() {
+            warn!("rediscover_changed: failed to save discovery cache: {err}");
+        }
         let tests: Vec<TestItem> = self
-            .inputs
+            .results
             .values()
-            .flat_map(|f| parse_tests(&self.db, *f).tests)
+            .flat_map(|r| r.parsed.tests.clone())
             .collect();
         debug!("rediscover_changed: {} tests after update", tests.len());
         tests
@@ -248,21 +431,20 @@ impl Discoverer {
     /// guards; the caller surfaces them as warnings so users don't debug
     /// missing tests from an unsupported guard shape.
     pub fn testing_guard_else_locations(&self) -> Vec<(PathBuf, u32)> {
-        let mut results: Vec<(PathBuf, u32)> = Vec::new();
-        for (path, file) in &self.inputs {
-            let parsed = parse_tests(&self.db, *file);
-            for line in &parsed.testing_guard_else_lines {
-                results.push((path.clone(), *line));
+        let mut lines: Vec<(PathBuf, u32)> = Vec::new();
+        for (path, result) in &self.results {
+            for line in &result.parsed.testing_guard_else_lines {
+                lines.push((path.clone(), *line));
             }
         }
-        results.sort();
-        results
+        lines.sort();
+        lines
     }
 
     /// Returns a sorted summary of the import graph for all known files.
     pub fn import_graph_summary(&self) -> Vec<GraphEntry> {
         let mut entries: Vec<GraphEntry> = self
-            .inputs
+            .results
             .keys()
             .map(|file| {
                 let imports = self

--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -7,6 +7,7 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use log::trace;
 use rayon::prelude::*;
 
+pub(crate) mod cache;
 pub(crate) mod db;
 mod discoverer;
 pub(crate) mod import_graph;
@@ -62,79 +63,109 @@ pub(crate) fn path_to_module(root: &Path, file: &Path) -> String {
     tryke_types::path_to_module(root, file).unwrap_or_default()
 }
 
-/// Resolve `module_name` (e.g. "foo.bar") as a local file under `root`.
-/// Tries `root/foo/bar.py` then `root/foo/bar/__init__.py`.
-fn resolve_absolute_import(root: &Path, module_name: &str) -> Option<PathBuf> {
+/// The two paths a Python importer would try, in order, for a dotted
+/// absolute import `root/foo/bar`: `root/foo/bar.py` first, then
+/// `root/foo/bar/__init__.py`. Returns whichever candidates start with
+/// `root` (the rest are stripped because we'd never resolve them to a
+/// project-local file anyway).
+///
+/// No filesystem access — the caller decides which candidate, if any,
+/// actually exists. See `resolve_import_candidate_groups`.
+fn candidate_absolute_import_paths(root: &Path, module_name: &str) -> Vec<PathBuf> {
     let mut path = root.to_path_buf();
     for part in module_name.split('.') {
         path = path.join(part);
     }
     let py = path.with_extension("py");
-    if py.starts_with(root) && py.exists() {
-        return Some(py);
-    }
     let init = path.join("__init__.py");
-    if init.starts_with(root) && init.exists() {
-        return Some(init);
-    }
-    None
+    [py, init]
+        .into_iter()
+        .filter(|p| p.starts_with(root))
+        .collect()
 }
 
-/// Resolve a module path from `base` directory.
-/// If `module_name` is empty, tries `base/__init__.py`.
-fn resolve_relative_import_path(root: &Path, base: &Path, module_name: &str) -> Option<PathBuf> {
+/// Candidates for a relative import (`from .foo import bar`) walked up
+/// `level-1` directories from `file`'s parent. Mirrors the old
+/// `resolve_relative_import_path` two-candidate behaviour without any
+/// filesystem access.
+fn candidate_relative_import_paths(root: &Path, base: &Path, module_name: &str) -> Vec<PathBuf> {
     if module_name.is_empty() {
         let init = base.join("__init__.py");
-        if init.starts_with(root) && init.exists() {
-            return Some(init);
-        }
-        return None;
+        return if init.starts_with(root) {
+            vec![init]
+        } else {
+            Vec::new()
+        };
     }
     let mut path = base.to_path_buf();
     for part in module_name.split('.') {
         path = path.join(part);
     }
     let py = path.with_extension("py");
-    if py.starts_with(root) && py.exists() {
-        return Some(py);
-    }
     let init = path.join("__init__.py");
-    if init.starts_with(root) && init.exists() {
-        return Some(init);
-    }
-    None
+    [py, init]
+        .into_iter()
+        .filter(|p| p.starts_with(root))
+        .collect()
 }
 
-/// Extract local file imports from a pre-parsed Python module body.
-/// Returns absolute paths of project-local files that this file imports.
-pub(crate) fn extract_local_imports(root: &Path, file: &Path, body: &[Stmt]) -> Vec<PathBuf> {
+/// A first-wins group of candidate import paths: the project-local file
+/// is whichever candidate in the group exists first, per Python's
+/// import semantics (plain `.py` before the package `__init__.py`). The
+/// outer caller resolves against a `HashSet` of enumerated project files.
+pub(crate) type ImportCandidateGroup = Vec<PathBuf>;
+
+/// Resolve candidate groups against a `HashSet` of project-local files,
+/// preserving insertion order and deduplicating across groups. Picks the
+/// first existing candidate within each group, matching the old
+/// `resolve_absolute_import` / `resolve_relative_import_path` contract.
+pub(crate) fn resolve_import_candidate_groups(
+    groups: &[ImportCandidateGroup],
+    project_files: &std::collections::HashSet<PathBuf>,
+) -> Vec<PathBuf> {
     let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
-    let mut result: Vec<PathBuf> = Vec::new();
-    collect_local_imports(root, file, body, &mut seen, &mut result);
-    result
+    let mut out: Vec<PathBuf> = Vec::new();
+    for group in groups {
+        for candidate in group {
+            if project_files.contains(candidate) {
+                if seen.insert(candidate.clone()) {
+                    out.push(candidate.clone());
+                }
+                break;
+            }
+        }
+    }
+    out
 }
 
-fn collect_local_imports(
+/// Extract candidate import groups from a parsed Python module body.
+/// Each group is a first-wins alternatives list; the caller resolves
+/// each group against the project file set via
+/// `resolve_import_candidate_groups`. No filesystem access.
+pub(crate) fn extract_local_import_candidate_groups(
     root: &Path,
     file: &Path,
     body: &[Stmt],
-    seen: &mut std::collections::HashSet<PathBuf>,
-    result: &mut Vec<PathBuf>,
-) {
-    let add =
-        |p: PathBuf, seen: &mut std::collections::HashSet<PathBuf>, result: &mut Vec<PathBuf>| {
-            if seen.insert(p.clone()) {
-                result.push(p);
-            }
-        };
+) -> Vec<ImportCandidateGroup> {
+    let mut groups: Vec<ImportCandidateGroup> = Vec::new();
+    collect_local_import_candidate_groups(root, file, body, &mut groups);
+    groups
+}
 
+fn collect_local_import_candidate_groups(
+    root: &Path,
+    file: &Path,
+    body: &[Stmt],
+    groups: &mut Vec<ImportCandidateGroup>,
+) {
     for stmt in body {
         match stmt {
             Stmt::Import(import_stmt) => {
                 for alias in &import_stmt.names {
                     let module_name = alias.name.id.as_str();
-                    if let Some(path) = resolve_absolute_import(root, module_name) {
-                        add(path, seen, result);
+                    let candidates = candidate_absolute_import_paths(root, module_name);
+                    if !candidates.is_empty() {
+                        groups.push(candidates);
                     }
                 }
             }
@@ -144,14 +175,16 @@ fn collect_local_imports(
                     // Absolute: from foo.bar import x
                     if let Some(module) = &from_stmt.module {
                         let module_name = module.id.as_str();
-                        if let Some(path) = resolve_absolute_import(root, module_name) {
-                            add(path, seen, result);
+                        let candidates = candidate_absolute_import_paths(root, module_name);
+                        if !candidates.is_empty() {
+                            groups.push(candidates);
                         }
                         for alias in &from_stmt.names {
                             let imported = alias.name.id.as_str();
                             let submodule = format!("{module_name}.{imported}");
-                            if let Some(path) = resolve_absolute_import(root, &submodule) {
-                                add(path, seen, result);
+                            let candidates = candidate_absolute_import_paths(root, &submodule);
+                            if !candidates.is_empty() {
+                                groups.push(candidates);
                             }
                         }
                     }
@@ -164,18 +197,18 @@ fn collect_local_imports(
                     if let Some(base) = base {
                         if let Some(module) = &from_stmt.module {
                             // from .utils import x → resolve "utils" from base
-                            if let Some(path) =
-                                resolve_relative_import_path(root, &base, module.id.as_str())
-                            {
-                                add(path, seen, result);
+                            let candidates =
+                                candidate_relative_import_paths(root, &base, module.id.as_str());
+                            if !candidates.is_empty() {
+                                groups.push(candidates);
                             }
                         } else {
                             // from . import x, y → try each name as a submodule
                             for alias in &from_stmt.names {
                                 let name = alias.name.id.as_str();
-                                if let Some(path) = resolve_relative_import_path(root, &base, name)
-                                {
-                                    add(path, seen, result);
+                                let candidates = candidate_relative_import_paths(root, &base, name);
+                                if !candidates.is_empty() {
+                                    groups.push(candidates);
                                 }
                             }
                         }
@@ -187,11 +220,35 @@ fn collect_local_imports(
                 // static import graph so `--changed` mode can precisely
                 // re-run in-source tests when their dependencies change.
                 if let Some(inner) = testing_guard_body(stmt) {
-                    collect_local_imports(root, file, inner, seen, result);
+                    collect_local_import_candidate_groups(root, file, inner, groups);
                 }
             }
         }
     }
+}
+
+/// Extract local file imports from a pre-parsed Python module body.
+/// Returns absolute paths of project-local files that this file imports,
+/// filtering candidates by on-disk existence. Kept for test
+/// compatibility — production discovery uses
+/// `extract_local_import_candidate_groups` plus
+/// `resolve_import_candidate_groups` to avoid per-import syscalls.
+#[cfg(test)]
+pub(crate) fn extract_local_imports(root: &Path, file: &Path, body: &[Stmt]) -> Vec<PathBuf> {
+    let groups = extract_local_import_candidate_groups(root, file, body);
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    let mut out: Vec<PathBuf> = Vec::new();
+    for group in &groups {
+        for candidate in group {
+            if candidate.exists() {
+                if seen.insert(candidate.clone()) {
+                    out.push(candidate.clone());
+                }
+                break;
+            }
+        }
+    }
+    out
 }
 
 fn is_locally_defined(name: &str, body: &[Stmt]) -> bool {
@@ -1440,14 +1497,23 @@ fn collect_doctests_from_body(
     }
 }
 
-pub(crate) fn parse_tests_from_source(root: &Path, file: &Path, source: &str) -> ParsedFile {
+/// Parse `source` once and produce everything discovery needs: the
+/// `ParsedFile` (tests, hooks, guard-else lines, errors), the project-local
+/// imports this file depends on, and whether it contains dynamic imports.
+/// Folding all three derivations into a single AST walk avoids the prior
+/// cold-start cost of parsing each file twice.
+pub(crate) fn discover_file_from_source(
+    root: &Path,
+    file: &Path,
+    source: &str,
+) -> crate::db::DiscoveredFile {
     trace!(
         "parsing {}",
         file.strip_prefix(root).unwrap_or(file).display()
     );
     let Ok(parsed) = parse_module(source) else {
         trace!("parse error in {}", file.display());
-        return ParsedFile::default();
+        return crate::db::DiscoveredFile::default();
     };
     let line_index = LineIndex::from_source_text(source);
     let module = parsed.syntax();
@@ -1471,15 +1537,25 @@ pub(crate) fn parse_tests_from_source(root: &Path, file: &Path, source: &str) ->
     );
     collect_doctests_from_body(body, root, file, &line_index, "", &mut tests);
     let testing_guard_else_lines = find_testing_guard_else_lines(body, &line_index);
+    let import_candidates = extract_local_import_candidate_groups(root, file, body);
+    let dynamic_imports = has_dynamic_imports(body);
     for err in &errors {
         log::error!("tryke discovery: {err}");
     }
-    ParsedFile {
-        tests,
-        hooks,
-        testing_guard_else_lines,
-        errors,
+    crate::db::DiscoveredFile {
+        parsed: ParsedFile {
+            tests,
+            hooks,
+            testing_guard_else_lines,
+            errors,
+        },
+        import_candidates,
+        dynamic_imports,
     }
+}
+
+pub(crate) fn parse_tests_from_source(root: &Path, file: &Path, source: &str) -> ParsedFile {
+    discover_file_from_source(root, file, source).parsed
 }
 
 fn parse_tests_from_file(root: &Path, file: &Path) -> ParsedFile {

--- a/crates/tryke_server/src/client.rs
+++ b/crates/tryke_server/src/client.rs
@@ -1,14 +1,22 @@
 use std::{
-    io::{BufRead, BufReader, Write},
+    io::{BufRead, BufReader, ErrorKind, Write},
     net::TcpStream,
     path::Path,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use tryke_reporter::Reporter;
 use tryke_types::{RunSummary, TestItem, TestResult};
 
 const RPC_REQUEST_ID: i64 = 1;
+
+/// Max time we keep reading notifications after the RPC response arrives,
+/// waiting for the matching `run_complete`. The notification writer task and
+/// the RPC response writer race for the connection's write lock, so late
+/// `test_complete` / `run_complete` messages can arrive after the response.
+/// If `run_complete` never shows up (e.g. broadcast channel lagged), the
+/// drain simply terminates with the summary from the RPC response.
+const POST_RESPONSE_DRAIN: Duration = Duration::from_secs(2);
 
 pub struct Client {
     port: u16,
@@ -57,76 +65,102 @@ impl Client {
         writer.write_all(b"\n")?;
         writer.flush()?;
 
-        let mut line = String::new();
-        let mut summary: Option<RunSummary> = None;
-        loop {
-            line.clear();
-            if reader.read_line(&mut line)? == 0 {
-                break;
-            }
-            let val: serde_json::Value = match serde_json::from_str(line.trim()) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
+        let summary = read_until_summary(&mut reader, &run_id, reporter)?;
+        reporter.on_run_complete(&summary);
+        if summary.failed > 0 || summary.errors > 0 {
+            return Err(anyhow::anyhow!(
+                "{} failed, {} error(s)",
+                summary.failed,
+                summary.errors
+            ));
+        }
+        Ok(())
+    }
+}
 
-            // Our RPC response: authoritative signal that the run is done.
-            // Detected by matching our request id — the server cannot lose
-            // this the way it can silently drop broadcast notifications under
-            // `Lagged`, so we break on the response rather than on the
-            // `run_complete` notification.
-            if val.get("method").is_none()
-                && val["id"].as_i64() == Some(RPC_REQUEST_ID)
-                && let Ok(s) =
-                    serde_json::from_value::<RunSummary>(val["result"]["summary"].clone())
+/// Read newline-delimited messages until we have the authoritative summary
+/// from the RPC response, then keep draining notifications for our `run_id`
+/// until `run_complete` arrives or `POST_RESPONSE_DRAIN` elapses. The drain
+/// phase exists because the server writes the response and the broadcast
+/// notifications from separate tasks, so late notifications can land on the
+/// socket after the response.
+fn read_until_summary(
+    reader: &mut BufReader<TcpStream>,
+    run_id: &str,
+    reporter: &mut dyn Reporter,
+) -> anyhow::Result<RunSummary> {
+    let mut line = String::new();
+    let mut summary: Option<RunSummary> = None;
+    let mut draining = false;
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(e)
+                if draining && matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) =>
             {
-                summary = Some(s);
                 break;
             }
+            Err(e) => return Err(e.into()),
+        }
+        let val: serde_json::Value = match serde_json::from_str(line.trim()) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
 
-            // Notifications for runs we didn't initiate arrive on the same
-            // broadcast channel (e.g. another client's run, or a watcher
-            // rediscovery). Filter them out so the reporter only sees this
-            // client's events.
-            let notif_run_id = val["params"]["run_id"].as_str();
-            if notif_run_id.is_some() && notif_run_id != Some(run_id.as_str()) {
-                continue;
+        if val.get("method").is_none() && val["id"].as_i64() == Some(RPC_REQUEST_ID) {
+            if let Some(err) = val.get("error") {
+                let code = err["code"].as_i64().unwrap_or(0);
+                let message = err["message"].as_str().unwrap_or("<missing>");
+                return Err(anyhow::anyhow!("server error {code}: {message}"));
             }
-
-            match val["method"].as_str() {
-                Some("run_start") => {
-                    if let Ok(tests) =
-                        serde_json::from_value::<Vec<TestItem>>(val["params"]["tests"].clone())
-                    {
-                        reporter.on_run_start(&tests);
-                    }
-                }
-                Some("test_complete") => {
-                    if let Ok(result) =
-                        serde_json::from_value::<TestResult>(val["params"]["result"].clone())
-                    {
-                        reporter.on_test_complete(&result);
-                    }
-                }
-                _ => {}
-            }
+            let Ok(s) = serde_json::from_value::<RunSummary>(val["result"]["summary"].clone())
+            else {
+                return Err(anyhow::anyhow!(
+                    "server returned a response with no summary for our run"
+                ));
+            };
+            summary = Some(s);
+            reader
+                .get_ref()
+                .set_read_timeout(Some(POST_RESPONSE_DRAIN))
+                .ok();
+            draining = true;
+            continue;
         }
 
-        if let Some(s) = summary {
-            reporter.on_run_complete(&s);
-            if s.failed > 0 || s.errors > 0 {
-                return Err(anyhow::anyhow!(
-                    "{} failed, {} error(s)",
-                    s.failed,
-                    s.errors
-                ));
+        // Notifications for runs we didn't initiate arrive on the same
+        // broadcast channel (e.g. another client's run, or a watcher
+        // rediscovery). Filter them so the reporter only sees our events.
+        let notif_run_id = val["params"]["run_id"].as_str();
+        if notif_run_id.is_some() && notif_run_id != Some(run_id) {
+            continue;
+        }
+
+        match val["method"].as_str() {
+            Some("run_start") => {
+                if let Ok(tests) =
+                    serde_json::from_value::<Vec<TestItem>>(val["params"]["tests"].clone())
+                {
+                    reporter.on_run_start(&tests);
+                }
             }
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(
-                "server closed connection before returning a run summary"
-            ))
+            Some("test_complete") => {
+                if let Ok(result) =
+                    serde_json::from_value::<TestResult>(val["params"]["result"].clone())
+                {
+                    reporter.on_test_complete(&result);
+                }
+            }
+            Some("run_complete") if draining => break,
+            _ => {}
         }
     }
+
+    summary
+        .ok_or_else(|| anyhow::anyhow!("server closed connection before returning a run summary"))
 }
 
 fn generate_run_id() -> String {
@@ -216,15 +250,34 @@ mod tests {
             .to_string()
     }
 
+    fn run_complete_notif() -> String {
+        format!(
+            r#"{{"jsonrpc":"2.0","method":"run_complete","params":{{"run_id":"{{RID}}","summary":{EMPTY_SUMMARY}}}}}"#
+        )
+    }
+
     fn rpc_response() -> String {
         format!(
             r#"{{"jsonrpc":"2.0","id":1,"result":{{"run_id":"{{RID}}","summary":{EMPTY_SUMMARY}}}}}"#
         )
     }
 
+    fn rpc_error_response(code: i32, message: &str) -> String {
+        format!(r#"{{"jsonrpc":"2.0","id":1,"error":{{"code":{code},"message":"{message}"}}}}"#)
+    }
+
+    fn test_complete_for(run_id: &str, name: &str) -> String {
+        format!(
+            r#"{{"jsonrpc":"2.0","method":"test_complete","params":{{"run_id":"{run_id}","result":{{"test":{{"name":"{name}","module_path":"x","file_path":null,"line_number":null,"display_name":null,"expected_assertions":[]}},"outcome":{{"status":"passed"}},"duration":{{"secs":0,"nanos":0}},"stdout":"","stderr":""}}}}}}"#
+        )
+    }
+
     #[test]
     fn client_dispatches_reporter_events() {
-        let port = start_mock_server(vec![run_start_notif(), rpc_response()], true);
+        let port = start_mock_server(
+            vec![run_start_notif(), rpc_response(), run_complete_notif()],
+            true,
+        );
 
         let dir = tempfile::tempdir().unwrap();
         let mut reporter = RecordingReporter::new();
@@ -252,15 +305,14 @@ mod tests {
         // Emit notifications tagged with a different run_id before our own
         // run_start+response. The reporter must not see any of them.
         let foreign_run_start = r#"{"jsonrpc":"2.0","method":"run_start","params":{"run_id":"other","tests":[{"name":"foreign","module_path":"x"}]}}"#;
-        let foreign_test_complete =
-            r#"{"jsonrpc":"2.0","method":"test_complete","params":{"run_id":"other","result":{"test":{"name":"foreign","module_path":"x"},"outcome":"Passed","duration":{"secs":0,"nanos":0},"stdout":"","stderr":""}}}"#
-                .to_string();
+        let foreign_test_complete = test_complete_for("other", "foreign");
         let port = start_mock_server(
             vec![
                 foreign_run_start.to_string(),
                 foreign_test_complete,
                 run_start_notif(),
                 rpc_response(),
+                run_complete_notif(),
             ],
             true,
         );
@@ -283,11 +335,21 @@ mod tests {
     }
 
     #[test]
-    fn client_breaks_on_rpc_response_even_without_run_complete() {
-        // The server no longer depends on `run_complete` for termination.
-        // If the broadcast channel lags and the run_complete notification is
-        // dropped, the RPC response is still the authoritative terminator.
-        let port = start_mock_server(vec![run_start_notif(), rpc_response()], true);
+    fn client_dispatches_notifications_that_arrive_after_rpc_response() {
+        // The server writes the RPC response and the broadcast notifications
+        // from different tasks, so a `test_complete` or `run_complete` can
+        // land on the socket after the response. The client must keep
+        // draining notifications (until run_complete or a short timeout) so
+        // the reporter sees the full event stream.
+        let port = start_mock_server(
+            vec![
+                run_start_notif(),
+                rpc_response(),
+                test_complete_for("{RID}", "late_test"),
+                run_complete_notif(),
+            ],
+            true,
+        );
 
         let dir = tempfile::tempdir().unwrap();
         let mut reporter = RecordingReporter::new();
@@ -295,7 +357,50 @@ mod tests {
             .run(dir.path(), &mut reporter)
             .unwrap();
 
+        assert_eq!(
+            reporter.results.len(),
+            1,
+            "late test_complete must reach the reporter via the drain phase"
+        );
         assert!(reporter.summary.is_some());
+    }
+
+    #[test]
+    fn client_breaks_on_rpc_response_even_without_run_complete() {
+        // When `run_complete` is lost to broadcast lag the client must still
+        // terminate (via the drain timeout) and report the summary from the
+        // authoritative RPC response.
+        let port = start_mock_server(vec![run_start_notif(), rpc_response()], true);
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut reporter = RecordingReporter::new();
+        let start = std::time::Instant::now();
+        Client::new(port, None, vec![], None)
+            .run(dir.path(), &mut reporter)
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(reporter.summary.is_some());
+        assert!(
+            elapsed < POST_RESPONSE_DRAIN + Duration::from_secs(1),
+            "drain took too long: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn client_surfaces_rpc_error_response() {
+        // If the server rejects our request (e.g. missing run_id, though
+        // the CLI client always sends one), the error response must turn
+        // into an Err instead of hanging the reader.
+        let port = start_mock_server(vec![rpc_error_response(-32602, "bad params")], false);
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut reporter = RecordingReporter::new();
+        let result = Client::new(port, None, vec![], None).run(dir.path(), &mut reporter);
+        let err = result.expect_err("expected Err");
+        let msg = err.to_string();
+        assert!(msg.contains("-32602"), "missing code in: {msg}");
+        assert!(msg.contains("bad params"), "missing message in: {msg}");
     }
 
     #[test]

--- a/crates/tryke_server/src/client.rs
+++ b/crates/tryke_server/src/client.rs
@@ -2,10 +2,13 @@ use std::{
     io::{BufRead, BufReader, Write},
     net::TcpStream,
     path::Path,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use tryke_reporter::Reporter;
 use tryke_types::{RunSummary, TestItem, TestResult};
+
+const RPC_REQUEST_ID: i64 = 1;
 
 pub struct Client {
     port: u16,
@@ -37,17 +40,25 @@ impl Client {
         let mut writer = stream.try_clone()?;
         let mut reader = BufReader::new(stream);
 
+        let run_id = generate_run_id();
         let req = serde_json::json!({
             "jsonrpc": "2.0",
-            "id": 1,
+            "id": RPC_REQUEST_ID,
             "method": "run",
-            "params": { "root": root, "filter": self.filter, "paths": self.paths, "markers": self.markers }
+            "params": {
+                "root": root,
+                "filter": self.filter,
+                "paths": self.paths,
+                "markers": self.markers,
+                "run_id": run_id,
+            }
         });
         writer.write_all(serde_json::to_vec(&req)?.as_slice())?;
         writer.write_all(b"\n")?;
         writer.flush()?;
 
         let mut line = String::new();
+        let mut summary: Option<RunSummary> = None;
         loop {
             line.clear();
             if reader.read_line(&mut line)? == 0 {
@@ -57,6 +68,30 @@ impl Client {
                 Ok(v) => v,
                 Err(_) => continue,
             };
+
+            // Our RPC response: authoritative signal that the run is done.
+            // Detected by matching our request id — the server cannot lose
+            // this the way it can silently drop broadcast notifications under
+            // `Lagged`, so we break on the response rather than on the
+            // `run_complete` notification.
+            if val.get("method").is_none()
+                && val["id"].as_i64() == Some(RPC_REQUEST_ID)
+                && let Ok(s) =
+                    serde_json::from_value::<RunSummary>(val["result"]["summary"].clone())
+            {
+                summary = Some(s);
+                break;
+            }
+
+            // Notifications for runs we didn't initiate arrive on the same
+            // broadcast channel (e.g. another client's run, or a watcher
+            // rediscovery). Filter them out so the reporter only sees this
+            // client's events.
+            let notif_run_id = val["params"]["run_id"].as_str();
+            if notif_run_id.is_some() && notif_run_id != Some(run_id.as_str()) {
+                continue;
+            }
+
             match val["method"].as_str() {
                 Some("run_start") => {
                     if let Ok(tests) =
@@ -72,26 +107,35 @@ impl Client {
                         reporter.on_test_complete(&result);
                     }
                 }
-                Some("run_complete") => {
-                    if let Ok(summary) =
-                        serde_json::from_value::<RunSummary>(val["params"]["summary"].clone())
-                    {
-                        reporter.on_run_complete(&summary);
-                        if summary.failed > 0 || summary.errors > 0 {
-                            return Err(anyhow::anyhow!(
-                                "{} failed, {} error(s)",
-                                summary.failed,
-                                summary.errors
-                            ));
-                        }
-                    }
-                    break;
-                }
                 _ => {}
             }
         }
-        Ok(())
+
+        if let Some(s) = summary {
+            reporter.on_run_complete(&s);
+            if s.failed > 0 || s.errors > 0 {
+                return Err(anyhow::anyhow!(
+                    "{} failed, {} error(s)",
+                    s.failed,
+                    s.errors
+                ));
+            }
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "server closed connection before returning a run summary"
+            ))
+        }
     }
+}
+
+fn generate_run_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| u64::try_from(d.as_nanos()).ok())
+        .unwrap_or(0);
+    format!("cli-{}-{:x}", std::process::id(), nanos)
 }
 
 #[cfg(test)]
@@ -104,7 +148,12 @@ mod tests {
 
     use super::*;
 
-    fn start_mock_server(responses: Vec<String>) -> u16 {
+    /// Spawn a mock server that captures the client's request, then emits
+    /// `responses` in order. If `echo_run_id` is true, the mock parses
+    /// `run_id` from the client's request and substitutes every `{RID}`
+    /// placeholder in the responses with it — lets tests simulate a real
+    /// server that echoes the `run_id` back.
+    fn start_mock_server(responses: Vec<String>, echo_run_id: bool) -> u16 {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         thread::spawn(move || {
@@ -112,8 +161,17 @@ mod tests {
                 let mut reader = BufReader::new(stream.try_clone().unwrap());
                 let mut req_line = String::new();
                 let _ = reader.read_line(&mut req_line);
+                let run_id = if echo_run_id {
+                    serde_json::from_str::<serde_json::Value>(req_line.trim())
+                        .ok()
+                        .and_then(|v| v["params"]["run_id"].as_str().map(String::from))
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                };
                 for resp in &responses {
-                    let _ = stream.write_all(resp.as_bytes());
+                    let substituted = resp.replace("{RID}", &run_id);
+                    let _ = stream.write_all(substituted.as_bytes());
                     let _ = stream.write_all(b"\n");
                 }
                 let _ = stream.flush();
@@ -150,11 +208,23 @@ mod tests {
         }
     }
 
+    const EMPTY_SUMMARY: &str =
+        r#"{"passed":0,"failed":0,"skipped":0,"duration":{"secs":0,"nanos":0}}"#;
+
+    fn run_start_notif() -> String {
+        r#"{"jsonrpc":"2.0","method":"run_start","params":{"run_id":"{RID}","tests":[]}}"#
+            .to_string()
+    }
+
+    fn rpc_response() -> String {
+        format!(
+            r#"{{"jsonrpc":"2.0","id":1,"result":{{"run_id":"{{RID}}","summary":{EMPTY_SUMMARY}}}}}"#
+        )
+    }
+
     #[test]
     fn client_dispatches_reporter_events() {
-        let run_start = r#"{"jsonrpc":"2.0","method":"run_start","params":{"tests":[]}}"#;
-        let run_complete = r#"{"jsonrpc":"2.0","method":"run_complete","params":{"summary":{"passed":0,"failed":0,"skipped":0,"duration":{"secs":0,"nanos":0}}}}"#;
-        let port = start_mock_server(vec![run_start.to_string(), run_complete.to_string()]);
+        let port = start_mock_server(vec![run_start_notif(), rpc_response()], true);
 
         let dir = tempfile::tempdir().unwrap();
         let mut reporter = RecordingReporter::new();
@@ -175,5 +245,82 @@ mod tests {
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("no server running on port") || !msg.is_empty());
+    }
+
+    #[test]
+    fn client_ignores_notifications_from_other_runs() {
+        // Emit notifications tagged with a different run_id before our own
+        // run_start+response. The reporter must not see any of them.
+        let foreign_run_start = r#"{"jsonrpc":"2.0","method":"run_start","params":{"run_id":"other","tests":[{"name":"foreign","module_path":"x"}]}}"#;
+        let foreign_test_complete =
+            r#"{"jsonrpc":"2.0","method":"test_complete","params":{"run_id":"other","result":{"test":{"name":"foreign","module_path":"x"},"outcome":"Passed","duration":{"secs":0,"nanos":0},"stdout":"","stderr":""}}}"#
+                .to_string();
+        let port = start_mock_server(
+            vec![
+                foreign_run_start.to_string(),
+                foreign_test_complete,
+                run_start_notif(),
+                rpc_response(),
+            ],
+            true,
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut reporter = RecordingReporter::new();
+        Client::new(port, None, vec![], None)
+            .run(dir.path(), &mut reporter)
+            .unwrap();
+
+        assert!(
+            reporter.started,
+            "our own run_start should still be dispatched"
+        );
+        assert!(
+            reporter.results.is_empty(),
+            "test_complete for a different run_id must be filtered out"
+        );
+        assert!(reporter.summary.is_some());
+    }
+
+    #[test]
+    fn client_breaks_on_rpc_response_even_without_run_complete() {
+        // The server no longer depends on `run_complete` for termination.
+        // If the broadcast channel lags and the run_complete notification is
+        // dropped, the RPC response is still the authoritative terminator.
+        let port = start_mock_server(vec![run_start_notif(), rpc_response()], true);
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut reporter = RecordingReporter::new();
+        Client::new(port, None, vec![], None)
+            .run(dir.path(), &mut reporter)
+            .unwrap();
+
+        assert!(reporter.summary.is_some());
+    }
+
+    #[test]
+    fn client_errors_when_server_closes_without_summary() {
+        // Server sends only notifications then EOF. Client must not hang;
+        // it must surface a clear error.
+        let port = start_mock_server(vec![run_start_notif()], true);
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut reporter = RecordingReporter::new();
+        let result = Client::new(port, None, vec![], None).run(dir.path(), &mut reporter);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("before returning a run summary")
+        );
+    }
+
+    #[test]
+    fn generate_run_id_includes_pid_prefix() {
+        let a = generate_run_id();
+        let b = generate_run_id();
+        assert!(a.starts_with("cli-"));
+        assert_ne!(a, b, "consecutive ids should differ by nanos");
     }
 }

--- a/crates/tryke_server/src/client.rs
+++ b/crates/tryke_server/src/client.rs
@@ -2,6 +2,7 @@ use std::{
     io::{BufRead, BufReader, ErrorKind, Write},
     net::TcpStream,
     path::Path,
+    sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -164,12 +165,17 @@ fn read_until_summary(
 }
 
 fn generate_run_id() -> String {
+    // Monotonic per-process counter so two calls in the same nanosecond
+    // still produce distinct ids. Some platforms (notably macOS) report
+    // SystemTime at coarser than nanosecond resolution.
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .ok()
         .and_then(|d| u64::try_from(d.as_nanos()).ok())
         .unwrap_or(0);
-    format!("cli-{}-{:x}", std::process::id(), nanos)
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("cli-{}-{:x}-{:x}", std::process::id(), nanos, seq)
 }
 
 #[cfg(test)]
@@ -426,6 +432,6 @@ mod tests {
         let a = generate_run_id();
         let b = generate_run_id();
         assert!(a.starts_with("cli-"));
-        assert_ne!(a, b, "consecutive ids should differ by nanos");
+        assert_ne!(a, b, "consecutive ids must be unique");
     }
 }

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -13,9 +13,9 @@ use tryke_types::filter::TestFilter;
 use tryke_types::{RunSummary, TestOutcome};
 
 use crate::protocol::{
-    DiscoverCompleteParams, DiscoverParams, ErrorResponse, METHOD_NOT_FOUND, Notification, Request,
-    Response, RpcError, RunCompleteParams, RunParams, RunResponse, RunStartParams,
-    TestCompleteParams,
+    DiscoverCompleteParams, DiscoverParams, ErrorResponse, INVALID_PARAMS, METHOD_NOT_FOUND,
+    Notification, Request, Response, RpcError, RunCompleteParams, RunParams, RunResponse,
+    RunStartParams, TestCompleteParams,
 };
 
 pub struct ConnectionHandler {
@@ -140,7 +140,7 @@ async fn execute_run(
     pool: &WorkerPool,
     run_lock: &Mutex<()>,
 ) -> (String, RunSummary) {
-    let run_id = rp.run_id.clone().unwrap_or_else(generate_run_id);
+    let run_id = rp.run_id.clone();
     // Serialize concurrent runs: only one run at a time may dispatch units
     // onto the shared pool, so per-module fixture state (and test_complete
     // notification ordering) is not interleaved across clients.
@@ -242,16 +242,6 @@ async fn execute_run(
     (run_id, summary)
 }
 
-/// Generate a `run_id` unique to this server process. Combines a monotonic
-/// counter with the process id so ids are still recognizable if the server
-/// restarts while a client is reconnecting.
-fn generate_run_id() -> String {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("srv-{}-{:x}", std::process::id(), n)
-}
-
 pub async fn handle_request(
     line: &str,
     disc: &tokio::sync::Mutex<tryke_discovery::Discoverer>,
@@ -277,10 +267,23 @@ pub async fn handle_request(
             serialize_response(id, serde_json::json!({ "tests": tests }))
         }
         "run" => {
-            let rp = req
-                .params
-                .and_then(|p| serde_json::from_value::<RunParams>(p).ok())
-                .unwrap_or_default();
+            let Some(params) = req.params else {
+                return serialize_error(
+                    req.id,
+                    INVALID_PARAMS,
+                    "method 'run' requires params with run_id".to_string(),
+                );
+            };
+            let rp = match serde_json::from_value::<RunParams>(params) {
+                Ok(rp) => rp,
+                Err(e) => {
+                    return serialize_error(
+                        req.id,
+                        INVALID_PARAMS,
+                        format!("invalid params for 'run': {e}"),
+                    );
+                }
+            };
             let (run_id, summary) = execute_run(rp, disc, bcast_tx, pool, run_lock).await;
             serialize_response(id, RunResponse { run_id, summary })
         }
@@ -383,7 +386,7 @@ mod tests {
         let pool = make_pool();
         let run_lock = make_run_lock();
         handle_request(
-            r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"root":"/ignored","tests":null}}"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"root":"/ignored","tests":null,"run_id":"r1"}}"#,
             &disc,
             &tx,
             &pool,
@@ -400,6 +403,26 @@ mod tests {
         }
         assert!(methods.contains(&"run_start".to_string()));
         assert!(methods.contains(&"run_complete".to_string()));
+    }
+
+    #[tokio::test]
+    async fn run_without_run_id_returns_invalid_params() {
+        let dir = make_root();
+        let (tx, _rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let resp = handle_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"tests":null}}"#,
+            &disc,
+            &tx,
+            &pool,
+            &run_lock,
+        )
+        .await
+        .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["error"]["code"], INVALID_PARAMS);
     }
 
     #[tokio::test]
@@ -460,7 +483,7 @@ mod tests {
         // Run should return only cached tests (test_x), not pick up test_y
         let (tx2, mut rx2) = broadcast::channel(64);
         handle_request(
-            r#"{"jsonrpc":"2.0","id":2,"method":"run","params":{"root":"/ignored","tests":null}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"run","params":{"root":"/ignored","tests":null,"run_id":"r1"}}"#,
             &disc,
             &tx2,
             &pool,
@@ -536,8 +559,7 @@ mod tests {
         let mut c1 = TcpStream::connect(addr).await.unwrap();
         let mut c2 = TcpStream::connect(addr).await.unwrap();
 
-        let run_req =
-            r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"root":"/ignored","tests":null}}"#;
+        let run_req = r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"root":"/ignored","tests":null,"run_id":"r1"}}"#;
         c1.write_all(format!("{run_req}\n").as_bytes())
             .await
             .unwrap();
@@ -574,7 +596,7 @@ mod tests {
         let pool = make_pool();
         let run_lock = make_run_lock();
         handle_request(
-            r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"filter":"alpha"}}"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"filter":"alpha","run_id":"r1"}}"#,
             &disc,
             &tx,
             &pool,

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -14,7 +14,8 @@ use tryke_types::{RunSummary, TestOutcome};
 
 use crate::protocol::{
     DiscoverCompleteParams, DiscoverParams, ErrorResponse, METHOD_NOT_FOUND, Notification, Request,
-    Response, RpcError, RunCompleteParams, RunParams, RunStartParams, TestCompleteParams,
+    Response, RpcError, RunCompleteParams, RunParams, RunResponse, RunStartParams,
+    TestCompleteParams,
 };
 
 pub struct ConnectionHandler {
@@ -23,6 +24,7 @@ pub struct ConnectionHandler {
     broadcast_rx: broadcast::Receiver<Bytes>,
     broadcast_tx: broadcast::Sender<Bytes>,
     pool: Arc<WorkerPool>,
+    run_lock: Arc<Mutex<()>>,
 }
 
 impl ConnectionHandler {
@@ -32,6 +34,7 @@ impl ConnectionHandler {
         broadcast_rx: broadcast::Receiver<Bytes>,
         broadcast_tx: broadcast::Sender<Bytes>,
         pool: Arc<WorkerPool>,
+        run_lock: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             stream,
@@ -39,6 +42,7 @@ impl ConnectionHandler {
             broadcast_rx,
             broadcast_tx,
             pool,
+            run_lock,
         }
     }
 
@@ -73,8 +77,10 @@ impl ConnectionHandler {
                     let disc = Arc::clone(&self.disc);
                     let bcast_tx = self.broadcast_tx.clone();
                     let pool = Arc::clone(&self.pool);
+                    let run_lock = Arc::clone(&self.run_lock);
                     let line_owned = line.clone();
-                    let response = handle_request(&line_owned, &disc, &bcast_tx, &pool).await;
+                    let response =
+                        handle_request(&line_owned, &disc, &bcast_tx, &pool, &run_lock).await;
                     if let Some(bytes) = response {
                         let mut w = writer.lock().await;
                         if w.write_all(&bytes).await.is_err() || w.flush().await.is_err() {
@@ -132,7 +138,14 @@ async fn execute_run(
     disc: &tokio::sync::Mutex<tryke_discovery::Discoverer>,
     bcast_tx: &broadcast::Sender<Bytes>,
     pool: &WorkerPool,
-) -> RunSummary {
+    run_lock: &Mutex<()>,
+) -> (String, RunSummary) {
+    let run_id = rp.run_id.clone().unwrap_or_else(generate_run_id);
+    // Serialize concurrent runs: only one run at a time may dispatch units
+    // onto the shared pool, so per-module fixture state (and test_complete
+    // notification ordering) is not interleaved across clients.
+    let _run_guard = run_lock.lock().await;
+
     let discovery_start = Instant::now();
     let guard = disc.lock().await;
     let all_tests = guard.tests();
@@ -164,6 +177,7 @@ async fn execute_run(
         bcast_tx,
         "run_start",
         RunStartParams {
+            run_id: run_id.clone(),
             tests: tests.clone(),
         },
     );
@@ -195,6 +209,7 @@ async fn execute_run(
             bcast_tx,
             "test_complete",
             TestCompleteParams {
+                run_id: run_id.clone(),
                 result: result.clone(),
             },
         );
@@ -219,11 +234,22 @@ async fn execute_run(
         bcast_tx,
         "run_complete",
         RunCompleteParams {
+            run_id: run_id.clone(),
             summary: summary.clone(),
         },
     );
 
-    summary
+    (run_id, summary)
+}
+
+/// Generate a `run_id` unique to this server process. Combines a monotonic
+/// counter with the process id so ids are still recognizable if the server
+/// restarts while a client is reconnecting.
+fn generate_run_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("srv-{}-{:x}", std::process::id(), n)
 }
 
 pub async fn handle_request(
@@ -231,6 +257,7 @@ pub async fn handle_request(
     disc: &tokio::sync::Mutex<tryke_discovery::Discoverer>,
     bcast_tx: &broadcast::Sender<Bytes>,
     pool: &WorkerPool,
+    run_lock: &Mutex<()>,
 ) -> Option<Vec<u8>> {
     let req: Request = serde_json::from_str(line.trim()).ok()?;
     let id = req.id.clone().unwrap_or(Value::Null);
@@ -254,8 +281,8 @@ pub async fn handle_request(
                 .params
                 .and_then(|p| serde_json::from_value::<RunParams>(p).ok())
                 .unwrap_or_default();
-            let summary = execute_run(rp, disc, bcast_tx, pool).await;
-            serialize_response(id, serde_json::json!({ "summary": summary }))
+            let (run_id, summary) = execute_run(rp, disc, bcast_tx, pool, run_lock).await;
+            serialize_response(id, RunResponse { run_id, summary })
         }
         _ => serialize_error(
             req.id,
@@ -302,17 +329,23 @@ mod tests {
         ))
     }
 
+    fn make_run_lock() -> Arc<Mutex<()>> {
+        Arc::new(Mutex::new(()))
+    }
+
     #[tokio::test]
     async fn ping_returns_pong() {
         let dir = make_root();
         let (tx, _rx) = broadcast::channel(16);
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
+        let run_lock = make_run_lock();
         let resp = handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#,
             &disc,
             &tx,
             &pool,
+            &run_lock,
         )
         .await
         .unwrap();
@@ -328,11 +361,13 @@ mod tests {
         let (tx, _rx) = broadcast::channel(16);
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
+        let run_lock = make_run_lock();
         let resp = handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"discover","params":{"root":"/ignored"}}"#,
             &disc,
             &tx,
             &pool,
+            &run_lock,
         )
         .await
         .unwrap();
@@ -346,11 +381,13 @@ mod tests {
         let (tx, mut rx) = broadcast::channel(64);
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
+        let run_lock = make_run_lock();
         handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"root":"/ignored","tests":null}}"#,
             &disc,
             &tx,
             &pool,
+            &run_lock,
         )
         .await;
 
@@ -366,6 +403,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_broadcasts_include_run_id() {
+        let dir = make_root();
+        let (tx, mut rx) = broadcast::channel(64);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let resp = handle_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"run_id":"test-run-xyz","tests":null}}"#,
+            &disc,
+            &tx,
+            &pool,
+            &run_lock,
+        )
+        .await
+        .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["result"]["run_id"], "test-run-xyz");
+
+        while let Ok(bytes) = rx.try_recv() {
+            let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            let method = val["method"].as_str().unwrap_or("");
+            if matches!(method, "run_start" | "run_complete" | "test_complete") {
+                assert_eq!(
+                    val["params"]["run_id"], "test-run-xyz",
+                    "notification {method} missing run_id"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn run_uses_cached_tests_not_rediscover() {
         let dir = make_root();
         fs::write(dir.path().join("test_x.py"), "@test\ndef test_x(): pass\n")
@@ -375,11 +443,13 @@ mod tests {
         // Populate cache via discover
         let (tx, _rx) = broadcast::channel(64);
         let pool = make_pool();
+        let run_lock = make_run_lock();
         handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"discover","params":{"root":"/ignored"}}"#,
             &disc,
             &tx,
             &pool,
+            &run_lock,
         )
         .await;
 
@@ -394,6 +464,7 @@ mod tests {
             &disc,
             &tx2,
             &pool,
+            &run_lock,
         )
         .await;
 
@@ -417,11 +488,13 @@ mod tests {
         let (tx, _rx) = broadcast::channel(16);
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
+        let run_lock = make_run_lock();
         let resp = handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"unknown_method"}"#,
             &disc,
             &tx,
             &pool,
+            &run_lock,
         )
         .await
         .unwrap();
@@ -442,6 +515,8 @@ mod tests {
         let disc_clone = Arc::clone(&disc);
         let pool_clone = Arc::clone(&pool);
 
+        let run_lock = make_run_lock();
+        let run_lock_clone = Arc::clone(&run_lock);
         tokio::spawn(async move {
             for _ in 0..2u8 {
                 let (stream, _) = listener.accept().await.unwrap();
@@ -449,8 +524,9 @@ mod tests {
                 let bcast_tx_conn = bcast_tx_clone.clone();
                 let d = Arc::clone(&disc_clone);
                 let p = Arc::clone(&pool_clone);
+                let rl = Arc::clone(&run_lock_clone);
                 tokio::spawn(async move {
-                    ConnectionHandler::new(stream, d, bcast_rx, bcast_tx_conn, p)
+                    ConnectionHandler::new(stream, d, bcast_rx, bcast_tx_conn, p, rl)
                         .run()
                         .await;
                 });
@@ -496,11 +572,13 @@ mod tests {
         // Populate cache
         disc.lock().await.rediscover();
         let pool = make_pool();
+        let run_lock = make_run_lock();
         handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"filter":"alpha"}}"#,
             &disc,
             &tx,
             &pool,
+            &run_lock,
         )
         .await;
 
@@ -516,5 +594,92 @@ mod tests {
             Some(1),
             "filter should restrict to only test_alpha"
         );
+    }
+
+    #[tokio::test]
+    async fn concurrent_runs_are_serialized() {
+        // Two concurrent `run` calls on the same pool should execute
+        // back-to-back, not interleaved. Proof: every test_complete
+        // notification between run_start(run_id=A) and run_complete(run_id=A)
+        // carries run_id=A, and same for B.
+        let dir = make_root();
+        fs::write(
+            dir.path().join("test_x.py"),
+            "@test\ndef test_alpha(): pass\n\n@test\ndef test_beta(): pass\n",
+        )
+        .expect("write test file");
+        let (tx, mut rx) = broadcast::channel(256);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        disc.lock().await.rediscover();
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+
+        let disc_a = Arc::clone(&disc);
+        let tx_a = tx.clone();
+        let pool_a = Arc::clone(&pool);
+        let run_lock_a = Arc::clone(&run_lock);
+        let handle_a = tokio::spawn(async move {
+            handle_request(
+                r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"run_id":"A","tests":null}}"#,
+                &disc_a,
+                &tx_a,
+                &pool_a,
+                &run_lock_a,
+            )
+            .await;
+        });
+        let handle_b = tokio::spawn(async move {
+            handle_request(
+                r#"{"jsonrpc":"2.0","id":2,"method":"run","params":{"run_id":"B","tests":null}}"#,
+                &disc,
+                &tx,
+                &pool,
+                &run_lock,
+            )
+            .await;
+        });
+        handle_a.await.unwrap();
+        handle_b.await.unwrap();
+
+        // Collect all notifications and walk them in order. Between
+        // run_start(X) and run_complete(X), every event must have run_id=X.
+        let mut events: Vec<(String, String)> = vec![];
+        while let Ok(bytes) = rx.try_recv() {
+            let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            if let Some(m) = v["method"].as_str() {
+                let rid = v["params"]["run_id"].as_str().unwrap_or("").to_string();
+                events.push((m.to_string(), rid));
+            }
+        }
+
+        let mut active: Option<String> = None;
+        for (method, rid) in &events {
+            match method.as_str() {
+                "run_start" => {
+                    assert!(
+                        active.is_none(),
+                        "run_start while another run is active: events={events:?}"
+                    );
+                    active = Some(rid.clone());
+                }
+                "run_complete" => {
+                    assert_eq!(
+                        active.as_ref(),
+                        Some(rid),
+                        "run_complete for {rid} while active is {active:?}"
+                    );
+                    active = None;
+                }
+                "test_complete" => {
+                    assert_eq!(
+                        active.as_ref(),
+                        Some(rid),
+                        "test_complete for {rid} while active is {active:?}"
+                    );
+                }
+                _ => {}
+            }
+        }
+        assert!(active.is_none(), "run never completed: events={events:?}");
     }
 }

--- a/crates/tryke_server/src/protocol.rs
+++ b/crates/tryke_server/src/protocol.rs
@@ -23,6 +23,12 @@ pub struct RunParams {
     pub filter: Option<String>,
     pub paths: Option<Vec<String>>,
     pub markers: Option<String>,
+    /// Client-generated opaque identifier that the server echoes back in the
+    /// `run` RPC response and every `run_start` / `test_complete` /
+    /// `run_complete` notification. Clients use this to demultiplex
+    /// notifications when multiple runs share the broadcast channel. If
+    /// absent, the server generates one.
+    pub run_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -59,16 +65,25 @@ pub struct DiscoverCompleteParams {
 
 #[derive(Debug, Serialize)]
 pub struct RunStartParams {
+    pub run_id: String,
     pub tests: Vec<TestItem>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct TestCompleteParams {
+    pub run_id: String,
     pub result: TestResult,
 }
 
 #[derive(Debug, Serialize)]
 pub struct RunCompleteParams {
+    pub run_id: String,
+    pub summary: RunSummary,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunResponse {
+    pub run_id: String,
     pub summary: RunSummary,
 }
 
@@ -154,5 +169,31 @@ mod tests {
         assert_eq!(val["method"], "discover_complete");
         assert!(val["params"]["tests"].is_array());
         assert!(val.get("id").is_none());
+    }
+
+    #[test]
+    fn run_params_without_run_id_deserializes() {
+        let json = r#"{"tests":null}"#;
+        let params: RunParams = serde_json::from_str(json).unwrap();
+        assert!(params.run_id.is_none());
+    }
+
+    #[test]
+    fn run_params_with_run_id_deserializes() {
+        let json = r#"{"tests":null,"run_id":"abc-123"}"#;
+        let params: RunParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.run_id.as_deref(), Some("abc-123"));
+    }
+
+    #[test]
+    fn run_start_params_serialize_with_run_id() {
+        let params = RunStartParams {
+            run_id: "r1".to_string(),
+            tests: vec![],
+        };
+        let val: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&params).unwrap()).unwrap();
+        assert_eq!(val["run_id"], "r1");
+        assert!(val["tests"].is_array());
     }
 }

--- a/crates/tryke_server/src/protocol.rs
+++ b/crates/tryke_server/src/protocol.rs
@@ -17,7 +17,7 @@ pub struct DiscoverParams {
     pub root: PathBuf,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct RunParams {
     pub tests: Option<Vec<String>>,
     pub filter: Option<String>,
@@ -25,10 +25,10 @@ pub struct RunParams {
     pub markers: Option<String>,
     /// Client-generated opaque identifier that the server echoes back in the
     /// `run` RPC response and every `run_start` / `test_complete` /
-    /// `run_complete` notification. Clients use this to demultiplex
-    /// notifications when multiple runs share the broadcast channel. If
-    /// absent, the server generates one.
-    pub run_id: Option<String>,
+    /// `run_complete` notification. Required: clients use this to
+    /// demultiplex notifications when multiple runs share the broadcast
+    /// channel.
+    pub run_id: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -88,6 +88,7 @@ pub struct RunResponse {
 }
 
 pub const METHOD_NOT_FOUND: i32 = -32601;
+pub const INVALID_PARAMS: i32 = -32602;
 
 #[cfg(test)]
 mod tests {
@@ -112,17 +113,16 @@ mod tests {
 
     #[test]
     fn deserializes_run_request_tests_null() {
-        let json =
-            r#"{"jsonrpc":"2.0","id":3,"method":"run","params":{"root":"/tmp","tests":null}}"#;
+        let json = r#"{"jsonrpc":"2.0","id":3,"method":"run","params":{"root":"/tmp","tests":null,"run_id":"r1"}}"#;
         let req: Request = serde_json::from_str(json).unwrap();
         let params: RunParams = serde_json::from_value(req.params.unwrap()).unwrap();
         assert!(params.tests.is_none());
+        assert_eq!(params.run_id, "r1");
     }
 
     #[test]
     fn deserializes_run_request_with_tests() {
-        let json =
-            r#"{"jsonrpc":"2.0","id":3,"method":"run","params":{"root":"/tmp","tests":["a","b"]}}"#;
+        let json = r#"{"jsonrpc":"2.0","id":3,"method":"run","params":{"root":"/tmp","tests":["a","b"],"run_id":"r1"}}"#;
         let req: Request = serde_json::from_str(json).unwrap();
         let params: RunParams = serde_json::from_value(req.params.unwrap()).unwrap();
         assert_eq!(params.tests, Some(vec!["a".to_string(), "b".to_string()]));
@@ -172,17 +172,17 @@ mod tests {
     }
 
     #[test]
-    fn run_params_without_run_id_deserializes() {
+    fn run_params_without_run_id_is_rejected() {
         let json = r#"{"tests":null}"#;
-        let params: RunParams = serde_json::from_str(json).unwrap();
-        assert!(params.run_id.is_none());
+        let result: Result<RunParams, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "run_id is required");
     }
 
     #[test]
     fn run_params_with_run_id_deserializes() {
         let json = r#"{"tests":null,"run_id":"abc-123"}"#;
         let params: RunParams = serde_json::from_str(json).unwrap();
-        assert_eq!(params.run_id.as_deref(), Some("abc-123"));
+        assert_eq!(params.run_id, "abc-123");
     }
 
     #[test]

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -180,7 +180,7 @@ mod tests {
         let mut c1 = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         let mut c2 = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
 
-        let run_req = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"run\",\"params\":{\"root\":\"/ignored\",\"tests\":null}}\n";
+        let run_req = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"run\",\"params\":{\"root\":\"/ignored\",\"tests\":null,\"run_id\":\"r1\"}}\n";
         c1.write_all(run_req.as_bytes()).await.unwrap();
 
         let mut r2 = BufReader::new(&mut c2);

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -45,6 +45,10 @@ impl Server {
         let pool = Arc::new(WorkerPool::new(size, &python, &self.root));
         pool.warm().await;
 
+        // Held across the full duration of a single `run` so concurrent
+        // clients don't interleave test execution on the shared pool.
+        let run_lock = Arc::new(Mutex::new(()));
+
         let (bcast_tx, _) = broadcast::channel::<Bytes>(256);
         let disc = Arc::new(Mutex::new(Discoverer::new_with_excludes(
             &self.root,
@@ -105,10 +109,18 @@ impl Server {
             let bcast_tx_conn = bcast_tx.clone();
             let disc_conn = Arc::clone(&disc);
             let pool_conn = Arc::clone(&pool);
+            let run_lock_conn = Arc::clone(&run_lock);
             tokio::spawn(async move {
-                ConnectionHandler::new(stream, disc_conn, bcast_rx, bcast_tx_conn, pool_conn)
-                    .run()
-                    .await;
+                ConnectionHandler::new(
+                    stream,
+                    disc_conn,
+                    bcast_rx,
+                    bcast_tx_conn,
+                    pool_conn,
+                    run_lock_conn,
+                )
+                .run()
+                .await;
             });
         }
     }


### PR DESCRIPTION
Adds a run_id that is carried through every run_start / test_complete /
run_complete notification and returned in the `run` RPC response. The
client filters broadcast notifications to its own run_id and terminates
on the RPC response rather than on run_complete, so a lagged broadcast
channel can no longer silently hang the client. A per-server run mutex
serializes concurrent runs so clients can't interleave test execution
or fixture state on the shared worker pool.

https://claude.ai/code/session_01HrcVmvYUuxdrrttE76reC6