### PR TITLE
Restrict discovery walk and skip import graph when paths are passed

### DIFF
--- a/crates/tryke/src/discovery.rs
+++ b/crates/tryke/src/discovery.rs
@@ -1,8 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use log::{debug, warn};
 use tryke_config::load_effective_config;
 use tryke_discovery::Discoverer;
+use tryke_types::filter::PathSpec;
 use tryke_types::{DiscoveryWarning, DiscoveryWarningKind, HookItem};
 
 use crate::git::resolve_changed_files;
@@ -134,6 +135,86 @@ pub fn discover_tests(
             warnings,
         }
     }
+}
+
+/// Discover tests restricted to the given path specs. Skips the full
+/// project walk and the import-graph build, since path-restricted runs
+/// don't drive change-based selection. Falls back to `discover_tests`
+/// if any spec resolves to a nonexistent file or escapes the project
+/// root — the existing post-filter (`TestFilter::apply`) still runs in
+/// `main` and handles suffix-match semantics in that case.
+pub fn discover_tests_for_paths(
+    root: &Path,
+    path_specs: &[PathSpec],
+    excludes: &[String],
+) -> DiscoverySelection {
+    let walk_roots = match resolve_walk_roots(root, path_specs) {
+        Some(roots) => roots,
+        None => {
+            debug!("discover_tests_for_paths: falling back to full discovery");
+            return discover_tests(root, false, None, excludes);
+        }
+    };
+
+    let mut discoverer = Discoverer::new_with_excludes(root, excludes);
+    let tests = discoverer.rediscover_restricted(&walk_roots);
+    let warnings = all_discovery_warnings(&discoverer);
+    let hooks = discoverer.hooks();
+    DiscoverySelection {
+        tests,
+        hooks,
+        changed_files: None,
+        changed_prefix_len: None,
+        warnings,
+    }
+}
+
+/// Translate `PathSpec`s into a deduplicated list of filesystem walk
+/// roots. Returns `None` if any spec resolves to a missing path or
+/// escapes `root`, signalling the caller to fall back to the full walk.
+fn resolve_walk_roots(root: &Path, path_specs: &[PathSpec]) -> Option<Vec<PathBuf>> {
+    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let mut walk_roots: Vec<PathBuf> = Vec::with_capacity(path_specs.len());
+    for spec in path_specs {
+        let raw = match spec {
+            PathSpec::File(p) | PathSpec::FileLine(p, _) => p.clone(),
+        };
+        let abs = if raw.is_absolute() {
+            raw
+        } else {
+            root.join(&raw)
+        };
+        let Ok(resolved) = abs.canonicalize() else {
+            debug!(
+                "discover_tests_for_paths: {} does not exist on disk",
+                abs.display()
+            );
+            return None;
+        };
+        if !resolved.starts_with(&canonical_root) {
+            warn!(
+                "discover_tests_for_paths: {} is outside project root {}, falling back",
+                resolved.display(),
+                canonical_root.display()
+            );
+            return None;
+        }
+        // `.py` files take the single-file fast path inside
+        // `collect_python_files_restricted`; directories trigger a walk;
+        // non-`.py` files yield no tests (the extension filter drops
+        // them) which mirrors the existing post-filter semantics.
+        walk_roots.push(resolved);
+    }
+
+    // Dedupe by ancestry: a file under a kept directory is redundant.
+    walk_roots.sort_by_key(|p| p.components().count());
+    let mut deduped: Vec<PathBuf> = Vec::new();
+    for r in walk_roots {
+        if !deduped.iter().any(|kept| r.starts_with(kept)) {
+            deduped.push(r);
+        }
+    }
+    Some(deduped)
 }
 
 /// Discover all tests but place changed tests first in the returned list.
@@ -404,6 +485,163 @@ mod tests {
         assert!(
             file_names.contains(&"test_dyn.py"),
             "warning should reference test_dyn.py, got: {file_names:?}"
+        );
+    }
+
+    // --- discover_tests_for_paths tests ---
+
+    fn make_project(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("pyproject.toml"), "").expect("write pyproject.toml");
+        for (rel, content) in files {
+            let path = dir.path().join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create_dir_all");
+            }
+            std::fs::write(&path, content).expect("write file");
+        }
+        dir
+    }
+
+    fn pathspec_file(p: &str) -> PathSpec {
+        PathSpec::File(PathBuf::from(p))
+    }
+
+    #[test]
+    fn for_paths_single_file_finds_only_that_file_tests() {
+        let dir = make_project(&[
+            (
+                "test_a.py",
+                "from tryke import test\n@test\ndef test_a(): pass\n",
+            ),
+            (
+                "test_b.py",
+                "from tryke import test\n@test\ndef test_b(): pass\n",
+            ),
+        ]);
+        let specs = vec![pathspec_file("test_a.py")];
+        let discovered = discover_tests_for_paths(dir.path(), &specs, &[]);
+        let names: Vec<&str> = discovered.tests.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["test_a"], "got: {names:?}");
+    }
+
+    #[test]
+    fn for_paths_directory_walks_only_subtree() {
+        let dir = make_project(&[
+            (
+                "tests/test_a.py",
+                "from tryke import test\n@test\ndef test_a(): pass\n",
+            ),
+            (
+                "tests/test_b.py",
+                "from tryke import test\n@test\ndef test_b(): pass\n",
+            ),
+            (
+                "other/test_c.py",
+                "from tryke import test\n@test\ndef test_c(): pass\n",
+            ),
+        ]);
+        let specs = vec![pathspec_file("tests")];
+        let discovered = discover_tests_for_paths(dir.path(), &specs, &[]);
+        let mut names: Vec<&str> = discovered.tests.iter().map(|t| t.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["test_a", "test_b"], "got: {names:?}");
+    }
+
+    #[test]
+    fn for_paths_mixed_file_and_dir_dedupe_by_ancestry() {
+        let dir = make_project(&[
+            (
+                "tests/test_a.py",
+                "from tryke import test\n@test\ndef test_a(): pass\n",
+            ),
+            (
+                "tests/test_b.py",
+                "from tryke import test\n@test\ndef test_b(): pass\n",
+            ),
+        ]);
+        // Dir + a contained file should dedupe to just the dir; both
+        // tests should be discovered (not just test_a).
+        let specs = vec![pathspec_file("tests"), pathspec_file("tests/test_a.py")];
+        let discovered = discover_tests_for_paths(dir.path(), &specs, &[]);
+        let mut names: Vec<&str> = discovered.tests.iter().map(|t| t.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["test_a", "test_b"], "got: {names:?}");
+    }
+
+    #[test]
+    fn for_paths_nonexistent_falls_back_to_full_walk() {
+        let dir = make_project(&[(
+            "test_real.py",
+            "from tryke import test\n@test\ndef test_real(): pass\n",
+        )]);
+        let specs = vec![pathspec_file("does_not_exist.py")];
+        let discovered = discover_tests_for_paths(dir.path(), &specs, &[]);
+        // Fallback runs full discovery; the post-filter (applied in
+        // main, not here) is what would narrow the set. So we expect
+        // every test in the project here.
+        let names: Vec<&str> = discovered.tests.iter().map(|t| t.name.as_str()).collect();
+        assert!(
+            names.contains(&"test_real"),
+            "fallback should run full discovery: {names:?}"
+        );
+    }
+
+    #[test]
+    fn for_paths_file_line_spec_walks_just_that_file() {
+        let dir = make_project(&[
+            (
+                "test_a.py",
+                "from tryke import test\n@test\ndef test_a(): pass\n",
+            ),
+            (
+                "test_b.py",
+                "from tryke import test\n@test\ndef test_b(): pass\n",
+            ),
+        ]);
+        let specs = vec![PathSpec::FileLine(PathBuf::from("test_a.py"), 2)];
+        let discovered = discover_tests_for_paths(dir.path(), &specs, &[]);
+        let names: Vec<&str> = discovered.tests.iter().map(|t| t.name.as_str()).collect();
+        // The walk is restricted to test_a.py — test_b should not appear
+        // even before the post-filter narrows by line.
+        assert_eq!(names, vec!["test_a"], "got: {names:?}");
+    }
+
+    #[test]
+    fn for_paths_excludes_honored_inside_walk_root() {
+        let dir = make_project(&[
+            (
+                "tests/test_a.py",
+                "from tryke import test\n@test\ndef test_a(): pass\n",
+            ),
+            (
+                "tests/skip/test_skipme.py",
+                "from tryke import test\n@test\ndef test_skipme(): pass\n",
+            ),
+        ]);
+        let specs = vec![pathspec_file("tests")];
+        let discovered = discover_tests_for_paths(dir.path(), &specs, &["tests/skip".to_string()]);
+        let names: Vec<&str> = discovered.tests.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["test_a"], "got: {names:?}");
+    }
+
+    #[test]
+    fn for_paths_outside_root_falls_back_to_full_walk() {
+        let dir = make_project(&[(
+            "test_real.py",
+            "from tryke import test\n@test\ndef test_real(): pass\n",
+        )]);
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("stray.py");
+        std::fs::write(&outside_file, "x = 1\n").expect("write stray");
+        let specs = vec![PathSpec::File(outside_file)];
+        let discovered = discover_tests_for_paths(dir.path(), &specs, &[]);
+        let names: Vec<&str> = discovered.tests.iter().map(|t| t.name.as_str()).collect();
+        // Out-of-root spec falls back to full discovery rather than
+        // attempting to walk outside the project.
+        assert!(
+            names.contains(&"test_real"),
+            "fallback should still find in-project tests: {names:?}"
         );
     }
 }

--- a/crates/tryke/src/discovery.rs
+++ b/crates/tryke/src/discovery.rs
@@ -199,10 +199,10 @@ fn resolve_walk_roots(root: &Path, path_specs: &[PathSpec]) -> Option<Vec<PathBu
             );
             return None;
         }
-        // `.py` files take the single-file fast path inside
-        // `collect_python_files_restricted`; directories trigger a walk;
-        // non-`.py` files yield no tests (the extension filter drops
-        // them) which mirrors the existing post-filter semantics.
+        // Both files and directories are walked via `WalkBuilder` inside
+        // `collect_python_files_restricted`; non-`.py` files yield no
+        // tests (the extension filter drops them) which mirrors the
+        // existing post-filter semantics.
         walk_roots.push(resolved);
     }
 

--- a/crates/tryke/src/main.rs
+++ b/crates/tryke/src/main.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use clap::Parser;
 use log::debug;
 use tryke::cli::{Cli, Commands, ReporterFormat};
-use tryke::discovery::{discover_tests, discover_tests_changed_first, resolved_excludes};
+use tryke::discovery::{
+    discover_tests, discover_tests_changed_first, discover_tests_for_paths, resolved_excludes,
+};
 use tryke::execution::run_tests;
 use tryke::graph::{run_fixture_graph, run_graph};
 use tryke::watch::run_watch;
@@ -105,7 +107,13 @@ fn main() -> Result<()> {
                 .map_err(|e| anyhow::anyhow!(e))?;
 
             let discovery_start = Instant::now();
-            let discovered = if *changed_first {
+            // Fast path: explicit paths without change-based selection
+            // skip the full project walk and import-graph build. The
+            // post-filter (`test_filter.apply` below) still runs to
+            // honor `:line` specs, `--filter`, and `--markers`.
+            let discovered = if !paths.is_empty() && !*changed && !*changed_first {
+                discover_tests_for_paths(root_path, &test_filter.path_specs, &excludes)
+            } else if *changed_first {
                 discover_tests_changed_first(root_path, base_branch.as_deref(), &excludes)
             } else {
                 discover_tests(root_path, *changed, base_branch.as_deref(), &excludes)

--- a/crates/tryke_discovery/src/discoverer.rs
+++ b/crates/tryke_discovery/src/discoverer.rs
@@ -226,6 +226,121 @@ impl Discoverer {
         tests
     }
 
+    /// Discover tests within the given `walk_roots` only. Used for the
+    /// `tryke test path/...` fast path: skips the full-project walk and
+    /// the import-graph build (phase 5), since path-restricted runs
+    /// don't drive change-based selection.
+    ///
+    /// Mutates `self.results` / `self.inputs` only for files within the
+    /// walk roots. The caller is expected to use a fresh `Discoverer`
+    /// here — the long-lived `Discoverer` used by server/watch must not
+    /// see this method, since skipping import-graph maintenance would
+    /// corrupt their incremental state.
+    pub fn rediscover_restricted(&mut self, walk_roots: &[PathBuf]) -> Vec<TestItem> {
+        let mut paths =
+            crate::collect_python_files_restricted(&self.root, walk_roots, &self.excludes);
+        paths.sort();
+        debug!(
+            "rediscover_restricted: found {} python files across {} walk roots",
+            paths.len(),
+            walk_roots.len()
+        );
+        let path_set: HashSet<PathBuf> = paths.iter().cloned().collect();
+
+        // Phase 1: parallel stat + cache lookup (same as `rediscover`).
+        let cache_ref = &self.cache;
+        let keyed: Vec<FileWork> = paths
+            .par_iter()
+            .map(|path| Self::prepare_work(cache_ref, path))
+            .collect();
+
+        // Phase 2 (`self.cache.retain`) intentionally skipped: we walked
+        // a deliberate subset, so we must not evict entries for files
+        // outside the walk roots — they're still valid for the next
+        // full `rediscover`.
+
+        // Phase 3: serial salsa ingest.
+        let mut misses: Vec<PathBuf> = Vec::new();
+        let mut hit_count = 0usize;
+        for work in keyed {
+            match work {
+                FileWork::Hit { path, data, key } => {
+                    self.results.insert(path.clone(), data);
+                    self.cache_keys_hit
+                        .entry(path)
+                        .and_modify(|k| *k = key)
+                        .or_insert(key);
+                    hit_count += 1;
+                }
+                FileWork::Miss { path, source, key } => {
+                    self.upsert_source(&path, source);
+                    self.cache_keys_hit.insert(path.clone(), key);
+                    misses.push(path);
+                }
+                FileWork::StatError { path } => {
+                    warn!(
+                        "rediscover_restricted: stat failed for {}, skipping",
+                        path.display()
+                    );
+                }
+            }
+        }
+        debug!(
+            "rediscover_restricted: cache hits {}/{} ({} parses pending)",
+            hit_count,
+            paths.len(),
+            misses.len()
+        );
+
+        // Phase 4: parallel parse for misses.
+        let miss_snapshots: Vec<(PathBuf, SourceFile)> = misses
+            .iter()
+            .filter_map(|p| self.inputs.get(p).map(|f| (p.clone(), *f)))
+            .collect();
+        let miss_results: Vec<(PathBuf, DiscoveredFile)> = self.parse_in_parallel(&miss_snapshots);
+        for (path, data) in &miss_results {
+            self.results.insert(path.clone(), data.clone());
+            if let Some(&key) = self.cache_keys_hit.get(path) {
+                self.cache.insert(path.clone(), key, data.clone());
+            }
+        }
+
+        // Phase 5 (full import-graph rebuild) intentionally skipped:
+        // restricted discovery doesn't drive change-based selection, so
+        // the import edges aren't consulted. We do a lightweight pass to
+        // mark always-dirty files so dynamic-import warnings still
+        // surface for the discovered subset.
+        let dynamic_paths: Vec<PathBuf> = self
+            .results
+            .iter()
+            .filter(|(p, r)| path_set.contains(*p) && r.dynamic_imports)
+            .map(|(p, _)| p.clone())
+            .collect();
+        for path in dynamic_paths {
+            self.import_graph.mark_always_dirty(path);
+        }
+
+        self.project_files.clone_from(&path_set);
+
+        // Phase 6: persist cache.
+        if let Err(err) = self.cache.save() {
+            warn!("rediscover_restricted: failed to save discovery cache: {err}");
+        }
+
+        // Collect tests only from the restricted set so the return is
+        // independent of any prior state on `self.results`.
+        let tests: Vec<TestItem> = path_set
+            .iter()
+            .filter_map(|p| self.results.get(p))
+            .flat_map(|r| r.parsed.tests.clone())
+            .collect();
+        debug!(
+            "rediscover_restricted: discovered {} tests total",
+            tests.len()
+        );
+        tests
+    }
+
     /// Stat `path` and consult the disk cache. On a cache hit, return
     /// the cached `DiscoveredFile` without reading the file. On a
     /// miss, read the file text so the parse phase doesn't stat-then-
@@ -986,6 +1101,61 @@ mod tests {
             test_entry.imports.is_empty(),
             "without src=[\"python\"], mypkg.mod should not resolve; got {:?}",
             test_entry.imports
+        );
+    }
+
+    #[test]
+    fn rediscover_restricted_skips_import_graph() {
+        // utils.py is imported by test_foo.py. After rediscover_restricted
+        // walks only test_foo.py, the import graph must remain empty —
+        // proving phase 5 was skipped. The discovered tests must still
+        // come from the restricted file.
+        let utils_src = "def helper(): pass\n";
+        let test_foo_src = "from utils import helper\n@test\ndef test_foo():\n    pass\n";
+        let other_src = "@test\ndef test_other():\n    pass\n";
+        let dir = make_project(&[
+            ("utils.py", utils_src),
+            ("test_foo.py", test_foo_src),
+            ("test_other.py", other_src),
+        ]);
+        let mut discoverer = Discoverer::new(dir.path());
+        let walk_roots = vec![dir.path().join("test_foo.py")];
+        let tests = discoverer.rediscover_restricted(&walk_roots);
+
+        let names: Vec<&str> = tests.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["test_foo"], "got: {names:?}");
+
+        let summary = discoverer.import_graph_summary();
+        let with_edges: Vec<&Path> = summary
+            .iter()
+            .filter(|e| !e.imports.is_empty() || !e.imported_by.is_empty())
+            .map(|e| e.file.as_path())
+            .collect();
+        assert!(
+            with_edges.is_empty(),
+            "phase 5 was skipped, so no import edges should be recorded; got entries with edges: {with_edges:?}"
+        );
+    }
+
+    #[test]
+    fn rediscover_restricted_marks_dynamic_imports_for_warnings() {
+        // Even though we skip the full graph build, dynamic-import
+        // warnings still need to surface for the walked subset.
+        let dynamic_src = "import importlib\nmod = importlib.import_module('os')\nfrom tryke import test\n@test\ndef test_dyn(): pass\n";
+        let dir = make_project(&[("test_dyn.py", dynamic_src)]);
+        let mut discoverer = Discoverer::new(dir.path());
+        let walk_roots = vec![dir.path().join("test_dyn.py")];
+        discoverer.rediscover_restricted(&walk_roots);
+
+        let dyn_files = discoverer.dynamic_import_files();
+        let names: Vec<&str> = dyn_files
+            .iter()
+            .filter_map(|p| p.file_name())
+            .filter_map(|n| n.to_str())
+            .collect();
+        assert!(
+            names.contains(&"test_dyn.py"),
+            "dynamic-import file should be tracked: {names:?}"
         );
     }
 }

--- a/crates/tryke_discovery/src/discoverer.rs
+++ b/crates/tryke_discovery/src/discoverer.rs
@@ -316,11 +316,10 @@ impl Discoverer {
         // the import edges aren't consulted. We do a lightweight pass to
         // mark always-dirty files so dynamic-import warnings still
         // surface for the discovered subset.
-        let dynamic_paths: Vec<PathBuf> = self
-            .results
+        let dynamic_paths: Vec<PathBuf> = path_set
             .iter()
-            .filter(|(p, r)| path_set.contains(*p) && r.dynamic_imports)
-            .map(|(p, _)| p.clone())
+            .filter(|p| self.results.get(p).is_some_and(|r| r.dynamic_imports))
+            .cloned()
             .collect();
         for path in dynamic_paths {
             self.import_graph.mark_always_dirty(path);

--- a/crates/tryke_discovery/src/discoverer.rs
+++ b/crates/tryke_discovery/src/discoverer.rs
@@ -231,15 +231,21 @@ impl Discoverer {
     /// the import-graph build (phase 5), since path-restricted runs
     /// don't drive change-based selection.
     ///
-    /// Mutates `self.results` / `self.inputs` only for files within the
-    /// walk roots. The caller is expected to use a fresh `Discoverer`
-    /// here — the long-lived `Discoverer` used by server/watch must not
-    /// see this method, since skipping import-graph maintenance would
-    /// corrupt their incremental state.
+    /// Resets `results`, `inputs`, and the import graph (incl.
+    /// `always_dirty`) up front so this method's "subset only" semantics
+    /// hold even if the `Discoverer` is accidentally reused across calls.
+    /// The long-lived `Discoverer` used by server/watch must not call
+    /// this method — skipping import-graph maintenance would corrupt
+    /// their incremental state.
     pub fn rediscover_restricted(&mut self, walk_roots: &[PathBuf]) -> Vec<TestItem> {
-        let mut paths =
-            crate::collect_python_files_restricted(&self.root, walk_roots, &self.excludes);
-        paths.sort();
+        // Defensive reset: if a non-fresh Discoverer reaches this method,
+        // stale entries here would leak into `tests()` / `hooks()` and
+        // `always_dirty` lookups for files outside `walk_roots`.
+        self.results.clear();
+        self.inputs.clear();
+        self.import_graph = ImportGraph::default();
+
+        let paths = crate::collect_python_files_restricted(&self.root, walk_roots, &self.excludes);
         debug!(
             "rediscover_restricted: found {} python files across {} walk roots",
             paths.len(),

--- a/crates/tryke_discovery/src/discoverer.rs
+++ b/crates/tryke_discovery/src/discoverer.rs
@@ -318,7 +318,7 @@ impl Discoverer {
         // surface for the discovered subset.
         let dynamic_paths: Vec<PathBuf> = path_set
             .iter()
-            .filter(|p| self.results.get(p).is_some_and(|r| r.dynamic_imports))
+            .filter(|p| self.results.get(*p).is_some_and(|r| r.dynamic_imports))
             .cloned()
             .collect();
         for path in dynamic_paths {
@@ -333,8 +333,10 @@ impl Discoverer {
         }
 
         // Collect tests only from the restricted set so the return is
-        // independent of any prior state on `self.results`.
-        let tests: Vec<TestItem> = path_set
+        // independent of any prior state on `self.results`. Iterate the
+        // sorted `paths` Vec (not the HashSet) so the output order is
+        // deterministic across runs.
+        let tests: Vec<TestItem> = paths
             .iter()
             .filter_map(|p| self.results.get(p))
             .flat_map(|r| r.parsed.tests.clone())

--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -81,13 +81,9 @@ pub(crate) fn collect_python_files_restricted(
     };
     let mut paths: Vec<PathBuf> = Vec::new();
     for walk_root in walk_roots {
-        if walk_root.is_file() {
-            // Single-file fast path: skip WalkBuilder entirely.
-            if walk_root.extension().is_some_and(|ext| ext == "py") && !is_excluded(walk_root) {
-                paths.push(walk_root.clone());
-            }
-            continue;
-        }
+        // `WalkBuilder::new(p)` works on either a directory or a single
+        // file; routing both through it keeps gitignore / .ignore / hidden
+        // semantics consistent with `collect_python_files`.
         for entry in WalkBuilder::new(walk_root).build().filter_map(Result::ok) {
             if !entry.file_type().is_some_and(|t| t.is_file()) {
                 continue;

--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -59,6 +59,54 @@ pub(crate) fn collect_python_files(root: &Path, excludes: &[String]) -> Vec<Path
         .collect()
 }
 
+/// Like `collect_python_files`, but walks only the supplied `walk_roots`
+/// instead of the whole project. Used by the path-restricted discovery
+/// fast path (`Discoverer::rediscover_restricted`) so a `tryke test
+/// path/to/foo.py` invocation doesn't pay an O(project-files) walk.
+///
+/// `walk_roots` may contain absolute paths to either directories or
+/// individual `.py` files. The exclude matcher is anchored at
+/// `project_root` so `pyproject.toml` exclude patterns evaluate against
+/// project-relative paths exactly as in the full walk.
+pub(crate) fn collect_python_files_restricted(
+    project_root: &Path,
+    walk_roots: &[PathBuf],
+    excludes: &[String],
+) -> Vec<PathBuf> {
+    let exclude_matcher = build_excludes(project_root, excludes);
+    let is_excluded = |p: &Path| -> bool {
+        exclude_matcher
+            .matched_path_or_any_parents(p, false)
+            .is_ignore()
+    };
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for walk_root in walk_roots {
+        if walk_root.is_file() {
+            // Single-file fast path: skip WalkBuilder entirely.
+            if walk_root.extension().is_some_and(|ext| ext == "py") && !is_excluded(walk_root) {
+                paths.push(walk_root.clone());
+            }
+            continue;
+        }
+        for entry in WalkBuilder::new(walk_root).build().filter_map(Result::ok) {
+            if !entry.file_type().is_some_and(|t| t.is_file()) {
+                continue;
+            }
+            let path = entry.into_path();
+            if path.extension().is_none_or(|ext| ext != "py") {
+                continue;
+            }
+            if is_excluded(&path) {
+                continue;
+            }
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
 pub(crate) fn path_to_module(root: &Path, file: &Path) -> String {
     tryke_types::path_to_module(root, file).unwrap_or_default()
 }


### PR DESCRIPTION
## Summary

- When `tryke test path/...` is invoked without `--changed`/`--changed-first`, discovery now walks only the requested subtrees instead of the whole project, and skips the import-graph build (which is only consulted for change-based selection). Falls back to the existing full walk if any path is missing or escapes the project root.
- New `Discoverer::rediscover_restricted` method: runs phases 1, 3, 4, 6 plus a lightweight always-dirty pass so dynamic-import warnings still surface; deliberately skips phase 2 (cache retain) and phase 5 (full graph rebuild). The throwaway `Discoverer` used by the new fast path can never reach long-lived server/watch state.
- Server and `tryke watch` are intentionally unchanged — both depend on the cached `Discoverer` and the import graph for incremental work.

## Test plan

- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo test --workspace` — all suites pass (added 7 tests in `discovery.rs` + 2 in `discoverer.rs`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo run test --reporter llm` — 202 passed / 3 skipped / 3 xfailed / 1 todo
- [x] `uvx prek run -a` clean
- [x] Smoke check: `tryke test tests/test_worker.py --collect-only` collects 34 tests (vs 209 from full walk), confirming the restricted path is engaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)