### PR TITLE
fix(logging): honor RUST_LOG so the VS Code server output isn't empty

### DIFF
--- a/crates/tryke/src/main.rs
+++ b/crates/tryke/src/main.rs
@@ -53,9 +53,15 @@ fn build_reporter(
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    env_logger::Builder::new()
-        .filter_level(cli.verbose.log_level_filter())
-        .init();
+    // `Builder::new()` ignores `RUST_LOG`, so consumers (e.g. the VS Code
+    // extension setting `RUST_LOG=tryke=info`) never see any output. Use
+    // `from_env` so the env var wins when set, while `-v`/`-q` still sets
+    // the default when it isn't.
+    env_logger::Builder::from_env(
+        env_logger::Env::default()
+            .default_filter_or(cli.verbose.log_level_filter().to_string()),
+    )
+    .init();
     debug!("{cli:?}");
 
     let verbosity = match cli.verbose.log_level() {


### PR DESCRIPTION
## Summary

- `env_logger::Builder::new()` in `crates/tryke/src/main.rs` ignores `RUST_LOG`. The VS Code extension's "Tryke Server" output panel was always empty as a result.
- The extension sets `RUST_LOG=tryke=<level>` (driven by `tryke.server.logLevel`) and pipes the server's stdout/stderr to the channel, but the env var was being dropped. The filter fell back to `-v`/`-q`, which the extension doesn't pass — so the default `WarnLevel` filtered out every `info!`/`debug!` call across `tryke_server`, `tryke_runner`, and `tryke_discovery`.
- Switch to `Builder::from_env(... default_filter_or(...))` so `RUST_LOG` wins when set and CLI flags still set the default otherwise. No behavior change for plain `tryke test` runs.

## Why users see this

Looking at the `tryke-vscode` `serverManager.ts`, the only thing currently visible in the output panel is the lifecycle markers it prints itself (`--- server starting ---`, `--- server exited ---`, `--- server spawn error ---`). Nothing the server logs ever lands there because the logger filter discards it.

## Test plan

- [x] Build the binary and run `tryke server` against `/tmp`:
  - `RUST_LOG=debug ... server` → 53 lines of structured output across crates (`tryke_runner::worker`, `tryke_discovery::cache`, `ignore::*`, etc.).
  - `RUST_LOG` unset → no output (matches prior behavior; default verbosity unchanged).
- [ ] Restart the VS Code extension, leave `tryke.server.logLevel` at `info`, and confirm the "Tryke Server" output channel now shows server boot logs in addition to the lifecycle markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)