### PR TITLE
Drop stale _all/before_all hook terminology and fix --lf migration row

### DIFF
--- a/crates/tryke_runner/src/schedule.rs
+++ b/crates/tryke_runner/src/schedule.rs
@@ -40,9 +40,9 @@ pub fn partition(tests: Vec<TestItem>, mode: DistMode) -> Vec<WorkUnit> {
 /// The result of [`partition_with_hooks`]: the work units plus any
 /// warnings produced while planning. Warnings cover situations where
 /// the requested `mode` had to be upgraded for correctness (e.g. a
-/// file-scope `_all` hook forced file-level grouping), and should be
-/// surfaced to the user so they understand why the distribution
-/// differs from what they asked for on the CLI.
+/// file-scope `per="scope"` fixture forced file-level grouping), and
+/// should be surfaced to the user so they understand why the
+/// distribution differs from what they asked for on the CLI.
 #[derive(Debug)]
 pub struct PartitionResult {
     pub units: Vec<WorkUnit>,
@@ -51,9 +51,9 @@ pub struct PartitionResult {
 
 /// Like [`partition`], but attaches discovered hooks to each work unit.
 ///
-/// When `_all` hooks are present, `DistMode::Test` is upgraded:
-/// - File-scope `_all` hooks (empty groups) force file-level grouping
-/// - Group-scope `_all` hooks force group-level grouping
+/// When `per="scope"` fixtures are present, `DistMode::Test` is upgraded:
+/// - File-scope `per="scope"` fixtures (empty groups) force file-level grouping
+/// - Group-scope `per="scope"` fixtures force group-level grouping
 #[must_use]
 fn group_by_file(tests: Vec<TestItem>) -> Vec<WorkUnit> {
     let mut by_file: IndexMap<Option<PathBuf>, Vec<TestItem>> = IndexMap::new();
@@ -151,7 +151,7 @@ pub fn partition_with_hooks(
         }
         result
     } else if mode == DistMode::Group && !file_constrained_modules.is_empty() {
-        // Group mode with file-scope _all hooks: upgrade those modules to file level.
+        // Group mode with file-scope per="scope" fixtures: upgrade those modules to file level.
         let (constrained, free): (Vec<_>, Vec<_>) = tests
             .into_iter()
             .partition(|t| file_constrained_modules.contains(t.module_path.as_str()));
@@ -310,13 +310,13 @@ mod tests {
     }
 
     #[test]
-    fn test_mode_with_file_scope_before_all_forces_file_grouping() {
+    fn test_mode_with_file_scope_scope_fixture_forces_file_grouping() {
         let tests = vec![
             item("a.py", "t1", &[]),
             item("a.py", "t2", &[]),
             item("b.py", "t3", &[]),
         ];
-        // Hook is in test_mod (same as a.py items) — only a.py tests are constrained.
+        // Fixture is in test_mod (same as a.py items) — only a.py tests are constrained.
         let hooks = vec![hook("setup", FixturePer::Scope, &[])];
         let result = partition_with_hooks(tests, &hooks, DistMode::Test);
         let a_units: Vec<_> = result
@@ -329,14 +329,14 @@ mod tests {
     }
 
     #[test]
-    fn test_mode_with_only_each_hooks_stays_individual() {
+    fn test_mode_with_only_per_test_fixtures_stays_individual() {
         let tests = vec![item("a.py", "t1", &[]), item("a.py", "t2", &[])];
         let hooks = vec![hook("setup", FixturePer::Test, &[])];
         let result = partition_with_hooks(tests, &hooks, DistMode::Test);
         assert_eq!(
             result.units.len(),
             2,
-            "each hooks don't constrain scheduling"
+            "per=\"test\" fixtures don't constrain scheduling"
         );
         assert!(result.warnings.is_empty());
     }
@@ -370,15 +370,15 @@ mod tests {
     }
 
     #[test]
-    fn group_mode_with_file_scope_before_all_forces_file_grouping() {
+    fn group_mode_with_file_scope_scope_fixture_forces_file_grouping() {
         let tests = vec![
             item("a.py", "t1", &["math"]),
             item("a.py", "t2", &["math"]),
             item("a.py", "t3", &["strings"]),
             item("b.py", "t4", &["other"]),
         ];
-        // Module "a" has a file-scope before_all (empty groups) — even in group mode,
-        // all of a.py's tests must land on one worker.
+        // Module "a" has a file-scope per="scope" fixture (empty groups) — even in
+        // group mode, all of a.py's tests must land on one worker.
         let hooks = vec![hook("setup", FixturePer::Scope, &[])];
         let result = partition_with_hooks(tests, &hooks, DistMode::Group);
         let a_units: Vec<_> = result
@@ -418,14 +418,14 @@ mod tests {
     }
 
     #[test]
-    fn before_all_in_one_module_does_not_constrain_other_modules() {
+    fn scope_fixture_in_one_module_does_not_constrain_other_modules() {
         let tests = vec![
             item("a.py", "t1", &[]),
             item("a.py", "t2", &[]),
             item("b.py", "t3", &[]),
             item("b.py", "t4", &[]),
         ];
-        // Only module "a" has a before_all hook.
+        // Only module "a" has a per="scope" fixture.
         let hooks = vec![hook_for_module("setup", "a", FixturePer::Scope, &[])];
         let result = partition_with_hooks(tests, &hooks, DistMode::Test);
         // a.py tests are grouped (1 unit), b.py tests are individual (2 units)
@@ -446,8 +446,8 @@ mod tests {
 
     #[test]
     fn test_mode_upgrade_emits_warning_naming_affected_modules() {
-        // The user asked for --dist test but a file-scope before_all on
-        // module "a" forces file-level grouping. The user must see this
+        // The user asked for --dist test but a file-scope per="scope" fixture
+        // on module "a" forces file-level grouping. The user must see this
         // as an explicit warning so they understand why their CLI flag
         // didn't take effect.
         let tests = vec![

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -145,8 +145,9 @@ impl WorkerProcess {
         Ok(())
     }
 
-    /// Tell the Python worker to run scope-level teardown (`after_all`, `wrap_all`)
-    /// for a module. Must be called after all tests from that module have run.
+    /// Tell the Python worker to run scope-level teardown for `per="scope"`
+    /// fixtures in a module. Must be called after all tests from that module
+    /// have run.
     #[expect(clippy::missing_errors_doc)]
     pub async fn finalize_hooks(&mut self, module: String) -> Result<()> {
         let value = serde_json::to_value(FinalizeHooksParams { module })?;

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -162,16 +162,18 @@ async def async_operation():
 
 ### Running changed tests
 
-**pytest** (requires plugin):
+**pytest** (requires a plugin like `pytest-picked` or `pytest-testmon`):
 
 ```bash
-pytest --lf  # last failed
+pytest --picked          # from pytest-picked: tests in git-changed files
+pytest --testmon         # from pytest-testmon: tests affected at runtime
 ```
 
-**Tryke** (built-in):
+**Tryke** (built-in, uses a static import graph):
 
 ```bash
-tryke test --changed  # tests affected by git changes
+tryke test --changed        # tests affected by git-changed files
+tryke test --changed-first  # changed tests first, then the rest
 ```
 
 ## What's different

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -535,7 +535,7 @@ class Worker:
         _log.debug("register_hooks: module=%s hook_count=%d", module_name, len(hooks))
 
     def _finalize_hooks(self, module_name: str) -> None:
-        """Run scope-level teardown (after_all, wrap_all) for a module."""
+        """Run scope-level teardown for a module's `per="scope"` fixtures."""
         executor = self._executors.get(module_name)
         if executor is not None:
             executor.finalize()


### PR DESCRIPTION
## Summary

Audit sweep of the docs website, README, and code comments to catch places where the text has drifted from current behavior. Most of the prose holds up — the README example, the CLI reference (autogenerated), the cases / fixtures / concurrency / client-server pages, and the dot-reporter glyph table all match the current code. Two things did need fixing:

- **Stale hook terminology in internal comments.** `crates/tryke_runner/src/schedule.rs`, `crates/tryke_runner/src/worker.rs`, and `python/tryke/worker.py` still talked about `_all` / `before_all` / `wrap_all` / `after_all` / "each hooks." The public API (and every user-facing scheduler warning) has been `@fixture(per="test" | "scope")` for a while — these comments were left behind from an earlier design. Renamed the stale comments and the four test names that mirrored them. No behavior change.
- **Migration guide's "Running changed tests" row.** It claimed `pytest --lf` requires a plugin and lined it up as the pytest equivalent of `tryke test --changed`. `--lf` is built into pytest and runs *last-failed* tests, not *changed* tests. Replaced with `pytest-picked` / `pytest-testmon` (the same plugins `why.md` already points at), and mentioned `--changed-first` alongside `--changed` for symmetry.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p tryke_runner --lib` (40 passed, including the four renamed scheduler tests)
- [x] `uvx prek run -a` (all hooks pass: fmt, clippy, generate-cli-docs, markdownlint, ruff, ty)


---
_Generated by [Claude Code](https://claude.ai/code/session_01F1kRxJ1LmYxt4pzuJo8xsA)_