### PR TITLE
Fold tryke watch into tryke test --watch

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -13,5 +13,3 @@ if ! command -v cargo-nextest >/dev/null 2>&1; then
 fi
 
 cargo nextest run --workspace --all-features
-
-cargo run test --reporter llm

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -11,5 +11,3 @@ cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 if ! command -v cargo-nextest >/dev/null 2>&1; then
   cargo install cargo-nextest --locked
 fi
-
-cargo nextest run --workspace --all-features

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+# Installs cargo-nextest (the project's canonical test runner per CLAUDE.md)
+# and pre-warms the Rust + Python test suites.
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+
+# Install cargo-nextest if missing. `cargo install --locked` is idempotent:
+# it skips reinstall when the binary is already at the requested version.
+if ! command -v cargo-nextest >/dev/null 2>&1; then
+  cargo install cargo-nextest --locked
+fi
+
+cargo nextest run --workspace --all-features
+
+cargo run test --reporter llm

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cargo test"
-          },
-          {
-            "type": "command",
-            "command": "cargo run test"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ with t.describe("users"):
 
 ```
 
-Run your tests — `tryke watch` for an always-on loop, `tryke test --changed`
+Run your tests — `tryke test --watch` for an always-on loop, `tryke test --changed`
 for just what your working tree touched, or plain:
 
 ```bash

--- a/crates/tryke/src/cli.rs
+++ b/crates/tryke/src/cli.rs
@@ -56,6 +56,7 @@ pub enum Commands {
     /// Collect and run tests.
     Test {
         /// File paths or file:line specs to restrict collection
+        #[arg(conflicts_with = "watch")]
         paths: Vec<String>,
         /// Exclude files/directories from discovery (overrides pyproject config)
         #[arg(short = 'e', long = "exclude")]
@@ -64,7 +65,7 @@ pub enum Commands {
         #[arg(short = 'i', long = "include")]
         include: Vec<String>,
         /// Collect tests without running them
-        #[arg(long)]
+        #[arg(long, conflicts_with = "watch")]
         collect_only: bool,
         /// Filter expression (e.g. "math and not slow")
         #[arg(short = 'k', long = "filter")]
@@ -79,13 +80,13 @@ pub enum Commands {
         #[arg(long)]
         root: Option<PathBuf>,
         /// Use an already-running server on the optional port
-        #[arg(long, default_missing_value = "2337", num_args = 0..=1, require_equals = false)]
+        #[arg(long, default_missing_value = "2337", num_args = 0..=1, require_equals = false, conflicts_with = "watch")]
         port: Option<u16>,
         /// Run only tests affected by files changed since HEAD (requires git)
-        #[arg(long, conflicts_with = "changed_first")]
+        #[arg(long, conflicts_with_all = ["changed_first", "watch"])]
         changed: bool,
         /// Run changed tests first, then all remaining tests (requires git)
-        #[arg(long, conflicts_with = "changed")]
+        #[arg(long, conflicts_with_all = ["changed", "watch"])]
         changed_first: bool,
         /// Base branch for --changed or --changed-first (e.g. "main"). Uses merge-base diff.
         #[arg(long)]
@@ -102,41 +103,11 @@ pub enum Commands {
         /// How tests are distributed across workers
         #[arg(long, default_value = "test")]
         dist: Dist,
-    },
-    /// Watch files and rerun affected tests.
-    Watch {
-        /// Exclude files/directories from discovery (overrides pyproject config)
-        #[arg(short = 'e', long = "exclude")]
-        exclude: Vec<String>,
-        /// Include files/directories even if excluded by `pyproject.toml`
-        #[arg(short = 'i', long = "include")]
-        include: Vec<String>,
-        /// Filter expression (e.g. "math and not slow")
-        #[arg(short = 'k', long = "filter")]
-        filter: Option<String>,
-        /// Tag/marker filter expression (e.g. "slow and not network")
-        #[arg(short = 'm', long = "markers")]
-        markers: Option<String>,
-        /// Reporter format to use for output
-        #[arg(long = "reporter", default_value = "text")]
-        reporter: ReporterFormat,
-        /// Project root used for discovery and execution
-        #[arg(long)]
-        root: Option<PathBuf>,
-        /// Stop after first failure
-        #[arg(short = 'x', long = "fail-fast")]
-        fail_fast: bool,
-        /// Stop after N failures
-        #[arg(long)]
-        maxfail: Option<usize>,
-        /// Number of worker processes (default: cpu_count)
-        #[arg(short = 'j', long = "workers")]
-        workers: Option<usize>,
-        /// How tests are distributed across workers
-        #[arg(long, default_value = "test")]
-        dist: Dist,
-        /// Rerun the full test set on every change instead of just affected tests
-        #[arg(short = 'a', long = "all")]
+        /// Watch files and rerun affected tests on change (press q to quit).
+        #[arg(short = 'w', long = "watch")]
+        watch: bool,
+        /// In watch mode, rerun the full test set on every change instead of just affected tests
+        #[arg(short = 'a', long = "all", requires = "watch")]
         all: bool,
     },
     /// Start a persistent worker server.

--- a/crates/tryke/src/main.rs
+++ b/crates/tryke/src/main.rs
@@ -85,6 +85,8 @@ fn main() -> Result<()> {
             workers,
             dist,
             include,
+            watch,
+            all,
         } => {
             if base_branch.is_some() && !changed && !changed_first {
                 return Err(anyhow::anyhow!(
@@ -93,6 +95,25 @@ fn main() -> Result<()> {
             }
             let resolved_maxfail = if *fail_fast { Some(1) } else { *maxfail };
             let mut rep = build_reporter(reporter, verbosity, cli.no_progress);
+            if *watch {
+                rep.set_subcommand_label("tryke test --watch");
+                rep.set_watch_hint(Some("Waiting for file changes... press q to quit".into()));
+                let cwd = env::current_dir()?;
+                let root_path = root.as_deref().unwrap_or(&cwd);
+                let excludes = resolved_excludes(root_path, exclude, include);
+                let test_filter = TestFilter::from_args(&[], filter.as_deref(), markers.as_deref())
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                return rt.block_on(run_watch(
+                    &mut *rep,
+                    Some(root_path),
+                    &excludes,
+                    &test_filter,
+                    resolved_maxfail,
+                    *workers,
+                    (*dist).into(),
+                    *all,
+                ));
+            }
             if let Some(p) = port {
                 if !exclude.is_empty() {
                     return Err(anyhow::anyhow!(
@@ -156,39 +177,6 @@ fn main() -> Result<()> {
                     changed_selection,
                 ))
             }
-        }
-        Commands::Watch {
-            exclude,
-            filter,
-            markers,
-            reporter,
-            root,
-            fail_fast,
-            maxfail,
-            workers,
-            dist,
-            include,
-            all,
-        } => {
-            let resolved_maxfail = if *fail_fast { Some(1) } else { *maxfail };
-            let mut rep = build_reporter(reporter, verbosity, cli.no_progress);
-            rep.set_subcommand_label("tryke watch");
-            rep.set_watch_hint(Some("Waiting for file changes... press q to quit".into()));
-            let cwd = env::current_dir()?;
-            let root_path = root.as_deref().unwrap_or(&cwd);
-            let excludes = resolved_excludes(root_path, exclude, include);
-            let test_filter = TestFilter::from_args(&[], filter.as_deref(), markers.as_deref())
-                .map_err(|e| anyhow::anyhow!(e))?;
-            rt.block_on(run_watch(
-                &mut *rep,
-                Some(root_path),
-                &excludes,
-                &test_filter,
-                resolved_maxfail,
-                *workers,
-                (*dist).into(),
-                *all,
-            ))
         }
         Commands::Server {
             port,
@@ -344,7 +332,7 @@ mod tests {
 
     #[test]
     fn no_progress_flag_parsed_for_watch() {
-        let cli = Cli::try_parse_from(["tryke", "watch", "--no-progress"]).unwrap();
+        let cli = Cli::try_parse_from(["tryke", "test", "--watch", "--no-progress"]).unwrap();
         assert!(cli.no_progress);
     }
 
@@ -468,21 +456,82 @@ mod tests {
     }
 
     #[test]
-    fn watch_subcommand_parsed() {
-        let cli = Cli::try_parse_from(["tryke", "watch"]).unwrap();
-        assert!(matches!(cli.command, Commands::Watch { .. }));
+    fn watch_flag_parsed() {
+        let cli = Cli::try_parse_from(["tryke", "test", "--watch"]).unwrap();
+        assert!(matches!(cli.command, Commands::Test { watch: true, .. }));
     }
 
     #[test]
-    fn watch_subcommand_with_reporter_parsed() {
-        let cli = Cli::try_parse_from(["tryke", "watch", "--reporter", "json"]).unwrap();
+    fn watch_short_flag_parsed() {
+        let cli = Cli::try_parse_from(["tryke", "test", "-w"]).unwrap();
+        assert!(matches!(cli.command, Commands::Test { watch: true, .. }));
+    }
+
+    #[test]
+    fn watch_with_reporter_parsed() {
+        let cli = Cli::try_parse_from(["tryke", "test", "--watch", "--reporter", "json"]).unwrap();
         assert!(matches!(
             cli.command,
-            Commands::Watch {
+            Commands::Test {
+                watch: true,
                 reporter: ReporterFormat::Json,
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn watch_conflicts_with_collect_only() {
+        let result = Cli::try_parse_from(["tryke", "test", "--watch", "--collect-only"]);
+        assert!(
+            result.is_err(),
+            "--watch and --collect-only should conflict"
+        );
+    }
+
+    #[test]
+    fn watch_conflicts_with_changed() {
+        let result = Cli::try_parse_from(["tryke", "test", "--watch", "--changed"]);
+        assert!(result.is_err(), "--watch and --changed should conflict");
+    }
+
+    #[test]
+    fn watch_conflicts_with_changed_first() {
+        let result = Cli::try_parse_from(["tryke", "test", "--watch", "--changed-first"]);
+        assert!(
+            result.is_err(),
+            "--watch and --changed-first should conflict"
+        );
+    }
+
+    #[test]
+    fn watch_conflicts_with_port() {
+        let result = Cli::try_parse_from(["tryke", "test", "--watch", "--port", "2337"]);
+        assert!(result.is_err(), "--watch and --port should conflict");
+    }
+
+    #[test]
+    fn watch_conflicts_with_paths() {
+        let result = Cli::try_parse_from(["tryke", "test", "--watch", "tests/foo.py"]);
+        assert!(
+            result.is_err(),
+            "--watch and positional paths should conflict"
+        );
+    }
+
+    #[test]
+    fn all_requires_watch() {
+        let result = Cli::try_parse_from(["tryke", "test", "--all"]);
+        assert!(result.is_err(), "--all without --watch should error");
+    }
+
+    #[test]
+    fn watch_subcommand_removed() {
+        let result = Cli::try_parse_from(["tryke", "watch"]);
+        assert!(
+            result.is_err(),
+            "`tryke watch` subcommand should no longer exist"
+        );
     }
 
     #[test]
@@ -598,10 +647,11 @@ mod tests {
 
     #[test]
     fn watch_filter_flag_parsed() {
-        let cli = Cli::try_parse_from(["tryke", "watch", "-k", "test_add"]).unwrap();
+        let cli = Cli::try_parse_from(["tryke", "test", "--watch", "-k", "test_add"]).unwrap();
         assert!(matches!(
             &cli.command,
-            Commands::Watch {
+            Commands::Test {
+                watch: true,
                 filter: Some(f),
                 ..
             } if f == "test_add"
@@ -640,10 +690,11 @@ mod tests {
 
     #[test]
     fn watch_workers_flag_parsed() {
-        let cli = Cli::try_parse_from(["tryke", "watch", "-j", "2"]).unwrap();
+        let cli = Cli::try_parse_from(["tryke", "test", "--watch", "-j", "2"]).unwrap();
         assert!(matches!(
             cli.command,
-            Commands::Watch {
+            Commands::Test {
+                watch: true,
                 workers: Some(2),
                 ..
             }
@@ -652,20 +703,41 @@ mod tests {
 
     #[test]
     fn watch_all_flag_defaults_to_false() {
-        let cli = Cli::try_parse_from(["tryke", "watch"]).unwrap();
-        assert!(matches!(cli.command, Commands::Watch { all: false, .. }));
+        let cli = Cli::try_parse_from(["tryke", "test", "--watch"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Test {
+                watch: true,
+                all: false,
+                ..
+            }
+        ));
     }
 
     #[test]
     fn watch_all_long_flag_parsed() {
-        let cli = Cli::try_parse_from(["tryke", "watch", "--all"]).unwrap();
-        assert!(matches!(cli.command, Commands::Watch { all: true, .. }));
+        let cli = Cli::try_parse_from(["tryke", "test", "--watch", "--all"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Test {
+                watch: true,
+                all: true,
+                ..
+            }
+        ));
     }
 
     #[test]
     fn watch_all_short_flag_parsed() {
-        let cli = Cli::try_parse_from(["tryke", "watch", "-a"]).unwrap();
-        assert!(matches!(cli.command, Commands::Watch { all: true, .. }));
+        let cli = Cli::try_parse_from(["tryke", "test", "--watch", "-a"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Test {
+                watch: true,
+                all: true,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/tryke_reporter/src/reporter.rs
+++ b/crates/tryke_reporter/src/reporter.rs
@@ -11,7 +11,7 @@ pub trait Reporter {
     /// those files are always included in `--changed` runs.
     fn on_discovery_warning(&mut self, _warning: &DiscoveryWarning) {}
     /// Lets the CLI tell the reporter which subcommand invoked it, so run
-    /// headers can read "tryke watch" instead of the generic "tryke test".
+    /// headers can read "tryke test --watch" instead of the generic "tryke test".
     fn set_subcommand_label(&mut self, _label: &'static str) {}
     /// In watch mode, sets a short trailing hint shown next to the
     /// pass/fail badge in the run summary (e.g. "Waiting for file

--- a/crates/tryke_server/src/watcher.rs
+++ b/crates/tryke_server/src/watcher.rs
@@ -353,8 +353,8 @@ mod tests {
         );
     }
 
-    /// Regression: in a fresh `tryke watch` session, the first event
-    /// the filter sees for a path may be a deletion. Without
+    /// Regression: in a fresh `tryke test --watch` session, the first
+    /// event the filter sees for a path may be a deletion. Without
     /// distinguishing "never seen" from "seen and currently missing",
     /// `current == prior == None` would silently drop the event and
     /// the discovery layer would never learn the file is gone.

--- a/demo/demo.tape
+++ b/demo/demo.tape
@@ -18,7 +18,7 @@ Type "clear"
 Enter
 Show
 
-Type "uvx tryke watch -v"
+Type "uvx tryke test --watch -v"
 Sleep 500ms
 Enter
 Sleep 10s

--- a/docs/concepts/concurrency.md
+++ b/docs/concepts/concurrency.md
@@ -13,7 +13,7 @@ The pool size depends on the context:
 | Context | Default |
 |---------|---------|
 | `tryke test` | `min(test_count, cpu_count)` |
-| `tryke watch` | `cpu_count` |
+| `tryke test --watch` | `cpu_count` |
 | `tryke server` | `cpu_count` |
 
 If CPU detection fails, the fallback is 4 workers. Override with `-j` / `--workers`:
@@ -28,7 +28,7 @@ The `tryke test` default avoids creating more workers than there are tests to ru
 
 Workers are pre-warmed at startup. Before any tests execute, Tryke sends a ping to every worker over a dedicated per-worker control channel, causing each one to spawn its Python subprocess in parallel. This means Python startup latency is absorbed before the first test begins, not during it.
 
-In `tryke watch` and `tryke server`, this same control channel is used to **restart** workers when a watched file changes: each worker kills its current Python process and immediately respawns a fresh one (replaying any cached fixture registrations). Pre-warming on restart is parallel, so the workers are warm again by the time the next test cycle begins. This is how Tryke picks up code changes — it does **not** call `importlib.reload` in-process, which is fragile once classes, closures, or decorator-bound state from the old definitions have been captured elsewhere.
+In `tryke test --watch` and `tryke server`, this same control channel is used to **restart** workers when a watched file changes: each worker kills its current Python process and immediately respawns a fresh one (replaying any cached fixture registrations). Pre-warming on restart is parallel, so the workers are warm again by the time the next test cycle begins. This is how Tryke picks up code changes — it does **not** call `importlib.reload` in-process, which is fragile once classes, closures, or decorator-bound state from the old definitions have been captured elsewhere.
 
 ## Distribution modes
 

--- a/docs/guides/reporters.md
+++ b/docs/guides/reporters.md
@@ -101,5 +101,5 @@ Like `next`, the live status bar is only drawn when both stdout and stderr are T
 The `--reporter` flag works with [watch mode](watch-mode.md) too:
 
 ```bash
-tryke watch --reporter dot
+tryke test --watch --reporter dot
 ```

--- a/docs/guides/watch-mode.md
+++ b/docs/guides/watch-mode.md
@@ -5,7 +5,7 @@ Watch mode monitors your project for file changes and reruns only the affected t
 ## Basic usage
 
 ```bash
-tryke watch
+tryke test --watch
 ```
 
 Tryke watches all `.py` files in the project, respecting `.gitignore`. When a file changes, it:
@@ -29,13 +29,13 @@ All the standard [filtering](filtering.md) flags work in watch mode:
 
 ```bash
 # Only watch tests matching a name pattern
-tryke watch -k "math"
+tryke test --watch -k "math"
 
 # Only watch tests with specific tags
-tryke watch -m "fast"
+tryke test --watch -m "fast"
 
 # Combine filters
-tryke watch -k "parse" -m "not slow"
+tryke test --watch -k "parse" -m "not slow"
 ```
 
 ## Options
@@ -45,7 +45,7 @@ tryke watch -k "parse" -m "not slow"
 Choose an output format:
 
 ```bash
-tryke watch --reporter dot
+tryke test --watch --reporter dot
 ```
 
 See [reporters](reporters.md) for all formats.
@@ -55,13 +55,13 @@ See [reporters](reporters.md) for all formats.
 Stop a run on the first failure:
 
 ```bash
-tryke watch -x
+tryke test --watch -x
 ```
 
 Or after N failures:
 
 ```bash
-tryke watch --maxfail 3
+tryke test --watch --maxfail 3
 ```
 
 ### Workers
@@ -69,7 +69,7 @@ tryke watch --maxfail 3
 Override the number of parallel workers (defaults to CPU count):
 
 ```bash
-tryke watch -j 4
+tryke test --watch -j 4
 ```
 
 See [concurrency](../concepts/concurrency.md) for details on the worker pool.
@@ -81,7 +81,7 @@ By default, watch mode reruns only the tests affected by the changed files
 discovered test set on every change instead:
 
 ```bash
-tryke watch --all
+tryke test --watch --all
 ```
 
 This is useful when:

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ with t.describe("users"):
 
 ```
 
-Run your tests — `tryke watch` for an always-on loop, `tryke test --changed`
+Run your tests — `tryke test --watch` for an always-on loop, `tryke test --changed`
 for just what your working tree touched, or plain:
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,6 @@ Usage: tryke [OPTIONS] <COMMAND>
 
 Commands:
   test    Collect and run tests
-  watch   Watch files and rerun affected tests
   server  Start a persistent worker server
   graph   Print the import dependency graph for the project
   help    Print this message or the help of the given subcommand(s)
@@ -55,23 +54,23 @@ Options:
       --connected-only
           Show only files that have dependents or dependencies (skip isolated files)
 
-      --changed
-          Show only files affected by files changed since HEAD (requires git)
-
   -v, --verbose...
           Increase logging verbosity
 
-      --base-branch <BASE_BRANCH>
-          Base branch for --changed (e.g. "main"). Uses merge-base diff
+      --changed
+          Show only files affected by files changed since HEAD (requires git)
 
   -q, --quiet...
           Decrease logging verbosity
 
-      --fixtures
-          Print the fixture (`@fixture` + `Depends()`) dependency graph instead of the import graph
+      --base-branch <BASE_BRANCH>
+          Base branch for --changed (e.g. "main"). Uses merge-base diff
 
       --no-progress
           Disable the terminal's native graphical progress bar (Ghostty, Windows Terminal, ConEmu, WezTerm, iTerm2 OSC 9;4)
+
+      --fixtures
+          Print the fixture (`@fixture` + `Depends()`) dependency graph instead of the import graph
 
   -h, --help
           Print help
@@ -140,23 +139,23 @@ Options:
   -k, --filter <FILTER>
           Filter expression (e.g. "math and not slow")
 
-  -m, --markers <MARKERS>
-          Tag/marker filter expression (e.g. "slow and not network")
-
   -v, --verbose...
           Increase logging verbosity
 
+  -m, --markers <MARKERS>
+          Tag/marker filter expression (e.g. "slow and not network")
+
   -q, --quiet...
           Decrease logging verbosity
+
+      --no-progress
+          Disable the terminal's native graphical progress bar (Ghostty, Windows Terminal, ConEmu, WezTerm, iTerm2 OSC 9;4)
 
       --reporter <REPORTER>
           Reporter format to use for output
 
           [default: text]
           [possible values: text, json, dot, junit, llm, next, sugar]
-
-      --no-progress
-          Disable the terminal's native graphical progress bar (Ghostty, Windows Terminal, ConEmu, WezTerm, iTerm2 OSC 9;4)
 
       --root <ROOT>
           Project root used for discovery and execution
@@ -192,71 +191,11 @@ Options:
 
           [default: test]
 
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-### `tryke watch`
-
-Watch files and rerun affected tests
-
-```text
-Watch files and rerun affected tests
-
-Usage: tryke watch [OPTIONS]
-
-Options:
-  -e, --exclude <EXCLUDE>
-          Exclude files/directories from discovery (overrides pyproject config)
-
-  -i, --include <INCLUDE>
-          Include files/directories even if excluded by `pyproject.toml`
-
-  -k, --filter <FILTER>
-          Filter expression (e.g. "math and not slow")
-
-  -m, --markers <MARKERS>
-          Tag/marker filter expression (e.g. "slow and not network")
-
-      --reporter <REPORTER>
-          Reporter format to use for output
-
-          [default: text]
-          [possible values: text, json, dot, junit, llm, next, sugar]
-
-  -v, --verbose...
-          Increase logging verbosity
-
-  -q, --quiet...
-          Decrease logging verbosity
-
-      --root <ROOT>
-          Project root used for discovery and execution
-
-      --no-progress
-          Disable the terminal's native graphical progress bar (Ghostty, Windows Terminal, ConEmu, WezTerm, iTerm2 OSC 9;4)
-
-  -x, --fail-fast
-          Stop after first failure
-
-      --maxfail <MAXFAIL>
-          Stop after N failures
-
-  -j, --workers <WORKERS>
-          Number of worker processes (default: cpu_count)
-
-      --dist <DIST>
-          How tests are distributed across workers
-
-          Possible values:
-          - test:  Each test is its own work unit (maximum parallelism)
-          - file:  All tests from a file go to one worker
-          - group: Tests within a describe() group go to one worker
-
-          [default: test]
+  -w, --watch
+          Watch files and rerun affected tests on change (press q to quit)
 
   -a, --all
-          Rerun the full test set on every change instead of just affected tests
+          In watch mode, rerun the full test set on every change instead of just affected tests
 
   -h, --help
           Print help (see a summary with '-h')

--- a/docs/why.md
+++ b/docs/why.md
@@ -40,7 +40,7 @@ def create_user():
 
 ### Built-in watch mode
 
-`tryke watch` reruns tests on file changes — no plugins or extra tools needed.
+`tryke test --watch` reruns tests on file changes — no plugins or extra tools needed.
 
 ### Client/server mode
 

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -855,9 +855,9 @@ def _configure_logging_from_env() -> None:
 
     Off by default so normal test runs don't emit anything on stderr.
     Set ``TRYKE_WORKER_LOG=DEBUG`` (or ``INFO`` / ``TRACE``) before
-    invoking ``tryke test``/``tryke watch``/``tryke server`` to trace
-    module registration and dispatch. Output goes to stderr so it never
-    contaminates the JSON-RPC stream on stdout.
+    invoking ``tryke test``/``tryke test --watch``/``tryke server`` to
+    trace module registration and dispatch. Output goes to stderr so it
+    never contaminates the JSON-RPC stream on stdout.
     """
     level_name = os.environ.get("TRYKE_WORKER_LOG", "").strip().upper()
     if not level_name:


### PR DESCRIPTION
Replace the standalone `watch` subcommand with a `--watch` / `-w` flag
on `tryke test`, plus `--all` / `-a` (requires --watch) for full reruns.
Hard break — the `watch` subcommand is gone, no aliases.

Updated all docs and code comments referencing the old subcommand,
including the regenerated CLI reference.