### PR TITLE
Support labeled test cases with @test("label").cases(...)

### DIFF
--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -490,7 +490,7 @@ fn is_tryke_test_cases_decorator(expr: &Expr, body: &[Stmt], aliases: &TrykeAlia
     if attr.attr.id.as_str() != "cases" {
         return false;
     }
-    is_bare_test_or_qualified(&attr.value, body, aliases)
+    is_test_or_call_wrapper(&attr.value, body, aliases)
 }
 
 /// Recognises bare `test` / `tryke.test` plus the marker attribute forms
@@ -522,6 +522,17 @@ fn is_bare_test_or_qualified(expr: &Expr, body: &[Stmt], aliases: &TrykeAliases)
                 && matches!(&*a.value, Expr::Name(n) if aliases.is_module(n.id.as_str()))
         }
         _ => false,
+    }
+}
+
+/// Same as :fn:`is_bare_test_or_qualified` but also accepts a call wrapper —
+/// `test("label")` / `test(name="…")` / `tryke.test(...)` — so
+/// `@test("label").cases(...)` is recognised as a cases decorator with the
+/// label flowing through to discovery as a display name.
+fn is_test_or_call_wrapper(expr: &Expr, body: &[Stmt], aliases: &TrykeAliases) -> bool {
+    match expr {
+        Expr::Call(c) => is_bare_test_or_qualified(&c.func, body, aliases),
+        _ => is_bare_test_or_qualified(expr, body, aliases),
     }
 }
 
@@ -1450,7 +1461,9 @@ fn collect_cases_from_func(
         TestModifier::SkipIf | TestModifier::None => (None, None, None),
     };
 
-    let display_name = extract_docstring(&func.body);
+    let display_name =
+        extract_cases_display_name(&cases_dec.expression).or_else(|| extract_docstring(&func.body));
+    let tags = extract_cases_tags(&cases_dec.expression);
     let line_number = u32::try_from(line_index.line_index(func.range.start()).get()).ok();
     let file_path = Some(file.strip_prefix(root).unwrap_or(file).to_path_buf());
     let module_path = path_to_module(root, file);
@@ -1467,13 +1480,44 @@ fn collect_cases_from_func(
             skip: case.skip.or_else(|| fn_skip.clone()),
             todo: case.todo.or_else(|| fn_todo.clone()),
             xfail: case.xfail.or_else(|| fn_xfail.clone()),
-            tags: vec![],
+            tags: tags.clone(),
             groups: groups.to_vec(),
             case_label: Some(case.label),
             case_index: u32::try_from(i).ok(),
             ..TestItem::default()
         });
     }
+}
+
+/// Extract a function-level display name from a `@test("label").cases(...)`
+/// decorator. Returns `None` for the bare `@test.cases(...)` form, which has
+/// no inner call to inspect.
+fn extract_cases_display_name(expr: &Expr) -> Option<String> {
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    let Expr::Attribute(attr) = &*call.func else {
+        return None;
+    };
+    if attr.attr.id.as_str() != "cases" {
+        return None;
+    }
+    extract_decorator_name(&attr.value)
+}
+
+/// Extract a `tags=[...]` kwarg from the inner `test(...)` call of a
+/// `@test(tags=[...]).cases(...)` decorator.
+fn extract_cases_tags(expr: &Expr) -> Vec<String> {
+    let Expr::Call(call) = expr else {
+        return vec![];
+    };
+    let Expr::Attribute(attr) = &*call.func else {
+        return vec![];
+    };
+    if attr.attr.id.as_str() != "cases" {
+        return vec![];
+    }
+    extract_decorator_tags(&attr.value)
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -2210,6 +2254,58 @@ def fn(n):
         // function-level skip is still inherited since xfail != skip.
         assert_eq!(items[1].skip.as_deref(), Some("default skip"));
         assert_eq!(items[1].xfail.as_deref(), Some("override"));
+    }
+
+    #[test]
+    fn cases_with_label_emits_display_name_per_case() {
+        let source = r#"@test("basic").cases(
+    test.case("1 + 1", a=1, b=1, expected=2),
+    test.case("1 + 2", a=1, b=2, expected=3),
+)
+def addition(a, b, expected):
+    pass
+"#;
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file).tests;
+        assert_eq!(items.len(), 2);
+        for item in &items {
+            assert_eq!(item.display_name.as_deref(), Some("basic"));
+            assert_eq!(item.name, "addition");
+        }
+        let labels: Vec<_> = items
+            .iter()
+            .map(|i| i.case_label.as_deref().unwrap_or(""))
+            .collect();
+        assert_eq!(labels, vec!["1 + 1", "1 + 2"]);
+    }
+
+    #[test]
+    fn cases_with_label_kwarg_form_emits_display_name() {
+        let source = r#"@test(name="square").cases(zero={"n": 0}, one={"n": 1})
+def fn(n):
+    pass
+"#;
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file).tests;
+        assert_eq!(items.len(), 2);
+        for item in &items {
+            assert_eq!(item.display_name.as_deref(), Some("square"));
+        }
+    }
+
+    #[test]
+    fn cases_with_label_inherits_tags() {
+        let source = r#"@test("slow path", tags=["slow"]).cases(a={}, b={})
+def fn():
+    pass
+"#;
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file).tests;
+        assert_eq!(items.len(), 2);
+        for item in &items {
+            assert_eq!(item.tags, vec!["slow".to_string()]);
+            assert_eq!(item.display_name.as_deref(), Some("slow path"));
+        }
     }
 
     #[test]

--- a/python/tryke/expect.py
+++ b/python/tryke/expect.py
@@ -303,6 +303,26 @@ def _validate_cases_table(table: CaseTable) -> None:
             raise TypeError(msg)
 
 
+def _make_cases_decorator(
+    positional: tuple[object, ...],
+    kwargs: dict[str, CaseArgs],
+) -> Callable[[_Fn], _Fn]:
+    """Build the runtime decorator shared by ``test.cases`` entry points.
+
+    Both ``_TestBuilder.cases`` and ``_TestDecorator.cases`` route through
+    here so the validation rules and stamping behaviour stay identical
+    across the bare and labelled spellings.
+    """
+    table = _build_cases_table(positional, kwargs)
+    _validate_cases_table(table)
+
+    def decorator(f: _Fn) -> _Fn:
+        _stamp_cases(f, table)
+        return f
+
+    return decorator
+
+
 def _build_cases_table(
     positional: tuple[object, ...],
     kwargs: dict[str, CaseArgs],
@@ -525,6 +545,62 @@ class _XfailMarker(_Marker, attr="__tryke_xfail__"):
         return decorator
 
 
+class _TestDecorator:
+    """Decorator returned by ``@test(...)`` when called with metadata.
+
+    Acts as a plain decorator (forwarding the decorated function unchanged
+    at runtime — the metadata is consumed by static discovery) and also
+    exposes :meth:`cases` so that ``@test("label").cases(...)`` parametrises
+    the test while keeping the function-level display name.
+    """
+
+    __slots__ = ()
+
+    def __call__(self, fn: _AnyTestFn, /) -> _AnyTestFn:
+        return fn
+
+    @overload
+    def cases[**P](
+        self,
+        *specs: _CaseSpec[P],
+    ) -> Callable[[Callable[P, None]], Callable[P, None]]: ...
+    @overload
+    def cases(
+        self,
+        positional: list[tuple[str, CaseArgs]],
+        /,
+    ) -> Callable[[_Fn], _Fn]: ...
+    @overload
+    def cases(
+        self,
+        /,
+        **kwargs: CaseArgs,
+    ) -> Callable[[_Fn], _Fn]: ...
+
+    def cases(
+        self,
+        *positional: object,
+        **kwargs: CaseArgs,
+    ) -> Callable[[_Fn], _Fn]:
+        """Parametrise a labelled test over multiple named cases.
+
+        Equivalent to :meth:`_TestBuilder.cases` but reachable through the
+        ``@test("label")`` decorator so callers can supply a function-level
+        display name and a case table in a single decoration.
+
+        Example:
+            ```python
+            @test("basic").cases(
+                test.case("1 + 1", a=1, b=1, expected=2),
+                test.case("1 + 2", a=1, b=2, expected=3),
+            )
+            def addition(a: int, b: int, expected: int) -> None:
+                expect(a + b).to_equal(expected)
+            ```
+        """
+        return _make_cases_decorator(positional, kwargs)
+
+
 class _TestBuilder:
     """Decorator for marking functions as tests.
 
@@ -561,7 +637,7 @@ class _TestBuilder:
     @overload
     def __call__(self, fn: _AnyTestFn, /) -> _AnyTestFn: ...
     @overload
-    def __call__(self, name: str, /) -> _Decorator: ...
+    def __call__(self, name: str, /) -> _TestDecorator: ...
     @overload
     def __call__(
         self,
@@ -570,7 +646,7 @@ class _TestBuilder:
         *,
         name: str | None = None,
         tags: list[str] | None = None,
-    ) -> _Decorator: ...
+    ) -> _TestDecorator: ...
 
     def __call__(
         self,
@@ -583,7 +659,10 @@ class _TestBuilder:
         """Register a function as a test.
 
         Can be used as a bare decorator (`@test`) or called with keyword
-        arguments (`@test(name="...", tags=[...])`) to set metadata.
+        arguments (`@test(name="...", tags=[...])`) to set metadata. The
+        parametrised form returns a :class:`_TestDecorator`, which acts as
+        a plain decorator and also exposes ``.cases(...)`` so labelled
+        tests can be parametrised in one decoration.
 
         Args:
             fn: The test function (when used as a bare decorator).
@@ -592,11 +671,7 @@ class _TestBuilder:
         """
         if callable(fn):
             return fn
-
-        def decorator(f: Callable[[], None]) -> Callable[[], None]:
-            return f
-
-        return decorator
+        return _TestDecorator()
 
     def case[**P](
         self,
@@ -684,14 +759,7 @@ class _TestBuilder:
             TypeError: If no cases are provided, forms are mixed, two
                 cases share a label, or cases disagree on key sets.
         """
-        table = _build_cases_table(positional, kwargs)
-        _validate_cases_table(table)
-
-        def decorator(f: _Fn) -> _Fn:
-            _stamp_cases(f, table)
-            return f
-
-        return decorator
+        return _make_cases_decorator(positional, kwargs)
 
     def skip_if(
         self,

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -191,6 +191,46 @@ with describe("test.cases composes with modifiers"):
         expect(x, "x equals -1 (expected to fail)").to_equal(-1)
 
 
+with describe("test.cases composes with @test(label)"):
+
+    @test("basic").cases(
+        test.case("1 + 1", a=1, b=1, expected=2),
+        test.case("1 + 2", a=1, b=2, expected=3),
+        test.case("1 + 3", a=1, b=3, expected=4),
+    )
+    def labelled_addition(a: int, b: int, expected: int) -> None:
+        expect(a + b, "a + b matches expected").to_equal(expected)
+
+    @test
+    def labelled_cases_stamp_attribute() -> None:
+        @test("basic").cases(
+            test.case("1 + 1", a=1, b=1, expected=2),
+            test.case("1 + 2", a=1, b=2, expected=3),
+        )
+        def fn(a: int, b: int, expected: int) -> None:  # noqa: ARG001
+            return
+
+        if not isinstance(fn, CasesMarked):
+            msg = "decorator should produce a CasesMarked function"
+            raise TypeError(msg)
+        labels = [e.label for e in fn.__tryke_cases__]
+        expect(labels, "labelled cases preserve order").to_equal(["1 + 1", "1 + 2"])
+
+    @test
+    def labelled_cases_kwargs_form() -> None:
+        @test(name="square").cases(zero={"n": 0}, one={"n": 1})
+        def fn(n: int) -> None:  # noqa: ARG001
+            return
+
+        if not isinstance(fn, CasesMarked):
+            msg = "decorator should produce a CasesMarked function"
+            raise TypeError(msg)
+        expect(
+            [e.label for e in fn.__tryke_cases__],
+            "kwargs labels preserved through @test(name=...).cases",
+        ).to_equal(["zero", "one"])
+
+
 with describe("test.cases rejects kwarg / fixture collision"):
 
     @test

--- a/tests/typed/test_cases_typing.py
+++ b/tests/typed/test_cases_typing.py
@@ -53,3 +53,12 @@ def square(n: int, expected: int) -> None:
 )
 def upper(name: str, upper: str) -> None:
     expect(name.upper(), "uppercased name matches").to_equal(upper)
+
+
+@test("basic").cases(
+    test.case("1 + 1", a=1, b=1, expected=2),
+    test.case("1 + 2", a=1, b=2, expected=3),
+    test.case("1 + 3", a=1, b=3, expected=4),
+)
+def labelled_addition(a: int, b: int, expected: int) -> None:
+    expect(a + b, "a + b matches expected").to_equal(expected)


### PR DESCRIPTION
## Summary
This change enables parametrised tests to be decorated with a function-level display name by composing `@test("label")` with `.cases(...)`, allowing `@test("label").cases(...)` syntax. The display name and tags from the outer `@test(...)` call flow through to individual test cases discovered by the static analyzer.

## Key Changes

**Discovery (Rust)**
- Renamed `is_bare_test_or_qualified()` call to `is_test_or_call_wrapper()` in `is_tryke_test_cases_decorator()` to recognize both bare `@test.cases(...)` and labelled `@test(...).cases(...)` forms
- Added `is_test_or_call_wrapper()` function that unwraps call expressions to check if the underlying function is a test decorator
- Added `extract_cases_display_name()` to extract the display name from `@test("label").cases(...)` decorators
- Added `extract_cases_tags()` to extract tags from the inner `test(...)` call
- Modified `collect_cases_from_func()` to populate `display_name` and `tags` fields from the decorator expression, with docstring as fallback for display name
- Added three test cases validating the new functionality

**Runtime (Python)**
- Created `_TestDecorator` class returned by `@test(...)` when called with metadata, which:
  - Acts as a plain decorator (returns the function unchanged)
  - Exposes a `.cases(...)` method for parametrisation
- Extracted common cases decorator logic into `_make_cases_decorator()` to ensure validation and stamping behavior is identical across `_TestBuilder.cases()` and `_TestDecorator.cases()`
- Updated `_TestBuilder.__call__()` return type annotations to reflect that parametrised forms return `_TestDecorator`
- Updated docstring to document the new composition capability

**Tests**
- Added runtime tests validating that `@test("label").cases(...)` properly stamps the function and preserves case labels
- Added test for the kwargs form: `@test(name="...").cases(...)`
- Added typing test demonstrating the new syntax works with type checking

https://claude.ai/code/session_01UfmveJXyAhq41iPTQvY12D