### PR TITLE
Accept Annotated[T, Depends(...)] alongside default-form dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For more information, see the [documentation](https://tryke.dev/).
 Write a test.
 
 ```python
+from typing import Annotated
+
 import tryke as t
 
 
@@ -33,7 +35,7 @@ with t.describe("users"):
     # By default, fixtures run per-test
     # Fixtures can be composed by requesting other fixtures
     @t.fixture
-    def users(database: dict[str, dict[str, str]] = t.Depends(database)):
+    def users(database: Annotated[dict[str, dict[str, str]], t.Depends(database)]):
         database["users"] = {}
         return database["users"]
 
@@ -41,14 +43,14 @@ with t.describe("users"):
         # Define display labels for tests
         # Async tests are supported
         @t.test("returns a stored user")
-        async def test_get(users: dict[str, str] = t.Depends(users)):
+        async def test_get(users: Annotated[dict[str, str], t.Depends(users)]):
             users["alice"] = "alice@example.com"
             t.expect(users["alice"]).to_equal("alice@example.com")
 
     with t.describe("set"):
 
         @t.test("stores a new user")
-        async def test_set(users: dict[str, str] = t.Depends(users)):
+        async def test_set(users: Annotated[dict[str, str], t.Depends(users)]):
             users["bob"] = "bob@example.com"
             t.expect(users["bob"]).to_equal("bob@example.com")
 

--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -542,7 +542,8 @@ fn is_tryke_fixture_decorator(
     }
 }
 
-/// Extract function names from `Depends(name)` calls in parameter defaults.
+/// Extract function names from `Depends(name)` calls in parameter
+/// defaults *or* `Annotated[..., Depends(name), ...]` annotations.
 ///
 /// Malformed `Depends(...)` forms (attribute access, calls, no argument)
 /// push a human-readable diagnostic into `errors` rather than being
@@ -559,23 +560,23 @@ fn extract_depends_from_params(
 ) -> Vec<String> {
     let mut deps = Vec::new();
     for param in func.parameters.iter_non_variadic_params() {
-        let Some(default) = &param.default else {
-            continue;
-        };
-        let Expr::Call(call) = default.as_ref() else {
-            continue;
-        };
-        let is_depends = match call.func.as_ref() {
-            Expr::Name(n) => is_bare_tryke_symbol(n.id.as_str(), "Depends", top_body, aliases),
-            Expr::Attribute(a) => {
-                a.attr.id.as_str() == "Depends"
-                    && matches!(&*a.value, Expr::Name(n) if aliases.is_module(n.id.as_str()))
-            }
-            _ => false,
-        };
-        if !is_depends {
-            continue;
-        }
+        // Default-value form takes precedence over the Annotated form,
+        // matching the runtime resolver's behaviour.
+        let call = param
+            .default
+            .as_deref()
+            .and_then(|d| match d {
+                Expr::Call(c) if is_depends_call(&c.func, top_body, aliases) => Some(c),
+                _ => None,
+            })
+            .or_else(|| {
+                param
+                    .parameter
+                    .annotation
+                    .as_deref()
+                    .and_then(|a| find_depends_in_annotated(a, top_body, aliases))
+            });
+        let Some(call) = call else { continue };
         let line = u32::try_from(line_index.line_index(call.range.start()).get()).unwrap_or(0);
         let display_file = file.strip_prefix(root).unwrap_or(file).display();
         let param_name = param.parameter.name.id.as_str();
@@ -604,6 +605,65 @@ fn extract_depends_from_params(
         }
     }
     deps
+}
+
+/// Is `func` a reference to tryke's `Depends`? Recognises both bare
+/// (`Depends(...)`) and qualified (`tryke.Depends(...)`) forms,
+/// honouring import aliases tracked in `TrykeAliases`.
+fn is_depends_call(func: &Expr, top_body: &[Stmt], aliases: &TrykeAliases) -> bool {
+    match func {
+        Expr::Name(n) => is_bare_tryke_symbol(n.id.as_str(), "Depends", top_body, aliases),
+        Expr::Attribute(a) => {
+            a.attr.id.as_str() == "Depends"
+                && matches!(&*a.value, Expr::Name(n) if aliases.is_module(n.id.as_str()))
+        }
+        _ => false,
+    }
+}
+
+/// If `annotation` is `Annotated[T, ..., Depends(name), ...]`, return
+/// the `Depends(...)` call expression. The actual type sits in the
+/// first slice element; metadata follows. We accept the bare
+/// `Annotated` name plus `typing.Annotated` / `typing_extensions.Annotated`
+/// without tracking imports — Annotated has no other meaning in tryke
+/// fixtures, and being permissive here matches `FastAPI`'s behaviour.
+fn find_depends_in_annotated<'a>(
+    annotation: &'a Expr,
+    top_body: &[Stmt],
+    aliases: &TrykeAliases,
+) -> Option<&'a ruff_python_ast::ExprCall> {
+    let Expr::Subscript(sub) = annotation else {
+        return None;
+    };
+    if !is_annotated_marker(&sub.value) {
+        return None;
+    }
+    let elements: &[Expr] = match sub.slice.as_ref() {
+        Expr::Tuple(t) => &t.elts,
+        single => std::slice::from_ref(single),
+    };
+    // Skip the first element (the actual type); only metadata args can
+    // carry a Depends() marker.
+    elements.iter().skip(1).find_map(|meta| match meta {
+        Expr::Call(call) if is_depends_call(&call.func, top_body, aliases) => Some(call),
+        _ => None,
+    })
+}
+
+/// Recognises `Annotated`, `typing.Annotated`, and
+/// `typing_extensions.Annotated` as the subscripted value.
+fn is_annotated_marker(expr: &Expr) -> bool {
+    match expr {
+        Expr::Name(n) => n.id.as_str() == "Annotated",
+        Expr::Attribute(a) => {
+            a.attr.id.as_str() == "Annotated"
+                && matches!(
+                    &*a.value,
+                    Expr::Name(n) if matches!(n.id.as_str(), "typing" | "typing_extensions"),
+                )
+        }
+        _ => false,
+    }
 }
 
 /// Short, human-readable label for an AST expression kind. Used in
@@ -3316,6 +3376,142 @@ def test_add():
         assert_eq!(svc.depends_on, vec!["db"]);
         assert_eq!(parsed.errors.len(), 1);
         assert!(parsed.errors[0].contains("Depends(attribute)"));
+    }
+
+    #[test]
+    fn extracts_depends_from_annotated_param() {
+        let source = "\
+from typing import Annotated\n\
+@fixture(per=\"scope\")\ndef db(): pass\n\
+@fixture\ndef table(conn: Annotated[str, Depends(db)]): pass\n";
+        let (dir, file) = write_source(source);
+        let parsed =
+            parse_tests_from_source(dir.path(), &[dir.path().to_path_buf()], &file, source);
+        let table = parsed
+            .hooks
+            .iter()
+            .find(|h| h.name == "table")
+            .expect("table fixture");
+        assert_eq!(table.depends_on, vec!["db"]);
+        assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+    }
+
+    #[test]
+    fn extracts_depends_from_qualified_typing_annotated() {
+        let source = "\
+import typing\n\
+@fixture(per=\"scope\")\ndef db(): pass\n\
+@fixture\ndef table(conn: typing.Annotated[str, Depends(db)]): pass\n";
+        let (dir, file) = write_source(source);
+        let parsed =
+            parse_tests_from_source(dir.path(), &[dir.path().to_path_buf()], &file, source);
+        let table = parsed
+            .hooks
+            .iter()
+            .find(|h| h.name == "table")
+            .expect("table fixture");
+        assert_eq!(table.depends_on, vec!["db"]);
+    }
+
+    #[test]
+    fn annotated_with_extra_metadata_after_depends_still_extracts() {
+        let source = "\
+from typing import Annotated\n\
+@fixture(per=\"scope\")\ndef db(): pass\n\
+@fixture\ndef table(conn: Annotated[str, Depends(db), \"extra\"]): pass\n";
+        let (dir, file) = write_source(source);
+        let parsed =
+            parse_tests_from_source(dir.path(), &[dir.path().to_path_buf()], &file, source);
+        let table = parsed
+            .hooks
+            .iter()
+            .find(|h| h.name == "table")
+            .expect("table fixture");
+        assert_eq!(table.depends_on, vec!["db"]);
+    }
+
+    #[test]
+    fn annotated_with_metadata_before_depends_still_extracts() {
+        let source = "\
+from typing import Annotated\n\
+@fixture(per=\"scope\")\ndef db(): pass\n\
+@fixture\ndef table(conn: Annotated[str, \"first\", Depends(db)]): pass\n";
+        let (dir, file) = write_source(source);
+        let parsed =
+            parse_tests_from_source(dir.path(), &[dir.path().to_path_buf()], &file, source);
+        let table = parsed
+            .hooks
+            .iter()
+            .find(|h| h.name == "table")
+            .expect("table fixture");
+        assert_eq!(table.depends_on, vec!["db"]);
+    }
+
+    #[test]
+    fn annotated_without_depends_extracts_nothing() {
+        let source = "\
+from typing import Annotated\n\
+@fixture\ndef table(conn: Annotated[str, \"meta\"]): pass\n";
+        let (dir, file) = write_source(source);
+        let parsed =
+            parse_tests_from_source(dir.path(), &[dir.path().to_path_buf()], &file, source);
+        assert_eq!(parsed.hooks.len(), 1);
+        assert!(parsed.hooks[0].depends_on.is_empty());
+        assert!(parsed.errors.is_empty());
+    }
+
+    #[test]
+    fn annotated_depends_with_attribute_arg_is_a_discovery_error() {
+        let source = "\
+from typing import Annotated\n\
+@fixture\ndef svc(x: Annotated[int, Depends(mod.fn)]): pass\n";
+        let (dir, file) = write_source(source);
+        let parsed =
+            parse_tests_from_source(dir.path(), &[dir.path().to_path_buf()], &file, source);
+        assert_eq!(parsed.hooks.len(), 1);
+        assert!(parsed.hooks[0].depends_on.is_empty());
+        assert_eq!(parsed.errors.len(), 1);
+        assert!(parsed.errors[0].contains("Depends(attribute)"));
+    }
+
+    #[test]
+    fn default_depends_takes_precedence_over_annotated_depends() {
+        let source = "\
+from typing import Annotated\n\
+@fixture(per=\"scope\")\ndef db(): pass\n\
+@fixture(per=\"scope\")\ndef cache(): pass\n\
+@fixture\ndef svc(x: Annotated[int, Depends(cache)] = Depends(db)): pass\n";
+        let (dir, file) = write_source(source);
+        let parsed =
+            parse_tests_from_source(dir.path(), &[dir.path().to_path_buf()], &file, source);
+        let svc = parsed
+            .hooks
+            .iter()
+            .find(|h| h.name == "svc")
+            .expect("svc fixture");
+        assert_eq!(svc.depends_on, vec!["db"]);
+        assert!(parsed.errors.is_empty());
+    }
+
+    #[test]
+    fn mixed_default_and_annotated_depends_in_same_function() {
+        // The Annotated parameter has no default, so it must come first
+        // to satisfy Python's argument-order rules.
+        let source = "\
+from typing import Annotated\n\
+@fixture(per=\"scope\")\ndef db(): pass\n\
+@fixture(per=\"scope\")\ndef cache(): pass\n\
+@fixture\ndef svc(c: Annotated[int, Depends(cache)], d=Depends(db)): pass\n";
+        let (dir, file) = write_source(source);
+        let parsed =
+            parse_tests_from_source(dir.path(), &[dir.path().to_path_buf()], &file, source);
+        let svc = parsed
+            .hooks
+            .iter()
+            .find(|h| h.name == "svc")
+            .expect("svc fixture");
+        assert_eq!(svc.depends_on, vec!["cache", "db"]);
+        assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
     }
 
     #[test]

--- a/docs/concepts/cases.md
+++ b/docs/concepts/cases.md
@@ -49,9 +49,11 @@ with describe("arithmetic"):
 
 ### With `@fixture` and `Depends()`
 
-Case kwargs and fixture-injected kwargs are merged at call time. Declare fixture params with `Depends()` defaults alongside case params:
+Case kwargs and fixture-injected kwargs are merged at call time. Declare fixture params with `Depends()` alongside case params:
 
 ```python
+from typing import Annotated
+
 from tryke import Depends, expect, fixture, test
 
 @fixture
@@ -62,7 +64,7 @@ def multiplier() -> int:
     test.case("small", n=1, expected=10),
     test.case("big", n=9, expected=90),
 )
-def scaled(n: int, expected: int, factor: int = Depends(multiplier)):
+def scaled(n: int, expected: int, factor: Annotated[int, Depends(multiplier)]):
     expect(n * factor).to_equal(expected)
 ```
 

--- a/docs/concepts/concurrency.md
+++ b/docs/concepts/concurrency.md
@@ -98,16 +98,18 @@ If your tests modify global state that other tests depend on, consider whether t
 Cross-worker isolation does not extend to tests *within the same worker*. When `@fixture(per="scope")` caches a value, every test in that scope running on that worker receives **the same object by reference**. Mutating it is observable by subsequent tests in the scope, exactly as if it were a module-level global.
 
 ```python
+from typing import Annotated
+
 @fixture(per="scope")
 def config() -> dict[str, str]:
     return {"env": "test"}
 
 @test
-def first(cfg: dict[str, str] = Depends(config)) -> None:
+def first(cfg: Annotated[dict[str, str], Depends(config)]) -> None:
     cfg["env"] = "mutated"  # Leaks to later tests in this scope.
 
 @test
-def second(cfg: dict[str, str] = Depends(config)) -> None:
+def second(cfg: Annotated[dict[str, str], Depends(config)]) -> None:
     # Sees {"env": "mutated"} if first() ran on the same worker.
     ...
 ```

--- a/docs/guides/writing-tests.md
+++ b/docs/guides/writing-tests.md
@@ -196,9 +196,11 @@ def fresh_user():
 
 ### Sharing state with `Depends()`
 
-Fixtures that produce values share them with tests via `Depends()` in function signatures:
+Fixtures that produce values share them with tests via `Depends()` in function signatures, FastAPI-style:
 
 ```python
+from typing import Annotated
+
 from tryke import fixture, test, expect, Depends
 
 @fixture(per="scope")
@@ -206,24 +208,9 @@ def db() -> Connection:
     return create_connection("test.db")
 
 @fixture
-def fresh_table(conn: Connection = Depends(db)) -> Table:
+def fresh_table(conn: Annotated[Connection, Depends(db)]) -> Table:
     conn.execute("DELETE FROM users")
     return conn.table("users")
-
-@test
-def finds_user(table: Table = Depends(fresh_table)):
-    table.insert({"name": "alice"})
-    expect(table.count()).to_equal(1)
-```
-
-`Depends()` is typed — type checkers see `Depends(db)` as returning `Connection`. At runtime, the framework resolves the dependency chain and passes the values as keyword arguments.
-
-You can also place `Depends()` inside an `Annotated[...]` type, FastAPI-style. The two forms are equivalent — pick whichever reads better:
-
-```python
-from typing import Annotated
-
-from tryke import fixture, test, expect, Depends
 
 @test
 def finds_user(table: Annotated[Table, Depends(fresh_table)]):
@@ -231,7 +218,9 @@ def finds_user(table: Annotated[Table, Depends(fresh_table)]):
     expect(table.count()).to_equal(1)
 ```
 
-If a parameter has both a default-form and an `Annotated`-form `Depends()` (an unusual pattern), the default-form wins.
+`Depends()` is typed — type checkers see `Depends(db)` as returning `Connection`. At runtime, the framework resolves the dependency chain and passes the values as keyword arguments.
+
+The default-value form (`conn: Connection = Depends(db)`) is also supported and behaves identically. The two forms can be mixed in the same signature; if both appear on the same parameter the default-value form wins.
 
 ### `per="scope"` — run once, reuse across tests
 
@@ -244,12 +233,12 @@ def db() -> Connection:
     return create_connection("test.db")
 
 @test
-def first_query(conn: Connection = Depends(db)):
+def first_query(conn: Annotated[Connection, Depends(db)]):
     # Gets the cached connection
     ...
 
 @test
-def second_query(conn: Connection = Depends(db)):
+def second_query(conn: Annotated[Connection, Depends(db)]):
     # Same connection instance as first_query
     ...
 ```
@@ -261,16 +250,18 @@ def second_query(conn: Connection = Depends(db)):
 Use `yield` to express teardown. Code before `yield` is setup; code after is teardown. Works for both `per="test"` and `per="scope"`:
 
 ```python
+from typing import Annotated
+
 from tryke import fixture, test, expect, Depends
 
 @fixture
-def with_transaction(conn: Connection = Depends(db)):
+def with_transaction(conn: Annotated[Connection, Depends(db)]):
     tx = conn.begin()
     yield tx
     tx.rollback()         # runs after the test
 
 @test
-def modifies_data(tx: Transaction = Depends(with_transaction)):
+def modifies_data(tx: Annotated[Transaction, Depends(with_transaction)]):
     tx.execute("INSERT INTO users (name) VALUES ('alice')")
     expect(tx.query("SELECT count(*) FROM users")).to_equal(1)
     # Transaction rolls back after test — no cleanup needed
@@ -281,6 +272,8 @@ def modifies_data(tx: Transaction = Depends(with_transaction)):
 Fixtures defined inside a `describe` block only apply to tests in that block:
 
 ```python
+from typing import Annotated
+
 from tryke import fixture, test, expect, describe, Depends
 
 @fixture(per="scope")
@@ -289,18 +282,18 @@ def api() -> TestClient:
 
 with describe("GET /users"):
     @fixture
-    def seed_users(client: TestClient = Depends(api)):
+    def seed_users(client: Annotated[TestClient, Depends(api)]):
         client.post("/users", json={"name": "alice"})
 
     @test
-    def returns_users(client: TestClient = Depends(api)):
+    def returns_users(client: Annotated[TestClient, Depends(api)]):
         resp = client.get("/users")
         expect(resp.status_code).to_equal(200)
 
 with describe("POST /users"):
     # seed_users does NOT run here — it's scoped to "GET /users"
     @test
-    def creates_user(client: TestClient = Depends(api)):
+    def creates_user(client: Annotated[TestClient, Depends(api)]):
         resp = client.post("/users", json={"name": "bob"})
         expect(resp.status_code).to_equal(201)
 ```
@@ -322,8 +315,8 @@ with describe("users"):
 
         @test
         def inserts_row(
-            repo: UserRepo = Depends(repo),
-            payload: dict[str, str] = Depends(payload),
+            repo: Annotated[UserRepo, Depends(repo)],
+            payload: Annotated[dict[str, str], Depends(payload)],
         ):
             repo.create(payload)
             expect(repo.count()).to_equal(1)
@@ -344,17 +337,17 @@ def config() -> AppConfig:
     return AppConfig.from_env("test")
 
 @fixture(per="scope")
-def db(cfg: AppConfig = Depends(config)) -> Database:
+def db(cfg: Annotated[AppConfig, Depends(config)]) -> Database:
     return Database(cfg.db_url)
 
 @fixture(per="scope")
-def cache(cfg: AppConfig = Depends(config)) -> RedisCache:
+def cache(cfg: Annotated[AppConfig, Depends(config)]) -> RedisCache:
     return RedisCache(cfg.redis_url)
 
 @fixture
 def service(
-    db: Database = Depends(db),
-    cache: RedisCache = Depends(cache),
+    db: Annotated[Database, Depends(db)],
+    cache: Annotated[RedisCache, Depends(cache)],
 ) -> UserService:
     return UserService(db, cache)
 ```

--- a/docs/guides/writing-tests.md
+++ b/docs/guides/writing-tests.md
@@ -218,6 +218,21 @@ def finds_user(table: Table = Depends(fresh_table)):
 
 `Depends()` is typed — type checkers see `Depends(db)` as returning `Connection`. At runtime, the framework resolves the dependency chain and passes the values as keyword arguments.
 
+You can also place `Depends()` inside an `Annotated[...]` type, FastAPI-style. The two forms are equivalent — pick whichever reads better:
+
+```python
+from typing import Annotated
+
+from tryke import fixture, test, expect, Depends
+
+@test
+def finds_user(table: Annotated[Table, Depends(fresh_table)]):
+    table.insert({"name": "alice"})
+    expect(table.count()).to_equal(1)
+```
+
+If a parameter has both a default-form and an `Annotated`-form `Depends()` (an unusual pattern), the default-form wins.
+
 ### `per="scope"` — run once, reuse across tests
 
 `@fixture(per="scope")` fixtures run once for their lexical scope. The return value is cached and shared across all tests in that scope:

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,8 @@ A Rust-based Python test runner with a Jest-style API.
 ## Getting started
 
 ```python
+from typing import Annotated
+
 import tryke as t
 
 
@@ -66,7 +68,7 @@ with t.describe("users"):
     # By default, fixtures run per-test
     # Fixtures can be composed by requesting other fixtures
     @t.fixture
-    def users(database: dict[str, dict[str, str]] = t.Depends(database)):
+    def users(database: Annotated[dict[str, dict[str, str]], t.Depends(database)]):
         database["users"] = {}
         return database["users"]
 
@@ -74,14 +76,14 @@ with t.describe("users"):
         # Define display labels for tests
         # Async tests are supported
         @t.test("returns a stored user")
-        async def test_get(users: dict[str, str] = t.Depends(users)):
+        async def test_get(users: Annotated[dict[str, str], t.Depends(users)]):
             users["alice"] = "alice@example.com"
             t.expect(users["alice"]).to_equal("alice@example.com")
 
     with t.describe("set"):
 
         @t.test("stores a new user")
-        async def test_set(users: dict[str, str] = t.Depends(users)):
+        async def test_set(users: Annotated[dict[str, str], t.Depends(users)]):
             users["bob"] = "bob@example.com"
             t.expect(users["bob"]).to_equal("bob@example.com")
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -218,6 +218,8 @@ def test_query(table):
 **Tryke:**
 
 ```python
+from typing import Annotated
+
 from tryke import test, expect, fixture, Depends
 
 @fixture(per="scope")
@@ -225,12 +227,12 @@ def db() -> Connection:
     return create_connection()
 
 @fixture
-def managed_conn(conn: Connection = Depends(db)):
+def managed_conn(conn: Annotated[Connection, Depends(db)]):
     yield conn
     conn.execute("DELETE FROM users")
 
 @test
-def query(conn: Connection = Depends(managed_conn)):
+def query(conn: Annotated[Connection, Depends(managed_conn)]):
     conn.execute("INSERT INTO users (name) VALUES ('alice')")
     expect(conn.execute("SELECT count(*) FROM users")).to_equal(1)
 ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -410,6 +410,19 @@ each conversion small enough to review.
 For each file:
 
 - Replace non-parametrized `def test_foo(...)` with `@test` + `def foo(...)`.
+- **Add a human-readable display name** to each test — `@test("returns 200
+  for known users")` (or `@test(name="...")`) — derived from the test's
+  docstring or its function name. Tryke surfaces this label in every
+  reporter where pytest only shows the function identifier; setting it
+  during the migration is far cheaper than retrofitting later. If a test
+  body has a one-line docstring, lift it into the decorator and delete
+  the docstring.
+- **Label each `expect(...)`** with a short description of what is being
+  checked: `expect(rows[0], "first row id").to_equal(42)`. The label is
+  static-only metadata — it costs nothing at runtime and shows up in
+  `--reporter llm`, JUnit, and the default text reporter, which makes
+  failure triage substantially faster. Skip the label only when the
+  expression is already self-explanatory.
 - Replace `assert` with `expect(...).to_...()` per the assertions table.
 - Replace `pytest.raises(Exc, match=...)` with
   `expect(lambda: ...).to_raise(Exc, match=...)` — **use the `match=` kwarg

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -190,6 +190,19 @@ def comprehensive_check():
     expect(response.headers).to_contain("json")    # soft — runs regardless
 ```
 
+### Display names for tests and expectations
+
+Tryke surfaces human-readable labels in reporters where pytest only shows function names and source snippets. Take advantage of this while migrating — names typed once read every time a report is rendered:
+
+```python
+@test("returns the cached row on the second call")
+def hits_cache():
+    expect(rows[0], "first row id").to_equal(42)
+    expect(rows[0], "first row name").to_equal("alice")
+```
+
+`@test("...")` (or `@test(name="...")`) sets the test's display name; the second positional argument to `expect(value, "...")` labels the assertion. Both are static-only metadata — discovery extracts them at parse time, and they show up in `--reporter llm`, `--reporter junit`, and the default text reporter without any runtime cost.
+
 ### Fixtures → `@fixture` + `Depends()`
 
 pytest uses `@pytest.fixture` with implicit parameter-name matching. Tryke uses a single `@fixture` decorator with explicit `Depends()` wiring:

--- a/python/tryke/hooks.py
+++ b/python/tryke/hooks.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import inspect
+import typing
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
@@ -58,7 +59,7 @@ class _Depends:
     and resolves them before calling the function.
     """
 
-    dependency: Callable[..., Any]
+    dependency: _FixtureFn
 
 
 if TYPE_CHECKING:
@@ -73,10 +74,28 @@ if TYPE_CHECKING:
     def Depends[T](dep: Callable[..., T], /) -> T: ...
 
 
-def Depends(dep: Callable[..., Any], /) -> Any:  # noqa: N802 - matches FastAPI convention
+def _depends_from_annotation(annotation: object) -> _Depends | None:
+    """Return the first ``_Depends`` in an ``Annotated[...]`` annotation.
+
+    ``typing.Annotated`` exposes its metadata tuple as ``__metadata__``;
+    every other annotation form returns ``None``. Multiple ``Depends()``
+    markers in the same ``Annotated`` are not meaningful — the first one
+    wins, mirroring how FastAPI consumes ``Annotated`` metadata.
+    """
+    metadata = getattr(annotation, "__metadata__", None)
+    if metadata is None:
+        return None
+    for meta in metadata:
+        if isinstance(meta, _Depends):
+            return meta
+    return None
+
+
+def Depends(dep: _FixtureFn, /) -> Any:  # noqa: N802, ANN401 - matches FastAPI convention
     """Declare a dependency on another fixture.
 
-    Used in function signatures to request a resolved value::
+    Used in function signatures to request a resolved value, either as
+    a default value or as ``Annotated`` metadata::
 
         @fixture(per="scope")
         def db() -> Connection:
@@ -84,6 +103,10 @@ def Depends(dep: Callable[..., Any], /) -> Any:  # noqa: N802 - matches FastAPI 
 
         @test
         def my_test(conn: Connection = Depends(db)):
+            ...
+
+        @test
+        def my_other_test(conn: Annotated[Connection, Depends(db)]):
             ...
 
     Type checkers see ``Depends(db)`` as returning ``Connection``. At
@@ -236,16 +259,39 @@ class DependencyResolver:
             loop.close()
 
     def resolve(self, fn: _FixtureFn) -> dict[str, Any]:
-        """Inspect *fn*'s signature and resolve all ``Depends()`` defaults.
+        """Inspect *fn*'s signature and resolve all ``Depends()`` markers.
+
+        Recognises both forms::
+
+            def fn(x = Depends(other)):           # default-value form
+                ...
+
+            def fn(x: Annotated[T, Depends(other)]):  # Annotated form
+                ...
 
         Returns a dict of ``{param_name: resolved_value}`` suitable for
-        passing as keyword arguments.
+        passing as keyword arguments. The default-value form takes
+        precedence if both are present on the same parameter.
         """
         kwargs: dict[str, Any] = {}
         sig = inspect.signature(fn)
+        # ``get_type_hints`` evaluates string annotations (PEP 563) and
+        # preserves ``Annotated`` metadata when ``include_extras=True``.
+        # Locally-defined fixtures may reference closure types that
+        # cannot be resolved from ``fn.__globals__``; in that case we
+        # silently fall back to the default-value form only.
+        try:
+            hints = typing.get_type_hints(fn, include_extras=True)
+        except Exception:  # noqa: BLE001 - any eval failure means no Annotated info
+            hints = {}
         for name, param in sig.parameters.items():
             if isinstance(param.default, _Depends):
                 kwargs[name] = self.resolve_hook(param.default.dependency)
+                continue
+            annotation = hints.get(name, param.annotation)
+            dep = _depends_from_annotation(annotation)
+            if dep is not None:
+                kwargs[name] = self.resolve_hook(dep.dependency)
         return kwargs
 
     def resolve_hook(self, fn: _FixtureFn) -> Any:  # noqa: ANN401

--- a/python/tryke/hooks.py
+++ b/python/tryke/hooks.py
@@ -105,6 +105,8 @@ def Depends(dep: _FixtureFn, /) -> Any:  # noqa: N802, ANN401 - matches FastAPI 
         def my_test(conn: Connection = Depends(db)):
             ...
 
+        from typing import Annotated
+
         @test
         def my_other_test(conn: Annotated[Connection, Depends(db)]):
             ...

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, assert_type
+from typing import TYPE_CHECKING, Annotated, assert_type
 
 import tryke
 from tryke import Depends, describe, expect, fixture, test
@@ -12,6 +12,7 @@ from tryke.hooks import (
     DependencyResolver,
     HookExecutor,
     _Depends,
+    _depends_from_annotation,
     _fixture_per,
 )
 
@@ -223,6 +224,135 @@ with describe("DependencyResolver"):
         expect(
             resolver.resolve_hook(per_scope), "per-scope preserved across clear"
         ).to_equal(1)
+
+
+# Module-level helpers used by the "Depends via Annotated" tests below.
+# These are deliberately *not* decorated with ``@fixture`` — they exist
+# purely to give the resolver something to chase, and module-level
+# ``per="scope"`` fixtures would force the whole file onto a single
+# worker. ``DependencyResolver`` defaults undecorated callables to
+# ``per="test"``. They're at module scope (not inside a test function)
+# so PEP-563 string annotations resolve via ``typing.get_type_hints``.
+def _annotated_db() -> str:
+    return "conn"
+
+
+def _annotated_cache() -> int:
+    return 7
+
+
+def _annotated_table(conn: Annotated[str, Depends(_annotated_db)]) -> str:
+    return f"{conn}/table"
+
+
+with describe("Depends via Annotated"):
+
+    @test(name="_depends_from_annotation extracts _Depends from Annotated metadata")
+    def test_extract_from_annotated_metadata() -> None:
+        def hook() -> int:
+            return 1
+
+        annotation = Annotated[int, Depends(hook)]
+        # ``_Depends`` is a frozen dataclass, so equality compares the
+        # wrapped callable by identity — no need to unwrap manually.
+        expect(
+            _depends_from_annotation(annotation),
+            "extracts the _Depends marker",
+        ).to_equal(_Depends(hook))
+
+    @test(name="_depends_from_annotation returns None for plain type")
+    def test_extract_from_plain_type() -> None:
+        expect(_depends_from_annotation(int), "no metadata on bare int").to_be_none()
+        expect(_depends_from_annotation(None), "None has no metadata").to_be_none()
+        expect(
+            _depends_from_annotation(Annotated[int, "no depends here"]),
+            "Annotated without _Depends metadata",
+        ).to_be_none()
+
+    @test(name="_depends_from_annotation picks the first _Depends in metadata")
+    def test_extract_picks_first_depends() -> None:
+        def hook_a() -> int:
+            return 1
+
+        def hook_b() -> int:
+            return 2
+
+        annotation = Annotated[int, Depends(hook_a), "extra", Depends(hook_b)]
+        expect(
+            _depends_from_annotation(annotation),
+            "first _Depends wins",
+        ).to_equal(_Depends(hook_a))
+
+    @test(name="resolver resolves Annotated[T, Depends(...)] params")
+    def test_resolver_handles_annotated_form() -> None:
+        resolver = DependencyResolver()
+        result = resolver.resolve(_annotated_table)
+        expect(result, "Annotated metadata is resolved").to_equal({"conn": "conn"})
+
+    @test(name="default-value Depends takes precedence over Annotated metadata")
+    def test_default_form_wins_over_annotated() -> None:
+        # Locally defined for runtime injection; closure types are fine
+        # because both Depends markers are runtime objects, not strings.
+        @fixture(per="scope")
+        def primary() -> str:
+            return "primary"
+
+        @fixture(per="scope")
+        def secondary() -> str:
+            return "secondary"
+
+        @fixture
+        def consumer(
+            x: Annotated[str, Depends(secondary)] = Depends(primary),
+        ) -> str:
+            return x
+
+        resolver = DependencyResolver()
+        result = resolver.resolve(consumer)
+        expect(result, "default Depends wins").to_equal({"x": "primary"})
+
+    @test(name="resolver mixes default and Annotated Depends in same function")
+    def test_mixed_default_and_annotated() -> None:
+        resolver = DependencyResolver()
+
+        # Use module-level fixtures so get_type_hints can resolve the
+        # Annotated form's string annotation against module globals.
+        def consumer(
+            conn: Annotated[str, Depends(_annotated_db)],
+            count: int = Depends(_annotated_cache),
+        ) -> tuple[str, int]:
+            return conn, count
+
+        result = resolver.resolve(consumer)
+        expect(result, "both forms resolved together").to_equal(
+            {"conn": "conn", "count": 7}
+        )
+
+    @test(name="resolver tolerates unresolvable annotations on local fixtures")
+    def test_resolver_ignores_unresolvable_annotation() -> None:
+        # Annotation references a local closure type that
+        # ``typing.get_type_hints`` cannot resolve under PEP 563. The
+        # resolver must fall back to the default-value form rather than
+        # raising NameError.
+        class Local:
+            pass
+
+        @fixture(per="scope")
+        def db() -> Local:
+            return Local()
+
+        @fixture
+        def consumer(value: Local = Depends(db)) -> Local:
+            return value
+
+        resolver = DependencyResolver()
+        result = resolver.resolve(consumer)
+        expect(set(result.keys()), "default-form Depends still resolves").to_equal(
+            {"value"}
+        )
+        expect(
+            isinstance(result["value"], Local), "value has the right type"
+        ).to_be_truthy()
 
 
 with describe("HookExecutor basics"):


### PR DESCRIPTION
Python and Rust discovery now both recognise the FastAPI-style
``Annotated`` form for dependency injection. The default-value form
keeps precedence when both are present, and string annotations that
fail to resolve under PEP 563 fall back silently to the default form.

https://claude.ai/code/session_01Befgbiw1DxGCCrZCwni7Jm