### PR TITLE
Track PEP 810 lazy imports in dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.6#e4c7f357777a2fdd34dbe6a98b1b7d3e7488f675"
 dependencies = [
  "aho-corasick",
  "bitflags 2.11.0",
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_parser"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.6#e4c7f357777a2fdd34dbe6a98b1b7d3e7488f675"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.6#e4c7f357777a2fdd34dbe6a98b1b7d3e7488f675"
 dependencies = [
  "itertools",
  "ruff_source_file",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.6#e4c7f357777a2fdd34dbe6a98b1b7d3e7488f675"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.6#e4c7f357777a2fdd34dbe6a98b1b7d3e7488f675"
 dependencies = [
  "get-size2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ license = "MIT"
 async-channel = "2"
 salsa = "0.26"
 ignore = "0.4"
-ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.15.4" }
-ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.4" }
-ruff_source_file = { git = "https://github.com/astral-sh/ruff", tag = "0.15.4" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff", tag = "0.15.4" }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.15.6" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.6" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff", tag = "0.15.6" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff", tag = "0.15.6" }
 rayon = "1"
 miette = { version = "7", features = ["fancy", "syntect-highlighter"] }
 owo-colors = { version = "4", features = ["supports-color"] }

--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -182,6 +182,24 @@ fn collect_local_imports(
                     }
                 }
             }
+            Stmt::Assign(s) => {
+                // PEP 810 transitional mechanism: a package `__init__.py` may
+                // declare `__lazy_modules__ = ["sub_a", "sub_b"]` to mark its
+                // submodules as lazily-importable from the package on Python
+                // 3.15+. Treat each entry as a static dependency so that
+                // editing the submodule re-runs tests that touch the package.
+                if let Some(names) = lazy_modules_targets(&s.targets, &s.value) {
+                    add_lazy_module_siblings(root, file, names, seen, result);
+                }
+            }
+            Stmt::AnnAssign(s) => {
+                // `__lazy_modules__: list[str] = [...]` form.
+                if let Some(value) = s.value.as_deref()
+                    && let Some(names) = lazy_modules_ann_target(&s.target, value)
+                {
+                    add_lazy_module_siblings(root, file, names, seen, result);
+                }
+            }
             _ => {
                 // Imports inside `if __TRYKE_TESTING__:` participate in the
                 // static import graph so `--changed` mode can precisely
@@ -190,6 +208,63 @@ fn collect_local_imports(
                     collect_local_imports(root, file, inner, seen, result);
                 }
             }
+        }
+    }
+}
+
+/// If `value` is a list literal of string literals AND `targets` is the single
+/// name `__lazy_modules__`, return the list contents as borrowed strings.
+fn lazy_modules_targets<'a>(targets: &[Expr], value: &'a Expr) -> Option<Vec<&'a str>> {
+    let [Expr::Name(n)] = targets else {
+        return None;
+    };
+    if n.id.as_str() != "__lazy_modules__" {
+        return None;
+    }
+    string_list_entries(value)
+}
+
+/// `__lazy_modules__: list[str] = [...]` annotated-assignment variant.
+fn lazy_modules_ann_target<'a>(target: &Expr, value: &'a Expr) -> Option<Vec<&'a str>> {
+    let Expr::Name(n) = target else {
+        return None;
+    };
+    if n.id.as_str() != "__lazy_modules__" {
+        return None;
+    }
+    string_list_entries(value)
+}
+
+fn string_list_entries(value: &Expr) -> Option<Vec<&str>> {
+    let Expr::List(list) = value else {
+        return None;
+    };
+    list.elts
+        .iter()
+        .map(|elt| match elt {
+            Expr::StringLiteral(s) => Some(s.value.to_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Resolve each name in `__lazy_modules__` as a sibling of `file` (the
+/// declaring `__init__.py`) and add the resolved paths as dependencies.
+fn add_lazy_module_siblings(
+    root: &Path,
+    file: &Path,
+    names: Vec<&str>,
+    seen: &mut std::collections::HashSet<PathBuf>,
+    result: &mut Vec<PathBuf>,
+) {
+    let Some(base) = file.parent() else {
+        return;
+    };
+    for name in names {
+        if let Some(path) = resolve_relative_import_path(root, base, name)
+            && seen.insert(path.clone())
+        {
+            result.push(path);
         }
     }
 }
@@ -2360,6 +2435,133 @@ def my_func():
         let file = root.join("test_foo.py");
         let imports = extract_local_imports(root, &file, &parsed.syntax().body);
         assert_eq!(imports.len(), 1);
+    }
+
+    // PEP 810: `lazy import` and `lazy from` parse as the same AST nodes as
+    // their eager counterparts (with `is_lazy=true`), so the static
+    // dependency graph treats them identically — editing the lazily-imported
+    // file still re-runs dependents under `--changed`.
+    #[test]
+    fn extract_local_imports_lazy_absolute() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::write(root.join("utils.py"), "").expect("write");
+        let source = "lazy import utils\n";
+        let parsed = parse_module(source).expect("parse");
+        let file = root.join("test_foo.py");
+        let imports = extract_local_imports(root, &file, &parsed.syntax().body);
+        assert_eq!(imports, vec![root.join("utils.py")]);
+    }
+
+    #[test]
+    fn extract_local_imports_lazy_from() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let pkg = root.join("pkg");
+        fs::create_dir_all(&pkg).expect("mkdir");
+        fs::write(pkg.join("__init__.py"), "").expect("write");
+        fs::write(pkg.join("helpers.py"), "").expect("write");
+        let source = "lazy from pkg import helpers\n";
+        let parsed = parse_module(source).expect("parse");
+        let file = root.join("test_foo.py");
+        let imports = extract_local_imports(root, &file, &parsed.syntax().body);
+        assert_eq!(
+            imports,
+            vec![pkg.join("__init__.py"), pkg.join("helpers.py"),]
+        );
+    }
+
+    #[test]
+    fn extract_local_imports_lazy_is_not_dynamic() {
+        // `lazy import` is statically visible — `has_dynamic_imports` must
+        // not flag it, otherwise `--changed` falls back to always-dirty.
+        let source = "lazy import utils\nlazy from pkg import sub\n";
+        let parsed = parse_module(source).expect("parse");
+        assert!(!has_dynamic_imports(&parsed.syntax().body));
+    }
+
+    // PEP 810 transitional mechanism: a package's `__init__.py` may declare
+    // `__lazy_modules__ = ["sub"]` to expose `sub` as a lazy attribute on
+    // 3.15+. We treat each entry as a static sibling-submodule dependency so
+    // edits to `pkg/sub.py` mark `pkg/__init__.py` dirty.
+    #[test]
+    fn extract_local_imports_lazy_modules_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let pkg = root.join("pkg");
+        fs::create_dir_all(&pkg).expect("mkdir");
+        fs::write(pkg.join("__init__.py"), "").expect("write");
+        fs::write(pkg.join("heavy.py"), "").expect("write");
+        fs::write(pkg.join("other.py"), "").expect("write");
+        let source = "__lazy_modules__ = [\"heavy\", \"other\"]\n";
+        let parsed = parse_module(source).expect("parse");
+        let file = pkg.join("__init__.py");
+        let imports = extract_local_imports(root, &file, &parsed.syntax().body);
+        assert_eq!(imports, vec![pkg.join("heavy.py"), pkg.join("other.py")]);
+    }
+
+    #[test]
+    fn extract_local_imports_lazy_modules_list_annotated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let pkg = root.join("pkg");
+        fs::create_dir_all(&pkg).expect("mkdir");
+        fs::write(pkg.join("__init__.py"), "").expect("write");
+        fs::write(pkg.join("heavy.py"), "").expect("write");
+        let source = "__lazy_modules__: list[str] = [\"heavy\"]\n";
+        let parsed = parse_module(source).expect("parse");
+        let file = pkg.join("__init__.py");
+        let imports = extract_local_imports(root, &file, &parsed.syntax().body);
+        assert_eq!(imports, vec![pkg.join("heavy.py")]);
+    }
+
+    #[test]
+    fn extract_local_imports_lazy_modules_resolves_subpackage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let pkg = root.join("pkg");
+        let nested = pkg.join("nested");
+        fs::create_dir_all(&nested).expect("mkdir");
+        fs::write(pkg.join("__init__.py"), "").expect("write");
+        fs::write(nested.join("__init__.py"), "").expect("write");
+        let source = "__lazy_modules__ = [\"nested\"]\n";
+        let parsed = parse_module(source).expect("parse");
+        let file = pkg.join("__init__.py");
+        let imports = extract_local_imports(root, &file, &parsed.syntax().body);
+        assert_eq!(imports, vec![nested.join("__init__.py")]);
+    }
+
+    #[test]
+    fn extract_local_imports_lazy_modules_skips_non_string_entries() {
+        // Mixed-type list (e.g. `[name, "other"]`) is not a valid PEP 810
+        // declaration and is ignored entirely rather than partially honored.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let pkg = root.join("pkg");
+        fs::create_dir_all(&pkg).expect("mkdir");
+        fs::write(pkg.join("__init__.py"), "").expect("write");
+        fs::write(pkg.join("other.py"), "").expect("write");
+        let source = "__lazy_modules__ = [name, \"other\"]\n";
+        let parsed = parse_module(source).expect("parse");
+        let file = pkg.join("__init__.py");
+        let imports = extract_local_imports(root, &file, &parsed.syntax().body);
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn extract_local_imports_lazy_modules_only_when_named_correctly() {
+        // A list literal bound to any other name is not a PEP 810 marker.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let pkg = root.join("pkg");
+        fs::create_dir_all(&pkg).expect("mkdir");
+        fs::write(pkg.join("__init__.py"), "").expect("write");
+        fs::write(pkg.join("heavy.py"), "").expect("write");
+        let source = "__all__ = [\"heavy\"]\n";
+        let parsed = parse_module(source).expect("parse");
+        let file = pkg.join("__init__.py");
+        let imports = extract_local_imports(root, &file, &parsed.syntax().body);
+        assert!(imports.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Bump Ruff `0.15.4` → `0.15.6` so the parser accepts PEP 810 `lazy import` / `lazy from` syntax (Ruff [#23755](https://github.com/astral-sh/ruff/pull/23755)).
- Lazy imports flow through the existing `Stmt::Import` / `Stmt::ImportFrom` arms unchanged, so `tryke test --changed` correctly re-runs dependents when a lazily imported file is edited.
- Recognize the PEP 810 transitional `__lazy_modules__ = [...]` declaration (bare and annotated forms) in package `__init__.py` files: each listed entry is resolved as a sibling submodule and added to the dependency graph, so edits to lazily-exposed submodules mark the package dirty.
- `has_dynamic_imports` is intentionally untouched — lazy imports parse as static import statements, so they are not flagged as dynamic and do not force always-dirty caching.

## Why this is enough
- `python/tryke/worker.py::_reload` needs no change: `importlib.reload` / `importlib.import_module` are transparent to lazy imports. A reified module lives in `sys.modules` exactly like an eager one; an unreified lazy reference goes through the normal import machinery (reading disk fresh) on first access. No `sys.lazy_modules` cleanup is required.
- No new config knob — Python version policy is already captured by `requires-python`.

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --exclude tryke` — 408 tests pass, including 8 new tests in `tryke_discovery`:
  - `extract_local_imports_lazy_absolute` / `_lazy_from`
  - `extract_local_imports_lazy_is_not_dynamic`
  - `extract_local_imports_lazy_modules_list` / `_annotated` / `_resolves_subpackage`
  - `extract_local_imports_lazy_modules_skips_non_string_entries`
  - `extract_local_imports_lazy_modules_only_when_named_correctly`
- [x] `uvx prek run -a` — all hooks pass (rustfmt, clippy, ruff check/format, ty, markdown, etc.)
- [ ] `cargo test -p tryke` — pre-existing env-dependent failures (sandbox has Python 3.11; tryke requires ≥3.12). Reproduces on `main`. Re-run in CI to confirm.
- [ ] `cargo run test --reporter llm` — same env constraint; will run in CI.

## References
- [PEP 810 – Explicit lazy imports](https://peps.python.org/pep-0810/)
- [Ruff CHANGELOG (0.15.6)](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md)
- [PEP 810 discussion thread](https://discuss.python.org/t/pep-810-explicit-lazy-imports/104131)

https://claude.ai/code/session_01EVzKygqRthbdsz1t7jA3cP

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVzKygqRthbdsz1t7jA3cP)_