### PR TITLE
Replace importlib.reload with worker subprocess restart

### DIFF
--- a/crates/tryke/src/watch.rs
+++ b/crates/tryke/src/watch.rs
@@ -109,7 +109,20 @@ pub async fn run_watch(
     let (tx, rx) = std::sync::mpsc::channel::<Vec<PathBuf>>();
     let _debouncer = tryke_server::watcher::spawn_watcher(root, excludes, tx)?;
 
-    for paths in &rx {
+    while let Ok(first) = rx.recv() {
+        // Coalesce any additional batches the watcher has already
+        // queued. A single editor save can produce events whose
+        // intermediate quiet windows fall just outside the watcher's
+        // debounce — so two batches arrive back-to-back. Without this
+        // drain, each batch triggers its own restart + test cycle,
+        // which the user perceives as a double-restart.
+        let mut paths = first;
+        while let Ok(more) = rx.try_recv() {
+            paths.extend(more);
+        }
+        paths.sort();
+        paths.dedup();
+
         debug!(
             "watch: file change batch — {} path(s) changed: {}",
             paths.len(),

--- a/crates/tryke/src/watch.rs
+++ b/crates/tryke/src/watch.rs
@@ -108,6 +108,7 @@ pub async fn run_watch(
 
     let (tx, rx) = std::sync::mpsc::channel::<Vec<PathBuf>>();
     let _debouncer = tryke_server::watcher::spawn_watcher(root, excludes, tx)?;
+    let mut change_filter = tryke_server::watcher::ChangeFilter::new();
 
     while let Ok(first) = rx.recv() {
         // Coalesce any additional batches the watcher has already
@@ -122,6 +123,17 @@ pub async fn run_watch(
         }
         paths.sort();
         paths.dedup();
+
+        // Drop paths whose `(mtime, size)` is unchanged since the
+        // last batch we accepted. This is the deterministic answer
+        // to "did the file actually change" — drain only catches
+        // batches queued together; this catches tail events that
+        // arrive after the previous cycle has finished.
+        let paths = change_filter.filter(&paths);
+        if paths.is_empty() {
+            debug!("watch: file change batch had no real content changes — skipping");
+            continue;
+        }
 
         debug!(
             "watch: file change batch — {} path(s) changed: {}",

--- a/crates/tryke/src/watch.rs
+++ b/crates/tryke/src/watch.rs
@@ -121,14 +121,14 @@ pub async fn run_watch(
         );
         let modules = discoverer.affected_modules(&paths);
         if modules.is_empty() {
-            debug!("watch: no modules affected by change — skipping pool.reload");
+            debug!("watch: no modules affected by change — skipping worker restart");
         } else {
             debug!(
-                "watch: reloading {} module(s) in worker pool: {}",
+                "watch: restarting worker pool to pick up changes in {} module(s): {}",
                 modules.len(),
                 modules.join(", ")
             );
-            pool.reload(modules).await;
+            pool.restart_workers().await;
         }
         discoverer.rediscover_changed(&paths);
         clear_if_tty();

--- a/crates/tryke_runner/src/pool.rs
+++ b/crates/tryke_runner/src/pool.rs
@@ -54,7 +54,6 @@ enum WorkerCtrl {
 pub struct WorkerPool {
     work_tx: async_channel::Sender<WorkerMsg>,
     ctrl_txs: Vec<mpsc::UnboundedSender<WorkerCtrl>>,
-    size: usize,
 }
 
 impl WorkerPool {
@@ -95,11 +94,7 @@ impl WorkerPool {
                 ctrl_rx,
             ));
         }
-        Self {
-            work_tx,
-            ctrl_txs,
-            size,
-        }
+        Self { work_tx, ctrl_txs }
     }
 
     pub fn run(&self, units: Vec<WorkUnit>) -> impl Stream<Item = TestResult> + use<> {
@@ -114,6 +109,28 @@ impl WorkerPool {
         UnboundedReceiverStream::new(stream_rx)
     }
 
+    /// Send one ctrl message per worker and await every ack.
+    ///
+    /// `build` is the ctrl-variant constructor (e.g. `WorkerCtrl::Ping`)
+    /// — taking it as a function pointer lets `warm` and
+    /// `restart_workers` share this whole fan-out path.
+    ///
+    /// If a worker task has died (ctrl channel receiver dropped), its
+    /// `send` returns `Err`; we skip its ack rather than push a future
+    /// that will never resolve, which would hang the watcher/server.
+    async fn fanout_ctrl(&self, build: fn(oneshot::Sender<()>) -> WorkerCtrl) {
+        let mut ack_rxs = Vec::with_capacity(self.ctrl_txs.len());
+        for ctrl_tx in &self.ctrl_txs {
+            let (ack_tx, ack_rx) = oneshot::channel();
+            if ctrl_tx.send(build(ack_tx)).is_ok() {
+                ack_rxs.push(ack_rx);
+            }
+        }
+        for ack_rx in ack_rxs {
+            let _ = ack_rx.await;
+        }
+    }
+
     /// Kill every worker subprocess and respawn a fresh one in its place.
     ///
     /// This is how watch and server mode pick up code changes: rather than
@@ -124,38 +141,17 @@ impl WorkerPool {
     /// process replays cached `register_hooks` calls so fixtures keep
     /// working — same path as crash recovery.
     pub async fn restart_workers(&self) {
-        // Per-worker channel: every worker gets exactly one Restart and
-        // one ack. Routing through the shared work-stealing channel
-        // would not give that guarantee.
-        let mut ack_rxs = Vec::with_capacity(self.size);
-        for ctrl_tx in &self.ctrl_txs {
-            let (ack_tx, ack_rx) = oneshot::channel();
-            let _ = ctrl_tx.send(WorkerCtrl::Restart(ack_tx));
-            ack_rxs.push(ack_rx);
-        }
-        for ack_rx in ack_rxs {
-            let _ = ack_rx.await;
-        }
+        self.fanout_ctrl(WorkerCtrl::Restart).await;
     }
 
     /// Pre-spawn all worker processes in parallel so Python startup
     /// latency is not on the critical path of the first tests.
     pub async fn warm(&self) {
-        // Per-worker channel: each worker spawns its own process. See
-        // `restart_workers` for why work-stealing fan-out is unsafe here.
-        let mut ack_rxs = Vec::with_capacity(self.size);
-        for ctrl_tx in &self.ctrl_txs {
-            let (ack_tx, ack_rx) = oneshot::channel();
-            let _ = ctrl_tx.send(WorkerCtrl::Ping(ack_tx));
-            ack_rxs.push(ack_rx);
-        }
-        for ack_rx in ack_rxs {
-            let _ = ack_rx.await;
-        }
+        self.fanout_ctrl(WorkerCtrl::Ping).await;
     }
 
     pub fn shutdown(self) {
-        for _ in 0..self.size {
+        for _ in 0..self.ctrl_txs.len() {
             let _ = self.work_tx.send_blocking(WorkerMsg::Shutdown);
         }
     }
@@ -308,6 +304,62 @@ async fn register_hooks_for_unit(
     }
 }
 
+async fn handle_ctrl(
+    state: &mut WorkerState,
+    python_bin: &str,
+    path_refs: &[&Path],
+    root: &Path,
+    ctrl: WorkerCtrl,
+) {
+    match ctrl {
+        WorkerCtrl::Ping(ack_tx) => {
+            trace!("worker_task: ping (pre-warm)");
+            let _ = ensure_worker(state, python_bin, path_refs, root).await;
+            let _ = ack_tx.send(());
+        }
+        WorkerCtrl::Restart(ack_tx) => {
+            trace!("worker_task: restart");
+            if let Some(mut w) = state.process.take() {
+                w.shutdown().await;
+            }
+            // Eagerly respawn so the next Unit doesn't pay Python startup
+            // latency. ensure_worker replays cached register_hooks against
+            // the fresh process, mirroring the crash-recovery path.
+            let _ = ensure_worker(state, python_bin, path_refs, root).await;
+            let _ = ack_tx.send(());
+        }
+    }
+}
+
+async fn handle_unit(
+    state: &mut WorkerState,
+    python_bin: &str,
+    path_refs: &[&Path],
+    root: &Path,
+    unit: WorkUnit,
+    result_tx: mpsc::UnboundedSender<TestResult>,
+) {
+    if !unit.hooks.is_empty() {
+        register_hooks_for_unit(state, python_bin, path_refs, root, &unit.hooks, &unit.tests).await;
+    }
+    let finalize_modules: std::collections::HashSet<String> = if unit.hooks.is_empty() {
+        std::collections::HashSet::new()
+    } else {
+        unit.tests.iter().map(|t| t.module_path.clone()).collect()
+    };
+    for test in unit.tests {
+        trace!("worker_task: running test {}", test.name);
+        run_single_test(state, python_bin, path_refs, root, test, &result_tx).await;
+    }
+    for module in finalize_modules {
+        if let Some(w) = state.process.as_mut()
+            && let Err(e) = w.finalize_hooks(module).await
+        {
+            debug!("worker_task: finalize_hooks failed: {e}");
+        }
+    }
+}
+
 async fn worker_task(
     python_bin: String,
     python_path: Vec<std::path::PathBuf>,
@@ -327,78 +379,16 @@ async fn worker_task(
         tokio::select! {
             biased;
             ctrl = ctrl_rx.recv() => {
-                let Some(ctrl) = ctrl else {
-                    // Pool dropped without sending Shutdown; exit cleanly.
-                    break;
-                };
-                match ctrl {
-                    WorkerCtrl::Ping(ack_tx) => {
-                        trace!("worker_task: ping (pre-warm)");
-                        let _ = ensure_worker(&mut state, &python_bin, &path_refs, &root).await;
-                        let _ = ack_tx.send(());
-                    }
-                    WorkerCtrl::Restart(ack_tx) => {
-                        trace!("worker_task: restart");
-                        if let Some(mut w) = state.process.take() {
-                            w.shutdown().await;
-                        }
-                        // Eagerly respawn so the next Unit doesn't pay
-                        // Python startup latency. ensure_worker replays
-                        // cached register_hooks against the fresh
-                        // process, mirroring the crash-recovery path.
-                        let _ = ensure_worker(&mut state, &python_bin, &path_refs, &root).await;
-                        let _ = ack_tx.send(());
-                    }
-                }
+                let Some(ctrl) = ctrl else { break };
+                handle_ctrl(&mut state, &python_bin, &path_refs, &root, ctrl).await;
             }
             msg = work_rx.recv() => {
-                let Ok(msg) = msg else {
-                    // Work channel closed and drained; pool is gone.
-                    break;
-                };
                 match msg {
-                    WorkerMsg::Unit(unit, result_tx) => {
-                        if !unit.hooks.is_empty() {
-                            register_hooks_for_unit(
-                                &mut state,
-                                &python_bin,
-                                &path_refs,
-                                &root,
-                                &unit.hooks,
-                                &unit.tests,
-                            )
+                    Ok(WorkerMsg::Unit(unit, result_tx)) => {
+                        handle_unit(&mut state, &python_bin, &path_refs, &root, unit, result_tx)
                             .await;
-                        }
-                        let mut finalize_modules = std::collections::HashSet::new();
-                        for test in &unit.tests {
-                            if !unit.hooks.is_empty() {
-                                finalize_modules.insert(test.module_path.clone());
-                            }
-                        }
-                        for test in unit.tests {
-                            trace!("worker_task: running test {}", test.name);
-                            run_single_test(
-                                &mut state,
-                                &python_bin,
-                                &path_refs,
-                                &root,
-                                test,
-                                &result_tx,
-                            )
-                            .await;
-                        }
-                        for module in finalize_modules {
-                            if let Some(w) = state.process.as_mut()
-                                && let Err(e) = w.finalize_hooks(module).await
-                            {
-                                debug!("worker_task: finalize_hooks failed: {e}");
-                            }
-                        }
                     }
-                    WorkerMsg::Shutdown => {
-                        trace!("worker_task: shutdown");
-                        break;
-                    }
+                    Ok(WorkerMsg::Shutdown) | Err(_) => break,
                 }
             }
         }

--- a/crates/tryke_runner/src/pool.rs
+++ b/crates/tryke_runner/src/pool.rs
@@ -36,7 +36,7 @@ impl WorkerState {
 enum WorkerMsg {
     Ping(oneshot::Sender<()>),
     Unit(WorkUnit, mpsc::UnboundedSender<TestResult>),
-    Reload(Vec<String>, oneshot::Sender<()>),
+    Restart(oneshot::Sender<()>),
     Shutdown,
 }
 
@@ -89,16 +89,22 @@ impl WorkerPool {
         UnboundedReceiverStream::new(stream_rx)
     }
 
-    pub async fn reload(&self, modules: Vec<String>) {
-        // Reload must reach every worker, so we send N messages (one per worker)
-        // and wait for all acknowledgements.
+    /// Kill every worker subprocess and respawn a fresh one in its place.
+    ///
+    /// This is how watch and server mode pick up code changes: rather than
+    /// trying to mutate a live interpreter with `importlib.reload` (which is
+    /// brittle once classes/closures/decorator-bound state from the old
+    /// definitions are referenced from elsewhere), we drop the whole process
+    /// and let it re-import everything on the next `run_test`. The fresh
+    /// process replays cached `register_hooks` calls so fixtures keep
+    /// working — same path as crash recovery.
+    pub async fn restart_workers(&self) {
+        // Restart must reach every worker, so we send N messages (one per
+        // worker) and wait for all acknowledgements.
         let mut ack_rxs = Vec::with_capacity(self.size);
         for _ in 0..self.size {
             let (ack_tx, ack_rx) = oneshot::channel();
-            let _ = self
-                .work_tx
-                .send(WorkerMsg::Reload(modules.clone(), ack_tx))
-                .await;
+            let _ = self.work_tx.send(WorkerMsg::Restart(ack_tx)).await;
             ack_rxs.push(ack_rx);
         }
         for ack_rx in ack_rxs {
@@ -322,11 +328,16 @@ async fn worker_task(
                     }
                 }
             }
-            WorkerMsg::Reload(modules, ack_tx) => {
-                trace!("worker_task: reload {modules:?}");
-                if let Some(w) = state.process.as_mut() {
-                    let _ = w.reload(&modules).await;
+            WorkerMsg::Restart(ack_tx) => {
+                trace!("worker_task: restart");
+                if let Some(mut w) = state.process.take() {
+                    w.shutdown().await;
                 }
+                // Eagerly respawn so the next Unit doesn't pay Python
+                // startup latency. ensure_worker replays cached
+                // register_hooks against the fresh process, mirroring
+                // the crash-recovery path.
+                let _ = ensure_worker(&mut state, &python_bin, &path_refs, &root).await;
                 let _ = ack_tx.send(());
             }
             WorkerMsg::Shutdown => {
@@ -472,6 +483,106 @@ def test_third(n: int = Depends(counter)) -> None:
             1,
             "crashing test must run exactly once (no retry), got {count:?}"
         );
+
+        pool.shutdown();
+    }
+
+    /// Restarting the pool must yield a *fresh* Python interpreter — not
+    /// just an `importlib.reload`-mutated module. We prove this by
+    /// recording one tally mark per fresh import of the test module: the
+    /// module body increments a sidecar counter on every initial load.
+    /// Importlib.reload would re-run the body too, but in production it
+    /// leaves classes/closures bound to the old definitions in *other*
+    /// modules — the brittleness this rearchitecture exists to fix.
+    /// A second tally after `restart_workers` confirms a brand new
+    /// interpreter is in play.
+    #[tokio::test]
+    async fn restart_workers_runs_module_body_on_fresh_interpreter() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("pyproject.toml"), "").expect("write pyproject.toml");
+
+        let counter_file = dir.path().join("IMPORT_COUNT");
+        let counter_escaped = counter_file.to_string_lossy().replace('\\', "\\\\");
+        let test_file = dir.path().join("test_restart_state.py");
+        let source = format!(
+            r#"from tryke import test, expect
+
+with open("{counter_escaped}", "a") as f:
+    f.write("x")
+    f.flush()
+
+@test
+def test_noop() -> None:
+    expect(1).to_equal(1)
+"#
+        );
+        std::fs::write(&test_file, source).expect("write test file");
+
+        let make_unit = || WorkUnit {
+            tests: vec![make_test_item(
+                "test_restart_state",
+                "test_noop",
+                &test_file,
+            )],
+            hooks: vec![],
+        };
+
+        let pool = WorkerPool::with_python_path(
+            1,
+            &test_python_bin(),
+            dir.path(),
+            &[dir.path().to_path_buf(), python_package_dir()],
+        );
+        pool.warm().await;
+
+        let r1: Vec<TestResult> = pool.run(vec![make_unit()]).collect().await;
+        assert_eq!(r1.len(), 1);
+        assert!(
+            matches!(r1[0].outcome, TestOutcome::Passed),
+            "first run should pass, got {:?}",
+            r1[0].outcome
+        );
+
+        pool.restart_workers().await;
+
+        let r2: Vec<TestResult> = pool.run(vec![make_unit()]).collect().await;
+        assert_eq!(r2.len(), 1);
+        assert!(
+            matches!(r2[0].outcome, TestOutcome::Passed),
+            "second run should pass on fresh interpreter, got {:?}",
+            r2[0].outcome
+        );
+
+        let count = std::fs::read_to_string(&counter_file).unwrap_or_default();
+        assert_eq!(
+            count.len(),
+            2,
+            "module body must run once per fresh interpreter \
+             (1 initial + 1 after restart_workers); got {count:?}"
+        );
+
+        pool.shutdown();
+    }
+
+    /// `restart_workers` on a pool with no live workers (warm not called,
+    /// no tests run yet) must be a no-op that still acks. Hitting this
+    /// path matters because the file watcher can fire before the user
+    /// triggers any test run, and the watcher awaits the ack.
+    #[tokio::test]
+    async fn restart_workers_with_no_live_processes_acks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("pyproject.toml"), "").expect("write pyproject.toml");
+
+        let pool = WorkerPool::with_python_path(
+            2,
+            &test_python_bin(),
+            dir.path(),
+            &[dir.path().to_path_buf(), python_package_dir()],
+        );
+        // No warm() — workers are not yet spawned.
+        let restarted =
+            tokio::time::timeout(std::time::Duration::from_secs(10), pool.restart_workers()).await;
+        assert!(restarted.is_ok(), "restart_workers must ack within timeout");
 
         pool.shutdown();
     }

--- a/crates/tryke_runner/src/pool.rs
+++ b/crates/tryke_runner/src/pool.rs
@@ -34,14 +34,26 @@ impl WorkerState {
 }
 
 enum WorkerMsg {
-    Ping(oneshot::Sender<()>),
     Unit(WorkUnit, mpsc::UnboundedSender<TestResult>),
-    Restart(oneshot::Sender<()>),
     Shutdown,
+}
+
+/// Control messages delivered on a per-worker channel.
+///
+/// `Ping` and `Restart` are fan-out operations: every worker must
+/// receive exactly one. Routing them through the shared work-stealing
+/// channel would let a single fast worker grab all N messages while
+/// other workers remained on stale Python processes — defeating the
+/// guarantee that watch/server-mode reloads run on a fresh interpreter.
+/// A dedicated channel per worker eliminates that race.
+enum WorkerCtrl {
+    Ping(oneshot::Sender<()>),
+    Restart(oneshot::Sender<()>),
 }
 
 pub struct WorkerPool {
     work_tx: async_channel::Sender<WorkerMsg>,
+    ctrl_txs: Vec<mpsc::UnboundedSender<WorkerCtrl>>,
     size: usize,
 }
 
@@ -69,12 +81,25 @@ impl WorkerPool {
         let python_path = python_path.to_vec();
         let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
         let (work_tx, work_rx) = async_channel::unbounded();
+        let mut ctrl_txs = Vec::with_capacity(size);
         for _ in 0..size {
             let bin = python_bin.to_owned();
-            let rx = work_rx.clone();
-            tokio::spawn(worker_task(bin, python_path.clone(), root.clone(), rx));
+            let work_rx = work_rx.clone();
+            let (ctrl_tx, ctrl_rx) = mpsc::unbounded_channel();
+            ctrl_txs.push(ctrl_tx);
+            tokio::spawn(worker_task(
+                bin,
+                python_path.clone(),
+                root.clone(),
+                work_rx,
+                ctrl_rx,
+            ));
         }
-        Self { work_tx, size }
+        Self {
+            work_tx,
+            ctrl_txs,
+            size,
+        }
     }
 
     pub fn run(&self, units: Vec<WorkUnit>) -> impl Stream<Item = TestResult> + use<> {
@@ -99,12 +124,13 @@ impl WorkerPool {
     /// process replays cached `register_hooks` calls so fixtures keep
     /// working — same path as crash recovery.
     pub async fn restart_workers(&self) {
-        // Restart must reach every worker, so we send N messages (one per
-        // worker) and wait for all acknowledgements.
+        // Per-worker channel: every worker gets exactly one Restart and
+        // one ack. Routing through the shared work-stealing channel
+        // would not give that guarantee.
         let mut ack_rxs = Vec::with_capacity(self.size);
-        for _ in 0..self.size {
+        for ctrl_tx in &self.ctrl_txs {
             let (ack_tx, ack_rx) = oneshot::channel();
-            let _ = self.work_tx.send(WorkerMsg::Restart(ack_tx)).await;
+            let _ = ctrl_tx.send(WorkerCtrl::Restart(ack_tx));
             ack_rxs.push(ack_rx);
         }
         for ack_rx in ack_rxs {
@@ -115,11 +141,12 @@ impl WorkerPool {
     /// Pre-spawn all worker processes in parallel so Python startup
     /// latency is not on the critical path of the first tests.
     pub async fn warm(&self) {
-        // Send one Ping per worker so each worker spawns its process.
+        // Per-worker channel: each worker spawns its own process. See
+        // `restart_workers` for why work-stealing fan-out is unsafe here.
         let mut ack_rxs = Vec::with_capacity(self.size);
-        for _ in 0..self.size {
+        for ctrl_tx in &self.ctrl_txs {
             let (ack_tx, ack_rx) = oneshot::channel();
-            let _ = self.work_tx.send(WorkerMsg::Ping(ack_tx)).await;
+            let _ = ctrl_tx.send(WorkerCtrl::Ping(ack_tx));
             ack_rxs.push(ack_rx);
         }
         for ack_rx in ack_rxs {
@@ -285,64 +312,94 @@ async fn worker_task(
     python_bin: String,
     python_path: Vec<std::path::PathBuf>,
     root: PathBuf,
-    rx: async_channel::Receiver<WorkerMsg>,
+    work_rx: async_channel::Receiver<WorkerMsg>,
+    mut ctrl_rx: mpsc::UnboundedReceiver<WorkerCtrl>,
 ) {
     let path_refs: Vec<&Path> = python_path.iter().map(PathBuf::as_path).collect();
     let mut state = WorkerState::new();
 
-    while let Ok(msg) = rx.recv().await {
-        match msg {
-            WorkerMsg::Ping(ack_tx) => {
-                trace!("worker_task: ping (pre-warm)");
-                let _ = ensure_worker(&mut state, &python_bin, &path_refs, &root).await;
-                let _ = ack_tx.send(());
-            }
-            WorkerMsg::Unit(unit, result_tx) => {
-                if !unit.hooks.is_empty() {
-                    register_hooks_for_unit(
-                        &mut state,
-                        &python_bin,
-                        &path_refs,
-                        &root,
-                        &unit.hooks,
-                        &unit.tests,
-                    )
-                    .await;
-                }
-                let mut finalize_modules = std::collections::HashSet::new();
-                for test in &unit.tests {
-                    if !unit.hooks.is_empty() {
-                        finalize_modules.insert(test.module_path.clone());
+    loop {
+        // `biased` guarantees control messages take priority once the
+        // current Unit (if any) finishes. Without it, `select!` could
+        // keep picking Units off the shared queue while a Restart sat
+        // in this worker's ctrl channel — leaving the worker on a stale
+        // interpreter for arbitrarily long.
+        tokio::select! {
+            biased;
+            ctrl = ctrl_rx.recv() => {
+                let Some(ctrl) = ctrl else {
+                    // Pool dropped without sending Shutdown; exit cleanly.
+                    break;
+                };
+                match ctrl {
+                    WorkerCtrl::Ping(ack_tx) => {
+                        trace!("worker_task: ping (pre-warm)");
+                        let _ = ensure_worker(&mut state, &python_bin, &path_refs, &root).await;
+                        let _ = ack_tx.send(());
                     }
-                }
-                for test in unit.tests {
-                    trace!("worker_task: running test {}", test.name);
-                    run_single_test(&mut state, &python_bin, &path_refs, &root, test, &result_tx)
-                        .await;
-                }
-                for module in finalize_modules {
-                    if let Some(w) = state.process.as_mut()
-                        && let Err(e) = w.finalize_hooks(module).await
-                    {
-                        debug!("worker_task: finalize_hooks failed: {e}");
+                    WorkerCtrl::Restart(ack_tx) => {
+                        trace!("worker_task: restart");
+                        if let Some(mut w) = state.process.take() {
+                            w.shutdown().await;
+                        }
+                        // Eagerly respawn so the next Unit doesn't pay
+                        // Python startup latency. ensure_worker replays
+                        // cached register_hooks against the fresh
+                        // process, mirroring the crash-recovery path.
+                        let _ = ensure_worker(&mut state, &python_bin, &path_refs, &root).await;
+                        let _ = ack_tx.send(());
                     }
                 }
             }
-            WorkerMsg::Restart(ack_tx) => {
-                trace!("worker_task: restart");
-                if let Some(mut w) = state.process.take() {
-                    w.shutdown().await;
+            msg = work_rx.recv() => {
+                let Ok(msg) = msg else {
+                    // Work channel closed and drained; pool is gone.
+                    break;
+                };
+                match msg {
+                    WorkerMsg::Unit(unit, result_tx) => {
+                        if !unit.hooks.is_empty() {
+                            register_hooks_for_unit(
+                                &mut state,
+                                &python_bin,
+                                &path_refs,
+                                &root,
+                                &unit.hooks,
+                                &unit.tests,
+                            )
+                            .await;
+                        }
+                        let mut finalize_modules = std::collections::HashSet::new();
+                        for test in &unit.tests {
+                            if !unit.hooks.is_empty() {
+                                finalize_modules.insert(test.module_path.clone());
+                            }
+                        }
+                        for test in unit.tests {
+                            trace!("worker_task: running test {}", test.name);
+                            run_single_test(
+                                &mut state,
+                                &python_bin,
+                                &path_refs,
+                                &root,
+                                test,
+                                &result_tx,
+                            )
+                            .await;
+                        }
+                        for module in finalize_modules {
+                            if let Some(w) = state.process.as_mut()
+                                && let Err(e) = w.finalize_hooks(module).await
+                            {
+                                debug!("worker_task: finalize_hooks failed: {e}");
+                            }
+                        }
+                    }
+                    WorkerMsg::Shutdown => {
+                        trace!("worker_task: shutdown");
+                        break;
+                    }
                 }
-                // Eagerly respawn so the next Unit doesn't pay Python
-                // startup latency. ensure_worker replays cached
-                // register_hooks against the fresh process, mirroring
-                // the crash-recovery path.
-                let _ = ensure_worker(&mut state, &python_bin, &path_refs, &root).await;
-                let _ = ack_tx.send(());
-            }
-            WorkerMsg::Shutdown => {
-                trace!("worker_task: shutdown");
-                break;
             }
         }
     }
@@ -564,9 +621,11 @@ def test_noop() -> None:
         pool.shutdown();
     }
 
-    /// `restart_workers` on a pool with no live workers (warm not called,
-    /// no tests run yet) must be a no-op that still acks. Hitting this
-    /// path matters because the file watcher can fire before the user
+    /// `restart_workers` on a pool that has not been warmed (no
+    /// processes spawned yet) must still ack. The handler eagerly
+    /// spawns a fresh process — same path as a normal restart — so the
+    /// next test run is not on the Python startup critical path. This
+    /// matters because the file watcher can fire before the user
     /// triggers any test run, and the watcher awaits the ack.
     #[tokio::test]
     async fn restart_workers_with_no_live_processes_acks() {

--- a/crates/tryke_runner/src/protocol.rs
+++ b/crates/tryke_runner/src/protocol.rs
@@ -16,9 +16,13 @@
 //!    are resolved and injected before the test function runs.
 //! 3. `finalize_hooks`   — after the last test in a module, Rust sends
 //!    [`FinalizeHooksParams`] so `per="scope"` teardown runs.
-//! 4. `reload` (watch/server mode only) — [`ReloadParams`] tells the worker
-//!    to drop any cached import of the listed dotted module names and
-//!    invalidate their cached executors. Next test triggers a fresh import.
+//!
+//! Watch and server mode pick up code changes by killing each worker
+//! subprocess and respawning a fresh one (see
+//! [`crate::pool::WorkerPool::restart_workers`]) — there is no `reload` RPC.
+//! In-process `importlib.reload` is too brittle once classes/closures
+//! captured under the old definitions are referenced from elsewhere; a
+//! clean process is the only reliable way to drop that state.
 //!
 //! Because hooks are discovered statically by Ruff (not by importing), the
 //! runner knows every `@fixture` name and every `Depends(...)` reference
@@ -115,11 +119,6 @@ pub struct FinalizeHooksParams {
 pub struct RunDoctestParams {
     pub module: String,
     pub object_path: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ReloadParams {
-    pub modules: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -10,7 +10,7 @@ use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tryke_types::{Assertion, ExpectedAssertion, TestItem, TestOutcome, TestResult};
 
 use crate::protocol::{
-    AssertionWire, FinalizeHooksParams, RegisterHooksParams, ReloadParams, RpcRequest, RpcResponse,
+    AssertionWire, FinalizeHooksParams, RegisterHooksParams, RpcRequest, RpcResponse,
     RunDoctestParams, RunTestParams, RunTestResultWire,
 };
 
@@ -192,16 +192,6 @@ impl WorkerProcess {
         })?;
         let wire: RunTestResultWire = self.call("run_doctest", Some(params)).await?;
         Ok(convert_result(test.clone(), wire))
-    }
-
-    #[expect(clippy::missing_errors_doc)]
-    pub async fn reload(&mut self, modules: &[String]) -> Result<()> {
-        let params = serde_json::to_value(ReloadParams {
-            modules: modules.to_vec(),
-        })?;
-        self.call::<serde_json::Value>("reload", Some(params))
-            .await?;
-        Ok(())
     }
 
     #[expect(clippy::missing_errors_doc)]

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -71,7 +71,19 @@ impl Server {
         let bcast_for_watcher = bcast_tx.clone();
         let pool_for_watcher = Arc::clone(&pool);
         tokio::spawn(async move {
-            while let Some(paths) = watcher_rx.recv().await {
+            while let Some(first) = watcher_rx.recv().await {
+                // Coalesce any additional batches already queued. A
+                // single editor save can produce events whose quiet
+                // windows straddle the watcher's debounce, yielding two
+                // back-to-back batches. Without this drain we would
+                // restart the worker pool twice for one save.
+                let mut paths = first;
+                while let Ok(more) = watcher_rx.try_recv() {
+                    paths.extend(more);
+                }
+                paths.sort();
+                paths.dedup();
+
                 let (modules, tests) = {
                     let mut disc = disc_for_watcher.lock().await;
                     let modules = disc.affected_modules(&paths);

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -70,6 +70,7 @@ impl Server {
         let disc_for_watcher = Arc::clone(&disc);
         let bcast_for_watcher = bcast_tx.clone();
         let pool_for_watcher = Arc::clone(&pool);
+        let mut change_filter = crate::watcher::ChangeFilter::new();
         tokio::spawn(async move {
             while let Some(first) = watcher_rx.recv().await {
                 // Coalesce any additional batches already queued. A
@@ -83,6 +84,16 @@ impl Server {
                 }
                 paths.sort();
                 paths.dedup();
+
+                // Drop paths whose `(mtime, size)` hasn't actually
+                // moved since the last accepted batch. Drain handles
+                // simultaneously-queued batches; this handles tail
+                // events that arrive after the previous cycle.
+                let paths = change_filter.filter(&paths);
+                if paths.is_empty() {
+                    debug!("server: file change batch had no real content changes — skipping");
+                    continue;
+                }
 
                 let (modules, tests) = {
                     let mut disc = disc_for_watcher.lock().await;

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -80,14 +80,14 @@ impl Server {
                     (modules, tests)
                 };
                 if modules.is_empty() {
-                    debug!("server: no modules affected by change — skipping pool.reload");
+                    debug!("server: no modules affected by change — skipping worker restart");
                 } else {
                     debug!(
-                        "server: reloading {} module(s) in worker pool: {}",
+                        "server: restarting worker pool to pick up changes in {} module(s): {}",
                         modules.len(),
                         modules.join(", ")
                     );
-                    pool_for_watcher.reload(modules).await;
+                    pool_for_watcher.restart_workers().await;
                 }
                 debug!("file change: {} affected tests", tests.len());
                 let notif = Notification {

--- a/crates/tryke_server/src/watcher.rs
+++ b/crates/tryke_server/src/watcher.rs
@@ -28,13 +28,13 @@ pub fn spawn_watcher(
     tx: mpsc::Sender<Vec<PathBuf>>,
 ) -> anyhow::Result<Debouncer<RecommendedWatcher>> {
     let gitignore = build_gitignore(root, excludes);
-    // 100ms is enough to coalesce the burst of inotify events the
-    // kernel emits for a single write syscall (typically sub-ms apart).
-    // We rely on `ChangeFilter` further downstream — not on a wide
-    // debounce window — to suppress duplicate restarts from editor
-    // tail activity that arrives after this window.
+    // 50ms is enough to coalesce the burst of inotify events the kernel
+    // emits for a single write syscall (typically sub-ms apart). We rely
+    // on `ChangeFilter` further downstream — not on a wide debounce
+    // window — to suppress duplicate restarts from editor tail activity
+    // that arrives after this window.
     let mut debouncer = new_debouncer(
-        Duration::from_millis(100),
+        Duration::from_millis(50),
         move |res: DebounceEventResult| {
             if let Ok(events) = res {
                 let paths: Vec<PathBuf> = events

--- a/crates/tryke_server/src/watcher.rs
+++ b/crates/tryke_server/src/watcher.rs
@@ -64,6 +64,16 @@ pub fn spawn_watcher(
 /// disk cache uses (`tryke_discovery::cache::FileKey`) so that any
 /// file the discovery layer would treat as "unchanged" is also
 /// treated as "unchanged" here.
+///
+/// Limitation: on filesystems with coarse mtime resolution
+/// (FAT32 ~2s, HFS+ ~1s), two distinct saves of the same byte
+/// length within one tick can collide on `(mtime, size)` and the
+/// second save will be silently dropped here. Source trees are
+/// virtually never hosted on those filesystems in practice
+/// (ext4/xfs/btrfs/APFS/NTFS all have ≥100ns resolution), and
+/// the discovery cache already accepts the same trade-off — a
+/// stronger key would have to be adopted in both layers together
+/// to remain consistent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FileSig {
     mtime_nanos: i128,

--- a/crates/tryke_server/src/watcher.rs
+++ b/crates/tryke_server/src/watcher.rs
@@ -1,7 +1,8 @@
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::mpsc,
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
@@ -52,6 +53,87 @@ pub fn spawn_watcher(
         .watcher()
         .watch(root, notify::RecursiveMode::Recursive)?;
     Ok(debouncer)
+}
+
+/// Cheap content signature used to decide whether a watcher event
+/// represents a real change. We deliberately match what the discovery
+/// disk cache uses (`tryke_discovery::cache::FileKey`) so that any
+/// file the discovery layer would treat as "unchanged" is also
+/// treated as "unchanged" here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileSig {
+    mtime_nanos: i128,
+    size: u64,
+}
+
+impl FileSig {
+    fn from_path(path: &Path) -> Option<Self> {
+        let m = std::fs::metadata(path).ok()?;
+        let mtime = m.modified().ok()?;
+        let mtime_nanos = match mtime.duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(d) => i128::try_from(d.as_nanos()).unwrap_or(i128::MAX),
+            Err(e) => -i128::try_from(e.duration().as_nanos()).unwrap_or(i128::MAX),
+        };
+        Some(Self {
+            mtime_nanos,
+            size: m.len(),
+        })
+    }
+}
+
+/// Drops watcher events that don't reflect a real content change.
+///
+/// `notify-debouncer-mini` coalesces inotify bursts within its 200ms
+/// quiet window, but a single editor save can still produce two batches
+/// when the editor's tail activity (metadata fsync, swap-file cleanup,
+/// format-on-save with identical output, LSP write) lands outside that
+/// window. Without dedup, each batch triggers its own restart cycle —
+/// the user perceives one save as two restarts.
+///
+/// `ChangeFilter` answers the deterministic question: "did the file's
+/// `(mtime, size)` actually move since the last batch we accepted?"
+/// Same primitive the discovery cache uses to skip re-parsing unchanged
+/// files. Tail events that don't move the signature are silently
+/// dropped; genuine second saves (different content → different mtime)
+/// still flow through.
+#[derive(Debug, Default)]
+pub struct ChangeFilter {
+    last_seen: HashMap<PathBuf, FileSig>,
+}
+
+impl ChangeFilter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return only the paths whose current sig differs from the
+    /// previously-stamped sig (or that have no stamp yet). Updates
+    /// stamps for every returned path.
+    ///
+    /// `None` from `FileSig::from_path` (file deleted, unreadable)
+    /// is treated as a state — a transition between `Some` and `None`
+    /// counts as a change too, so a deletion is reported once and
+    /// then quiesces if no further action is taken on the path.
+    pub fn filter(&mut self, paths: &[PathBuf]) -> Vec<PathBuf> {
+        let mut out = Vec::with_capacity(paths.len());
+        for path in paths {
+            let current = FileSig::from_path(path);
+            let prior = self.last_seen.get(path).copied();
+            if current != prior {
+                match current {
+                    Some(sig) => {
+                        self.last_seen.insert(path.clone(), sig);
+                    }
+                    None => {
+                        self.last_seen.remove(path);
+                    }
+                }
+                out.push(path.clone());
+            }
+        }
+        out
+    }
 }
 
 #[cfg(test)]
@@ -148,6 +230,129 @@ mod tests {
         assert!(
             paths.iter().any(|p| p == &py_file || p == &canonical),
             "expected changed path in notification, got {paths:?}"
+        );
+    }
+
+    /// Bump mtime on `path` until `FileSig::from_path` actually
+    /// observes a different sig than `prior`. Filesystem mtime
+    /// resolution varies by platform (1ns on Linux ext4, 1µs on
+    /// some macOS configs), so a `fs::write` immediately followed by
+    /// another `fs::write` can produce identical mtimes.
+    fn bump_until_sig_changes(path: &Path, prior: FileSig) {
+        for i in 0u32..100 {
+            fs::write(path, format!("@test\ndef bumped_{i}(): pass\n# {i:08}\n")).expect("write");
+            if let Some(now) = FileSig::from_path(path)
+                && now != prior
+            {
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!(
+            "could not bump mtime/size on {} after 100 attempts",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn change_filter_first_observation_is_change() {
+        let dir = make_project();
+        let py = dir.path().join("a.py");
+        fs::write(&py, "x = 1").expect("write");
+
+        let mut f = ChangeFilter::new();
+        let first = f.filter(std::slice::from_ref(&py));
+        assert_eq!(first, vec![py.clone()], "first sighting must report");
+        let second = f.filter(std::slice::from_ref(&py));
+        assert!(
+            second.is_empty(),
+            "no-op event with unchanged sig must be dropped, got {second:?}"
+        );
+    }
+
+    #[test]
+    fn change_filter_detects_mtime_change() {
+        let dir = make_project();
+        let py = dir.path().join("a.py");
+        fs::write(&py, "x = 1").expect("write");
+
+        let mut f = ChangeFilter::new();
+        let _ = f.filter(std::slice::from_ref(&py));
+        let prior = FileSig::from_path(&py).expect("sig");
+
+        bump_until_sig_changes(&py, prior);
+
+        let after = f.filter(std::slice::from_ref(&py));
+        assert_eq!(
+            after,
+            vec![py],
+            "real content change must be reported as changed"
+        );
+    }
+
+    #[test]
+    fn change_filter_ignores_no_op_event() {
+        let dir = make_project();
+        let py = dir.path().join("a.py");
+        fs::write(&py, "x = 1").expect("write");
+
+        let mut f = ChangeFilter::new();
+        let _ = f.filter(std::slice::from_ref(&py));
+        // Re-fire with no underlying FS change at all.
+        let again = f.filter(std::slice::from_ref(&py));
+        let again2 = f.filter(std::slice::from_ref(&py));
+        assert!(
+            again.is_empty(),
+            "no-op event #1 should drop, got {again:?}"
+        );
+        assert!(
+            again2.is_empty(),
+            "no-op event #2 should drop, got {again2:?}"
+        );
+    }
+
+    #[test]
+    fn change_filter_detects_deletion() {
+        let dir = make_project();
+        let py = dir.path().join("a.py");
+        fs::write(&py, "x = 1").expect("write");
+
+        let mut f = ChangeFilter::new();
+        let _ = f.filter(std::slice::from_ref(&py));
+
+        fs::remove_file(&py).expect("rm");
+        let after_delete = f.filter(std::slice::from_ref(&py));
+        assert_eq!(
+            after_delete,
+            vec![py.clone()],
+            "deletion (Some -> None) must be reported once"
+        );
+        let after_quiet = f.filter(std::slice::from_ref(&py));
+        assert!(
+            after_quiet.is_empty(),
+            "second event on still-deleted path is a no-op, got {after_quiet:?}"
+        );
+    }
+
+    #[test]
+    fn change_filter_only_returns_changed_paths_in_mixed_batch() {
+        let dir = make_project();
+        let a = dir.path().join("a.py");
+        let b = dir.path().join("b.py");
+        fs::write(&a, "x = 1").expect("write a");
+        fs::write(&b, "y = 1").expect("write b");
+
+        let mut f = ChangeFilter::new();
+        let _ = f.filter(&[a.clone(), b.clone()]);
+
+        let prior_a = FileSig::from_path(&a).expect("sig a");
+        bump_until_sig_changes(&a, prior_a);
+
+        let mixed = f.filter(&[a.clone(), b]);
+        assert_eq!(
+            mixed,
+            vec![a],
+            "only the path that actually moved should be reported"
         );
     }
 }

--- a/crates/tryke_server/src/watcher.rs
+++ b/crates/tryke_server/src/watcher.rs
@@ -28,8 +28,13 @@ pub fn spawn_watcher(
     tx: mpsc::Sender<Vec<PathBuf>>,
 ) -> anyhow::Result<Debouncer<RecommendedWatcher>> {
     let gitignore = build_gitignore(root, excludes);
+    // 100ms is enough to coalesce the burst of inotify events the
+    // kernel emits for a single write syscall (typically sub-ms apart).
+    // We rely on `ChangeFilter` further downstream — not on a wide
+    // debounce window — to suppress duplicate restarts from editor
+    // tail activity that arrives after this window.
     let mut debouncer = new_debouncer(
-        Duration::from_millis(200),
+        Duration::from_millis(100),
         move |res: DebounceEventResult| {
             if let Ok(events) = res {
                 let paths: Vec<PathBuf> = events

--- a/crates/tryke_server/src/watcher.rs
+++ b/crates/tryke_server/src/watcher.rs
@@ -103,7 +103,14 @@ impl FileSig {
 /// still flow through.
 #[derive(Debug, Default)]
 pub struct ChangeFilter {
-    last_seen: HashMap<PathBuf, FileSig>,
+    // `Option<FileSig>` rather than `FileSig` so we can distinguish
+    // "never seen" (key absent) from "seen and currently missing"
+    // (key present, value `None`). Without that distinction, the
+    // first-ever event for a path that's already been deleted would
+    // be silently dropped (`current == prior == None`), and the user
+    // would see no restart / no rediscovery for what is in fact a
+    // real change.
+    last_seen: HashMap<PathBuf, Option<FileSig>>,
 }
 
 impl ChangeFilter {
@@ -117,23 +124,20 @@ impl ChangeFilter {
     /// stamps for every returned path.
     ///
     /// `None` from `FileSig::from_path` (file deleted, unreadable)
-    /// is treated as a state — a transition between `Some` and `None`
-    /// counts as a change too, so a deletion is reported once and
-    /// then quiesces if no further action is taken on the path.
+    /// is treated as a real state — transitions between `Some` and
+    /// `None` count as changes (so deletions and re-creations both
+    /// flow through), and the first observation of a path is always
+    /// a change regardless of whether it currently exists.
     pub fn filter(&mut self, paths: &[PathBuf]) -> Vec<PathBuf> {
         let mut out = Vec::with_capacity(paths.len());
         for path in paths {
             let current = FileSig::from_path(path);
-            let prior = self.last_seen.get(path).copied();
-            if current != prior {
-                match current {
-                    Some(sig) => {
-                        self.last_seen.insert(path.clone(), sig);
-                    }
-                    None => {
-                        self.last_seen.remove(path);
-                    }
-                }
+            let changed = match self.last_seen.get(path) {
+                None => true,
+                Some(prior) => *prior != current,
+            };
+            if changed {
+                self.last_seen.insert(path.clone(), current);
                 out.push(path.clone());
             }
         }
@@ -336,6 +340,33 @@ mod tests {
         assert!(
             after_quiet.is_empty(),
             "second event on still-deleted path is a no-op, got {after_quiet:?}"
+        );
+    }
+
+    /// Regression: in a fresh `tryke watch` session, the first event
+    /// the filter sees for a path may be a deletion. Without
+    /// distinguishing "never seen" from "seen and currently missing",
+    /// `current == prior == None` would silently drop the event and
+    /// the discovery layer would never learn the file is gone.
+    #[test]
+    fn change_filter_first_event_deletion_is_reported() {
+        let dir = make_project();
+        let py = dir.path().join("a.py");
+        // The path never existed (or was deleted before the watcher
+        // started); ChangeFilter has never observed it.
+        assert!(!py.exists());
+
+        let mut f = ChangeFilter::new();
+        let result = f.filter(std::slice::from_ref(&py));
+        assert_eq!(
+            result,
+            vec![py.clone()],
+            "first observation of a missing path must be reported"
+        );
+        let again = f.filter(std::slice::from_ref(&py));
+        assert!(
+            again.is_empty(),
+            "second event on the same still-missing path must quiesce, got {again:?}"
         );
     }
 

--- a/docs/concepts/client-server.md
+++ b/docs/concepts/client-server.md
@@ -68,7 +68,7 @@ File changes trigger a `discover_complete` notification with the updated test li
 
 ## Filesystem watching
 
-The server watches all `.py` files in the project (respecting `.gitignore`) with a 200ms debounce. When files change:
+The server watches all `.py` files in the project (respecting `.gitignore`) with a 100ms debounce. When files change:
 
 1. The batch is dedup'd against each path's last-seen `(mtime, size)` so editor tail events that don't actually change the file (metadata fsync, swap-file cleanup, format-on-save with identical output) are dropped before any work happens
 2. The import graph is incrementally updated

--- a/docs/concepts/client-server.md
+++ b/docs/concepts/client-server.md
@@ -71,7 +71,7 @@ File changes trigger a `discover_complete` notification with the updated test li
 The server watches all `.py` files in the project (respecting `.gitignore`) with a 200ms debounce. When files change:
 
 1. The import graph is incrementally updated
-2. Affected modules are reloaded in the worker pool
+2. The worker subprocesses are restarted so the next run loads fresh code
 3. A `discover_complete` notification is broadcast to all connected clients
 
 This means editors can keep their test explorer up to date in real time.

--- a/docs/concepts/client-server.md
+++ b/docs/concepts/client-server.md
@@ -1,6 +1,6 @@
 # Client/server mode
 
-Tryke can run as a persistent server that keeps Python workers warm and caches test discovery. Clients connect over TCP to request test runs with minimal startup overhead.
+Tryke can run as a persistent server that keeps Python workers warm between file changes and caches test discovery. Clients connect over TCP to request test runs with minimal startup overhead.
 
 ## Starting the server
 
@@ -70,11 +70,12 @@ File changes trigger a `discover_complete` notification with the updated test li
 
 The server watches all `.py` files in the project (respecting `.gitignore`) with a 200ms debounce. When files change:
 
-1. The import graph is incrementally updated
-2. The worker subprocesses are restarted so the next run loads fresh code
-3. A `discover_complete` notification is broadcast to all connected clients
+1. The batch is dedup'd against each path's last-seen `(mtime, size)` so editor tail events that don't actually change the file (metadata fsync, swap-file cleanup, format-on-save with identical output) are dropped before any work happens
+2. The import graph is incrementally updated
+3. The worker subprocesses are restarted so the next run loads fresh code in a brand-new Python interpreter (no `importlib.reload`)
+4. A `discover_complete` notification is broadcast to all connected clients
 
-This means editors can keep their test explorer up to date in real time.
+This means editors can keep their test explorer up to date in real time without spurious double-restarts on a single save.
 
 ## Editor integration
 
@@ -97,6 +98,6 @@ See the [editor integration guide](../guides/editor-integration.md) for setup in
 
 Without the server, every `tryke test` invocation pays for Python startup and test discovery. With the server:
 
-- **Worker processes stay warm** — no Python startup per run
+- **Worker processes stay warm between file changes** — no Python startup per run; on a file change, workers are restarted and immediately re-warmed in parallel so the next run is still on warm interpreters
 - **Discovery is cached** — only changed files are re-scanned
 - **Multiple clients** — several editor windows or terminals can share one server

--- a/docs/concepts/client-server.md
+++ b/docs/concepts/client-server.md
@@ -68,7 +68,7 @@ File changes trigger a `discover_complete` notification with the updated test li
 
 ## Filesystem watching
 
-The server watches all `.py` files in the project (respecting `.gitignore`) with a 100ms debounce. When files change:
+The server watches all `.py` files in the project (respecting `.gitignore`) with a 50ms debounce. When files change:
 
 1. The batch is dedup'd against each path's last-seen `(mtime, size)` so editor tail events that don't actually change the file (metadata fsync, swap-file cleanup, format-on-save with identical output) are dropped before any work happens
 2. The import graph is incrementally updated

--- a/docs/concepts/concurrency.md
+++ b/docs/concepts/concurrency.md
@@ -26,7 +26,9 @@ The `tryke test` default avoids creating more workers than there are tests to ru
 
 ## Pre-warming
 
-Workers are pre-warmed at startup. Before any tests execute, Tryke sends a ping to every worker, causing each one to spawn its Python subprocess in parallel. This means Python startup latency is absorbed before the first test begins, not during it.
+Workers are pre-warmed at startup. Before any tests execute, Tryke sends a ping to every worker over a dedicated per-worker control channel, causing each one to spawn its Python subprocess in parallel. This means Python startup latency is absorbed before the first test begins, not during it.
+
+In `tryke watch` and `tryke server`, this same control channel is used to **restart** workers when a watched file changes: each worker kills its current Python process and immediately respawns a fresh one (replaying any cached fixture registrations). Pre-warming on restart is parallel, so the workers are warm again by the time the next test cycle begins. This is how Tryke picks up code changes — it does **not** call `importlib.reload` in-process, which is fragile once classes, closures, or decorator-bound state from the old definitions have been captured elsewhere.
 
 ## Distribution modes
 

--- a/docs/concepts/discovery.md
+++ b/docs/concepts/discovery.md
@@ -55,16 +55,16 @@ warning: tests/helpers/loader.py — dynamic imports found; this file will alway
 
 ### Effect on watch and server mode
 
-Tryke tracks which Python modules to reload between test cycles by following static
-import edges. Dynamic import edges are invisible to this graph. This means:
+Watch and server mode pick up code changes by restarting the worker subprocesses
+between cycles, so every cycle starts with an empty `sys.modules`. Both static
+and dynamic imports load the latest source on the first test that needs them —
+there is no stale-cache pitfall here.
 
-- If `helper.py` is only imported dynamically by `loader.py`, and `helper.py` changes,
-  the watch-mode worker may not reload `helper` during that cycle.
-- `loader.py` itself will always be reloaded (it is always-dirty), but when its code
-  re-executes `importlib.import_module("helper")`, it may receive the stale cached
-  version from `sys.modules`.
-- This can cause tests to pass or fail based on code that hasn't been reflected yet,
-  persisting until the watch session restarts.
+The static import graph still drives **test selection**: only tests that
+transitively import a changed file are rerun. A file with a dynamic import is
+marked always-dirty (the same rule as `--changed`), so any test that imports it
+will rerun on every change. To narrow watch reruns, prefer static imports — see
+the recommendations below.
 
 ## Recommendations
 
@@ -153,8 +153,7 @@ exclude = ["scripts/generate.py", "benchmarks/suites"]
 ### Accept the tradeoff when it's intentional
 
 If a file intentionally tests dynamic loading behavior — for example, a test that
-verifies your plugin loader works — that's fine. Just be aware that:
-
-- Those tests will always run with `--changed`
-- In watch/server mode, editing the dynamically-loaded target may require restarting
-  the watch session to pick up changes reliably
+verifies your plugin loader works — that's fine. Just be aware that those tests
+will always run with `--changed`, since the import graph cannot prove they aren't
+affected by an unrelated change. (Watch and server mode restart workers on every
+change, so the dynamically-loaded code itself is always reloaded fresh.)

--- a/docs/concepts/discovery.md
+++ b/docs/concepts/discovery.md
@@ -121,7 +121,7 @@ if TYPE_CHECKING:
 Python 3.15 introduces an explicit `lazy` keyword that defers a real import to the
 first use of the bound name. Tryke parses `lazy import` and `lazy from` exactly like
 their eager counterparts and adds them to the import graph, so deferring an import
-does **not** break `--changed` selection or watch-mode reloads:
+does **not** break `--changed` selection or watch-mode reruns:
 
 ```python
 # tracked just like a plain import

--- a/docs/guides/running-tests.md
+++ b/docs/guides/running-tests.md
@@ -113,4 +113,4 @@ tryke test --port
 tryke test --port 2337
 ```
 
-The server keeps Python workers warm and caches test discovery, so subsequent runs skip startup overhead.
+The server keeps Python workers warm between file changes and caches test discovery, so subsequent runs skip startup overhead. When a watched file changes, the workers are restarted (so the new code loads in a fresh interpreter) and immediately re-warmed in parallel.

--- a/docs/guides/watch-mode.md
+++ b/docs/guides/watch-mode.md
@@ -12,9 +12,10 @@ Tryke watches all `.py` files in the project, respecting `.gitignore`. When a fi
 
 1. Identifies which modules were modified
 2. Walks the import graph to find all tests that depend on the changed modules
-3. Reruns only those tests
+3. Restarts the worker subprocesses so the next run loads the updated code in a fresh Python interpreter
+4. Reruns only the affected tests
 
-This gives you fast feedback without rerunning the entire suite.
+This gives you fast feedback without rerunning the entire suite. Restarting the workers (rather than calling `importlib.reload` in-process) avoids the classic reload pitfalls — stale class objects, captured closures, and decorator-bound state from the old definitions are all dropped because the interpreter itself is gone.
 
 ## How affected tests are determined
 
@@ -95,6 +96,8 @@ This is useful when:
 Worker subprocesses are still restarted on every change so Python picks up
 the new code from a fresh interpreter; only the test selection is broadened.
 
-## Debouncing
+## Debouncing and change dedup
 
-File system events are debounced with a 200ms window. Rapid successive saves are coalesced into a single rerun.
+File system events are debounced with a 200ms quiet window — rapid successive saves are coalesced into a single rerun.
+
+On top of the debouncer, watch mode tracks each file's `(mtime, size)` signature and skips events that don't actually move it. Editor tail activity (atomic-rename metadata writes, swap-file cleanup, format-on-save that produces identical output, LSP re-saves) often produces a second batch of events outside the debounce window; without the signature check, that second batch would trigger a redundant restart for a single user save. With it, only batches that represent a real content change reach the worker pool.

--- a/docs/guides/watch-mode.md
+++ b/docs/guides/watch-mode.md
@@ -98,6 +98,6 @@ the new code from a fresh interpreter; only the test selection is broadened.
 
 ## Debouncing and change dedup
 
-File system events are debounced with a 200ms quiet window — rapid successive saves are coalesced into a single rerun.
+File system events are debounced with a 100ms quiet window — just long enough to coalesce the burst of inotify events the kernel emits for a single write syscall.
 
-On top of the debouncer, watch mode tracks each file's `(mtime, size)` signature and skips events that don't actually move it. Editor tail activity (atomic-rename metadata writes, swap-file cleanup, format-on-save that produces identical output, LSP re-saves) often produces a second batch of events outside the debounce window; without the signature check, that second batch would trigger a redundant restart for a single user save. With it, only batches that represent a real content change reach the worker pool.
+On top of the debouncer, watch mode tracks each file's `(mtime, size)` signature and skips events that don't actually move it. Editor tail activity (atomic-rename metadata writes, swap-file cleanup, format-on-save that produces identical output, LSP re-saves) often produces a second batch of events outside the debounce window; without the signature check, that second batch would trigger a redundant restart for a single user save. With it, only batches that represent a real content change reach the worker pool — so we can keep the debounce tight without paying for it in spurious restarts.

--- a/docs/guides/watch-mode.md
+++ b/docs/guides/watch-mode.md
@@ -98,6 +98,6 @@ the new code from a fresh interpreter; only the test selection is broadened.
 
 ## Debouncing and change dedup
 
-File system events are debounced with a 100ms quiet window — just long enough to coalesce the burst of inotify events the kernel emits for a single write syscall.
+File system events are debounced with a 50ms quiet window — just long enough to coalesce the burst of inotify events the kernel emits for a single write syscall.
 
 On top of the debouncer, watch mode tracks each file's `(mtime, size)` signature and skips events that don't actually move it. Editor tail activity (atomic-rename metadata writes, swap-file cleanup, format-on-save that produces identical output, LSP re-saves) often produces a second batch of events outside the debounce window; without the signature check, that second batch would trigger a redundant restart for a single user save. With it, only batches that represent a real content change reach the worker pool — so we can keep the debounce tight without paying for it in spurious restarts.

--- a/docs/guides/watch-mode.md
+++ b/docs/guides/watch-mode.md
@@ -92,8 +92,8 @@ This is useful when:
 - You are debugging test ordering or flake issues and want a full run on
   every save.
 
-Module reload still happens for the changed files, so Python picks up the new
-code; only the test selection is broadened.
+Worker subprocesses are still restarted on every change so Python picks up
+the new code from a fresh interpreter; only the test selection is broadened.
 
 ## Debouncing
 

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -18,14 +18,13 @@ Supported methods:
 - `finalize_hooks {module}` → `null`
 - `run_test    {module, function, xfail?, groups?}` → tagged outcome dict
 - `run_doctest {module, object_path}` → tagged outcome dict
-- `reload {modules: [...]}` → `null`  (watch/server mode only)
 
 The wire format mirrors `crates/tryke_runner/src/protocol.rs`. The
 TypedDicts below (`_AssertionWire`, `_PassedResult`, …) are the result
 shapes the runner decodes. The hook-related request shapes are handled
-at the dispatch boundary in `_register_hooks` / `_reload` — the Rust
-side statically discovered the fixture metadata with Ruff, so the
-worker just trusts the incoming list and does not re-parse source.
+at the dispatch boundary in `_register_hooks` — the Rust side
+statically discovered the fixture metadata with Ruff, so the worker
+just trusts the incoming list and does not re-parse source.
 
 ## Hook lifecycle
 
@@ -41,9 +40,11 @@ worker just trusts the incoming list and does not re-parse source.
    teardown callbacks. Result is cached in `self._executors[module]`.
 4. After every test in a module has run, the runner sends
    `finalize_hooks` and the executor runs `per="scope"` teardown.
-5. In watch/server mode, file changes trigger a `reload` which drops
-   `self._modules[name]` / `self._executors[name]` and calls
-   `importlib.reload(...)` so the next `run_test` gets a fresh import.
+5. In watch/server mode, file changes do not reach the worker over the
+   wire — the runner instead kills this subprocess and respawns it,
+   replaying `register_hooks` on the fresh process. `importlib.reload`
+   is not used; a clean interpreter is the only reliable way to drop
+   classes and closures captured under the old definitions.
 """
 
 from __future__ import annotations
@@ -97,9 +98,9 @@ if TYPE_CHECKING:
 _TRYKE_PKG = str(Path(__file__).resolve().parent)
 
 # Worker-side logger. Debug/trace output is useful when auditing module
-# reloads under watch/server mode; enable with `TRYKE_WORKER_LOG=DEBUG`
-# (or `TRACE`). Messages go to stderr so they don't corrupt the JSON-RPC
-# channel on stdout. Off by default.
+# import and dispatch; enable with `TRYKE_WORKER_LOG=DEBUG` (or `TRACE`).
+# Messages go to stderr so they don't corrupt the JSON-RPC channel on
+# stdout. Off by default.
 _log = logging.getLogger("tryke.worker")
 
 
@@ -478,12 +479,6 @@ class Worker:
                 self._require_str(params, "module", method),
                 str(params.get("object_path", "")),
             )
-        if method == "reload":
-            raw = params.get("modules", [])
-            if not isinstance(raw, list):
-                msg = "method 'reload' parameter 'modules' must be a list"
-                raise _InvalidParamsError(msg)
-            return self._reload([str(m) for m in raw])
         msg = f"unknown method: {method}"
         raise ValueError(msg)
 
@@ -525,7 +520,8 @@ class Worker:
 
         Any previously-cached :class:`HookExecutor` for this module is
         dropped so the next test rebuilds fixtures from the fresh
-        metadata — this matters after `reload` or re-registration.
+        metadata — this matters when the runner re-registers the same
+        module (e.g. after a worker respawn during watch/server mode).
         """
         if not isinstance(hooks, list):
             return
@@ -853,47 +849,6 @@ class Worker:
             )
         return _passed(ms, out, err)
 
-    def _reload(self, module_names: list[str]) -> None:
-        """Drop cached imports and executors for the given modules.
-
-        Called by the runner in watch/server mode when the file watcher
-        reports a change that affects these modules. We use
-        :func:`importlib.reload` rather than popping ``sys.modules`` so
-        classes/functions imported *elsewhere* under the old module
-        identity stay referencable — ``reload`` mutates the existing
-        module object in place instead of building a new one.
-
-        The cached :class:`HookExecutor` is always dropped, even if the
-        module was never imported in this worker, because a fresh
-        ``register_hooks`` from the runner may have arrived before the
-        next ``run_test``.
-        """
-        _log.debug("reload: requested modules=%s", module_names)
-        reloaded_count = 0
-        for name in module_names:
-            if name in sys.modules:
-                try:
-                    reloaded = importlib.reload(sys.modules[name])
-                except Exception:
-                    _log.exception("reload: importlib.reload failed for %s", name)
-                    raise
-                self._modules[name] = reloaded
-                reloaded_count += 1
-                _log.debug("reload: reloaded %s", name)
-            else:
-                _log.debug(
-                    "reload: %s not in sys.modules — skipping reload, "
-                    "executor will be rebuilt on next run_test",
-                    name,
-                )
-            # Clear cached executor so hooks are re-discovered on next run.
-            self._executors.pop(name, None)
-        _log.debug(
-            "reload: done — %d/%d module(s) actually reloaded",
-            reloaded_count,
-            len(module_names),
-        )
-
 
 def _configure_logging_from_env() -> None:
     """Opt-in worker logging via ``TRYKE_WORKER_LOG``.
@@ -901,8 +856,8 @@ def _configure_logging_from_env() -> None:
     Off by default so normal test runs don't emit anything on stderr.
     Set ``TRYKE_WORKER_LOG=DEBUG`` (or ``INFO`` / ``TRACE``) before
     invoking ``tryke test``/``tryke watch``/``tryke server`` to trace
-    module registration and reload behavior. Output goes to stderr so
-    it never contaminates the JSON-RPC stream on stdout.
+    module registration and dispatch. Output goes to stderr so it never
+    contaminates the JSON-RPC stream on stdout.
     """
     level_name = os.environ.get("TRYKE_WORKER_LOG", "").strip().upper()
     if not level_name:


### PR DESCRIPTION
## Summary

Replace the brittle `importlib.reload`-based approach to picking up code changes in watch/server mode with a cleaner subprocess restart strategy. When files change, the runner now kills and respawns worker subprocesses instead of attempting to reload modules in-process.

## Key Changes

- **Worker pool API**: Renamed `reload(modules)` to `restart_workers()` which kills each worker subprocess and respawns a fresh one, rather than attempting in-process module reloading
- **Worker message protocol**: Changed `WorkerMsg::Reload(Vec<String>, ack_tx)` to `WorkerMsg::Restart(ack_tx)`, removing the module list parameter since the entire process is restarted
- **Worker task implementation**: Updated to call `shutdown()` on the old process and eagerly respawn via `ensure_worker()`, which replays cached `register_hooks` calls to restore fixture state
- **Python worker**: Removed the `_reload()` method and `reload` RPC dispatch entirely; the worker no longer needs to handle module reloading
- **Protocol**: Removed `ReloadParams` struct from the RPC protocol
- **Watch/server integration**: Updated watch mode and server mode to call `restart_workers()` instead of `reload(modules)`
- **Documentation**: Updated all references to explain that code changes are picked up via fresh interpreter startup, not in-process reloading

## Implementation Details

The new approach is more reliable because:
- A completely fresh Python interpreter avoids the brittleness of `importlib.reload`, which leaves classes/closures/decorator-bound state from old definitions referenced elsewhere
- The respawned worker replays cached `register_hooks` calls, mirroring the crash-recovery path and ensuring fixtures continue to work
- The static import graph still drives test selection (only tests importing changed files rerun), but code freshness is guaranteed

Two new tests verify the behavior:
- `restart_workers_runs_module_body_on_fresh_interpreter`: Confirms module bodies execute on fresh interpreters by counting imports
- `restart_workers_with_no_live_processes_acks`: Ensures restart works gracefully when no workers are yet spawned (e.g., file watcher fires before first test run)

https://claude.ai/code/session_01EnmdUm6e6iyrw4yZyhTtBm