### PR TITLE
Switch to cargo-nextest and fix slow tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.default]
+# Warn on tests slower than 30s. No terminate-after — that masks flakes.
+slow-timeout = { period = "30s" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,11 @@ jobs:
           allow-prereleases: true
       - run: rustup show
       - uses: Swatinem/rust-cache@v2.8.2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - run: cargo build --verbose
-      - run: cargo test --verbose
+      - run: cargo nextest run --workspace --all-features
       - run: cargo run -- test
 
   ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,15 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo run test --reporter llm
 ```
 
+## running rust tests
+
+we use [`cargo-nextest`](https://nexte.st) — install once with
+`cargo install cargo-nextest --locked`, then:
+
+```bash
+cargo nextest run --workspace --all-features
+```
+
 ## dev guidelines
 
 - all changes must be tested. if you're not testing your changes, you're not done.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,21 @@ virtualenv so you can import and test the python bindings locally.
 
 run `cargo run test` to test tryke's own python code, using tryke
 
+## rust tests
+
+we use [`cargo-nextest`](https://nexte.st) for the rust test suite. install it
+once:
+
+```bash
+cargo install cargo-nextest --locked
+```
+
+then run the suite with:
+
+```bash
+cargo nextest run --workspace --all-features
+```
+
 ## updating CLI docs
 
 run `cargo run -p tryke_dev --bin generate-cli-docs --` after changing the Rust CLI definitions
@@ -51,7 +66,7 @@ to validate the generated benchmark docs without rewriting files, run
 
 ## updating snapshot tests
 
-1. run `cargo test` — new or changed snapshots are written to
+1. run `cargo nextest run` — new or changed snapshots are written to
 `crates/tryke/tests/snapshots/` as `.snap.new` files
 2. review pending snapshots: `cargo insta review` (interactive) or accept all:
 `cargo insta accept`

--- a/crates/tryke/src/execution.rs
+++ b/crates/tryke/src/execution.rs
@@ -214,7 +214,7 @@ pub async fn report_cycle(
 
 #[cfg(test)]
 mod tests {
-    use std::{env, path::PathBuf};
+    use std::path::PathBuf;
 
     use tryke_discovery::Discoverer;
     use tryke_reporter::{DotReporter, JSONReporter, JUnitReporter, TextReporter};
@@ -229,10 +229,6 @@ mod tests {
             .canonicalize()
             .expect("workspace root");
         tryke_runner::resolve_python(&root)
-    }
-
-    fn cwd() -> PathBuf {
-        env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
     }
 
     async fn run_cycle(
@@ -253,16 +249,18 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
-    async fn test_command_text() {
-        let mut reporter = TextReporter::with_writer(Vec::new());
-        let root = cwd();
-        let excludes = resolved_excludes(&root, &[], &[]);
-        let tests = discover_tests(&root, false, None, &excludes).tests;
-        // ignore pass/fail result — this test verifies the reporter doesn't panic
+    /// Smoke-test a reporter against the full `run_tests` pipeline using an
+    /// empty project. Exercises check_python_version, pool init/teardown, and
+    /// the reporter's run_start/run_summary callbacks without doing real work.
+    /// Snapshot tests in `tests/snapshots.rs` cover per-test rendering.
+    async fn smoke_run_tests(reporter: &mut dyn Reporter) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("pyproject.toml"), "").expect("write pyproject.toml");
+        let excludes = resolved_excludes(dir.path(), &[], &[]);
+        let tests = discover_tests(dir.path(), false, None, &excludes).tests;
         let _ = run_tests(
-            &mut reporter,
-            &root,
+            reporter,
+            dir.path(),
             tests,
             &[],
             None,
@@ -272,66 +270,30 @@ mod tests {
             None,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_command_text() {
+        let mut reporter = TextReporter::with_writer(Vec::new());
+        smoke_run_tests(&mut reporter).await;
     }
 
     #[tokio::test]
     async fn test_command_json() {
         let mut reporter = JSONReporter::with_writer(Vec::new());
-        let root = cwd();
-        let excludes = resolved_excludes(&root, &[], &[]);
-        let tests = discover_tests(&root, false, None, &excludes).tests;
-        let _ = run_tests(
-            &mut reporter,
-            &root,
-            tests,
-            &[],
-            None,
-            None,
-            DistMode::Test,
-            None,
-            None,
-        )
-        .await;
+        smoke_run_tests(&mut reporter).await;
     }
 
     #[tokio::test]
     async fn test_command_dot() {
         let mut reporter = DotReporter::with_writer(Vec::new());
-        let root = cwd();
-        let excludes = resolved_excludes(&root, &[], &[]);
-        let tests = discover_tests(&root, false, None, &excludes).tests;
-        let _ = run_tests(
-            &mut reporter,
-            &root,
-            tests,
-            &[],
-            None,
-            None,
-            DistMode::Test,
-            None,
-            None,
-        )
-        .await;
+        smoke_run_tests(&mut reporter).await;
     }
 
     #[tokio::test]
     async fn test_command_junit() {
         let mut reporter = JUnitReporter::with_writer(Vec::new());
-        let root = cwd();
-        let excludes = resolved_excludes(&root, &[], &[]);
-        let tests = discover_tests(&root, false, None, &excludes).tests;
-        let _ = run_tests(
-            &mut reporter,
-            &root,
-            tests,
-            &[],
-            None,
-            None,
-            DistMode::Test,
-            None,
-            None,
-        )
-        .await;
+        smoke_run_tests(&mut reporter).await;
     }
 
     #[tokio::test]

--- a/crates/tryke_server/src/watcher.rs
+++ b/crates/tryke_server/src/watcher.rs
@@ -9,6 +9,13 @@ use log::debug;
 use notify::RecommendedWatcher;
 use notify_debouncer_mini::{DebounceEventResult, Debouncer, new_debouncer};
 
+// Tests use a shorter delay so the suite doesn't pay 200ms per watcher case;
+// the real watcher needs 200ms to coalesce bursty editor saves.
+#[cfg(not(test))]
+const DEBOUNCE_DELAY: Duration = Duration::from_millis(200);
+#[cfg(test)]
+const DEBOUNCE_DELAY: Duration = Duration::from_millis(50);
+
 fn build_gitignore(root: &Path, excludes: &[String]) -> Gitignore {
     let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
     let mut builder = GitignoreBuilder::new(&canonical);
@@ -27,27 +34,24 @@ pub fn spawn_watcher(
     tx: mpsc::Sender<Vec<PathBuf>>,
 ) -> anyhow::Result<Debouncer<RecommendedWatcher>> {
     let gitignore = build_gitignore(root, excludes);
-    let mut debouncer = new_debouncer(
-        Duration::from_millis(200),
-        move |res: DebounceEventResult| {
-            if let Ok(events) = res {
-                let paths: Vec<PathBuf> = events
-                    .iter()
-                    .filter(|e| e.path.extension().is_some_and(|ext| ext == "py"))
-                    .filter(|e| {
-                        !gitignore
-                            .matched_path_or_any_parents(&e.path, false)
-                            .is_ignore()
-                    })
-                    .map(|e| e.path.clone())
-                    .collect();
-                if !paths.is_empty() {
-                    debug!("file changes detected: {paths:?}");
-                    let _ = tx.send(paths);
-                }
+    let mut debouncer = new_debouncer(DEBOUNCE_DELAY, move |res: DebounceEventResult| {
+        if let Ok(events) = res {
+            let paths: Vec<PathBuf> = events
+                .iter()
+                .filter(|e| e.path.extension().is_some_and(|ext| ext == "py"))
+                .filter(|e| {
+                    !gitignore
+                        .matched_path_or_any_parents(&e.path, false)
+                        .is_ignore()
+                })
+                .map(|e| e.path.clone())
+                .collect();
+            if !paths.is_empty() {
+                debug!("file changes detected: {paths:?}");
+                let _ = tx.send(paths);
             }
-        },
-    )?;
+        }
+    })?;
     debouncer
         .watcher()
         .watch(root, notify::RecursiveMode::Recursive)?;
@@ -101,7 +105,7 @@ mod tests {
         fs::write(&txt_file, "some text").expect("write txt file");
 
         assert!(
-            rx.recv_timeout(Duration::from_millis(500)).is_err(),
+            rx.recv_timeout(Duration::from_millis(400)).is_err(),
             "should not fire for non-py files"
         );
     }
@@ -123,7 +127,7 @@ mod tests {
         fs::write(&ignored_file, "x = 2").expect("update ignored py file");
 
         assert!(
-            rx.recv_timeout(Duration::from_millis(500)).is_err(),
+            rx.recv_timeout(Duration::from_millis(400)).is_err(),
             "should not fire for gitignored py files"
         );
     }


### PR DESCRIPTION
## Summary

- migrate ci and the `CONTRIBUTING.md` / `AGENTS.md` docs to `cargo nextest run` (workspace has no doctests, so no extra `cargo test --doc` step needed). nextest is installed in ci via `taiki-e/install-action@v2`.
- fix the two clusters of slow tests that nextest's per-test timing made visible:
  - `execution::tests::test_command_{text,json,dot,junit}` were calling `cwd()` and discovering all ~525 tests in the workspace, four times over. replaced with an empty tempdir fixture via a small `smoke_run_tests` helper. **~40s → ~17ms each.**
  - watcher tests use a `cfg(test)`-shadowed `DEBOUNCE_DELAY` (50ms in tests vs 200ms in prod), and the two negative-case `recv_timeout`s drop from 500ms → 400ms. **~5.6s → ~1.8s worst case.**
- rust suite wall-clock locally: **~45s → ~5s**.
- new `.config/nextest.toml` with `slow-timeout = "30s"` (warning only — no `terminate-after`, which would mask flakes).
- intentionally left alone: `worker_continues_after_large_stderr_write` (the 1MB write is intentional regression coverage for pipe-buffer deadlock) and `check_python_version_*` (cost is real Python cold-start).

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 523 passed in ~5s
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `uvx prek run -a`
- [x] `cargo run -- test --reporter llm` — 202 passed
- [ ] confirm matrix passes in ci (4 python versions × 3 oses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)