### PR TITLE
Refresh stale tryke test banner version to 0.0.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ uvx tryke test
 ```
 
 ```text
-tryke test v0.0.18
+tryke test v0.0.23
 
 example.py:
   users

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ uvx tryke test
 ```
 
 ```text
-tryke test v0.0.18
+tryke test v0.0.23
 
 example.py:
   users


### PR DESCRIPTION
## Summary

Audited the docs site (`docs/`), `README.md`, and Rust/Python code comments for drift against current behavior. The codebase is in good shape — Python version support, CLI flags (`--changed`, `--changed-first`, `--base-branch`, `watch --all`, etc.), the Python API surface (`@test`, `@fixture` with `per=`, `Depends`, `describe`, `expect` matchers), the configuration keys, the discovery/PEP 810 lazy import notes, and the migration guide all line up with the implementation. No leftover `before_all` / `after_all` / `wrap_all` hook references survive in either docs or code.

The only discrepancy worth fixing was the example output banner. The reporter prints `tryke test v{CARGO_PKG_VERSION}` (`crates/tryke_reporter/src/text.rs`), but the static example in two places still showed `v0.0.18` while the workspace had shipped `0.0.23`.

- `README.md`: updated example banner `v0.0.18` → `v0.0.23`
- `docs/index.md`: same update on the landing page

(The "as of 0.0.21" mention in `docs/concepts/cases.md` refers to Astral's `ty` type checker version, not tryke, and is intentional — left as-is.)

## Test plan

- [x] `uvx prek run -a` passes (clippy, markdownlint, ruff, ty, etc.)
- [x] Diff is two single-line text edits inside fenced code blocks; no code or behavior change

https://claude.ai/code/session_019W2QN2kzjt2w1VWXy1Vpfv

---
_Generated by [Claude Code](https://claude.ai/code/session_019W2QN2kzjt2w1VWXy1Vpfv)_