### PR TITLE
Add --all flag to rerun the full test set on every change

### DIFF
--- a/crates/tryke/src/cli.rs
+++ b/crates/tryke/src/cli.rs
@@ -128,6 +128,9 @@ pub enum Commands {
         /// How tests are distributed across workers
         #[arg(long, default_value = "test")]
         dist: Dist,
+        /// Rerun the full test set on every change instead of just affected tests
+        #[arg(short = 'a', long = "all")]
+        all: bool,
     },
     /// Start a persistent worker server.
     Server {

--- a/crates/tryke/src/main.rs
+++ b/crates/tryke/src/main.rs
@@ -151,6 +151,7 @@ fn main() -> Result<()> {
             workers,
             dist,
             include,
+            all,
         } => {
             let resolved_maxfail = if *fail_fast { Some(1) } else { *maxfail };
             let mut rep = build_reporter(reporter, verbosity);
@@ -168,6 +169,7 @@ fn main() -> Result<()> {
                 resolved_maxfail,
                 *workers,
                 (*dist).into(),
+                *all,
             ))
         }
         Commands::Server {
@@ -580,6 +582,24 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn watch_all_flag_defaults_to_false() {
+        let cli = Cli::try_parse_from(["tryke", "watch"]).unwrap();
+        assert!(matches!(cli.command, Commands::Watch { all: false, .. }));
+    }
+
+    #[test]
+    fn watch_all_long_flag_parsed() {
+        let cli = Cli::try_parse_from(["tryke", "watch", "--all"]).unwrap();
+        assert!(matches!(cli.command, Commands::Watch { all: true, .. }));
+    }
+
+    #[test]
+    fn watch_all_short_flag_parsed() {
+        let cli = Cli::try_parse_from(["tryke", "watch", "-a"]).unwrap();
+        assert!(matches!(cli.command, Commands::Watch { all: true, .. }));
     }
 
     #[test]

--- a/crates/tryke/src/watch.rs
+++ b/crates/tryke/src/watch.rs
@@ -74,6 +74,10 @@ async fn run_watch_cycle(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Watch options map directly to CLI flags; grouping into a struct would add indirection without clear benefit."
+)]
 pub async fn run_watch(
     reporter: &mut dyn Reporter,
     root: Option<&Path>,
@@ -82,6 +86,7 @@ pub async fn run_watch(
     maxfail: Option<usize>,
     workers: Option<usize>,
     dist: DistMode,
+    all_tests: bool,
 ) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let root = root.unwrap_or(&cwd);
@@ -128,7 +133,17 @@ pub async fn run_watch(
         discoverer.rediscover_changed(&paths);
         clear_if_tty();
         let disc_start = Instant::now();
-        let tests = test_filter.apply(discoverer.tests_for_changed(&paths));
+        // When `--all` is set, rerun the full test set on every change instead
+        // of restricting to tests transitively affected by the changed files.
+        // Useful when the import graph misses dependencies (dynamic imports,
+        // string-referenced modules, external fixtures) or when debugging
+        // test ordering/flakiness.
+        let raw_tests = if all_tests {
+            discoverer.tests()
+        } else {
+            discoverer.tests_for_changed(&paths)
+        };
+        let tests = test_filter.apply(raw_tests);
         let hooks = discoverer.hooks();
         let disc_dur = Some(disc_start.elapsed());
         emit_discovery_warnings(reporter, &discoverer);

--- a/docs/guides/watch-mode.md
+++ b/docs/guides/watch-mode.md
@@ -73,6 +73,28 @@ tryke watch -j 4
 
 See [concurrency](../concepts/concurrency.md) for details on the worker pool.
 
+### Run all tests on every change
+
+By default, watch mode reruns only the tests affected by the changed files
+(via the import graph). Pass `--all` (short: `-a`) to rerun the full
+discovered test set on every change instead:
+
+```bash
+tryke watch --all
+```
+
+This is useful when:
+
+- The import graph misses a dependency the test relies on (dynamic imports,
+  plugin registries, fixtures wired up at runtime, string-referenced modules).
+- An external resource (schema, fixture file, environment variable) changed
+  in a way the import graph cannot see.
+- You are debugging test ordering or flake issues and want a full run on
+  every save.
+
+Module reload still happens for the changed files, so Python picks up the new
+code; only the test selection is broadened.
+
 ## Debouncing
 
 File system events are debounced with a 200ms window. Rapid successive saves are coalesced into a single rerun.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -240,6 +240,9 @@ Options:
 
           [default: test]
 
+  -a, --all
+          Rerun the full test set on every change instead of just affected tests
+
   -h, --help
           Print help (see a summary with '-h')
 ```


### PR DESCRIPTION
## Summary

- Adds an opt-in `--all` / `-a` flag to `tryke watch` that reruns the full discovered test set on every file change, instead of restricting to tests transitively affected by changed files (the existing reverse-import-graph behavior).
- Useful when the import graph misses dependencies (dynamic imports, plugin registries, runtime-wired fixtures, string-referenced modules) or when debugging test ordering / flake issues.
- Module reload behavior is unchanged — we still reload the changed files in the worker pool; only the test selection is broadened.

## Implementation

- `crates/tryke/src/cli.rs`: new `all: bool` field on `Commands::Watch` (`-a`, `--all`).
- `crates/tryke/src/main.rs`: thread `all` from the parsed CLI into `run_watch`.
- `crates/tryke/src/watch.rs`: `run_watch` now takes `all_tests: bool`; in the watch event loop, picks `discoverer.tests()` (full set) vs `discoverer.tests_for_changed(&paths)` (existing default) accordingly. `discoverer.rediscover_changed(&paths)` still runs first so the discovered set stays current in both modes.
- `docs/reference/cli.md`: regenerated by the `generate-cli-docs` hook.

## Test plan

- [x] `cargo build -p tryke` — compiles.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo test -p tryke --bin tryke` — 40/40 pass, including 3 new tests:
  - `watch_all_flag_defaults_to_false`
  - `watch_all_long_flag_parsed`
  - `watch_all_short_flag_parsed`
- [x] Existing `run_watch_cycle_absorbs_test_failures` still passes.
- [x] `uvx prek run -a` — all hooks pass.
- [ ] Manual smoke test: in a project with `test_a.py` (imports `util.py`) and `test_b.py` (does not), edit `util.py`:
  - `tryke watch` reruns only `test_a`.
  - `tryke watch --all` reruns both.

Note: 3 pre-existing failures in `execution::tests` (`integration_python_worker_runs_tests`, `report_cycle_returns_ok_when_all_pass`, `run_cycle_runs_without_error`) reproduce on `main` and are unrelated to this change — they appear to depend on a Python worker environment.

https://claude.ai/code/session_01PjsEj2qWeHeH8b6eS8RENB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjsEj2qWeHeH8b6eS8RENB)_