### PR TITLE
Unify Rust and Python worker logging via TRYKE_LOG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,14 @@ interpreter:
 uv run cargo run -- test --reporter llm
 ```
 
+## logging
+
+A single knob (`-v` / `-q` flags or `TRYKE_LOG` env) drives both rust
+and python verbosity. `RUST_LOG` is honored as a power-user override
+for the rust side only. Default is `warn` on rust, off for workers
+(no chatter unless asked). See `docs/guides/configuration.md` for the
+full precedence chain.
+
 ## running rust tests
 
 we use [`cargo-nextest`](https://nexte.st) — install once with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ virtualenv so you can import and test the python bindings locally.
 
 ## python tests
 
-run `cargo run test` to test tryke's own python code, using tryke
+run `cargo run -- test` to test tryke's own python code, using tryke
 
 ## rust tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,6 +2180,7 @@ dependencies = [
 name = "tryke_config"
 version = "0.0.26"
 dependencies = [
+ "log",
  "serde",
  "tempfile",
  "toml",
@@ -2218,6 +2219,7 @@ dependencies = [
  "console 0.15.11",
  "ctrlc",
  "indicatif",
+ "log",
  "miette",
  "owo-colors",
  "serde",

--- a/crates/tryke/src/execution.rs
+++ b/crates/tryke/src/execution.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use log::LevelFilter;
 use tokio_stream::StreamExt;
 use tryke_reporter::Reporter;
 use tryke_runner::{DistMode, WorkerPool, partition_with_hooks};
@@ -15,6 +16,7 @@ pub async fn run_tests(
     reporter: &mut dyn Reporter,
     root: &std::path::Path,
     python: &str,
+    log_level: LevelFilter,
     tests: Vec<tryke_types::TestItem>,
     hooks: &[HookItem],
     maxfail: Option<usize>,
@@ -24,7 +26,7 @@ pub async fn run_tests(
     changed_selection: Option<ChangedSelectionSummary>,
 ) -> Result<RunSummary> {
     let pool_size = workers.unwrap_or_else(|| tests.len().min(worker_pool_size()));
-    let pool = WorkerPool::new(pool_size, python, root);
+    let pool = WorkerPool::new(pool_size, python, root, log_level);
     pool.warm().await;
     let summary = report_cycle(
         reporter,
@@ -250,6 +252,7 @@ mod tests {
             reporter,
             dir.path(),
             &test_python_bin(),
+            LevelFilter::Off,
             tests,
             &[],
             None,
@@ -317,6 +320,7 @@ mod tests {
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_dir],
+            LevelFilter::Off,
         );
         assert!(
             run_cycle(&mut reporter, &mut discoverer, &pool)
@@ -331,7 +335,7 @@ mod tests {
         std::fs::write(dir.path().join("pyproject.toml"), "").expect("write pyproject.toml");
         let mut discoverer = Discoverer::new(dir.path());
         let mut reporter = JSONReporter::with_writer(Vec::new());
-        let pool = WorkerPool::new(1, &test_python_bin(), dir.path());
+        let pool = WorkerPool::new(1, &test_python_bin(), dir.path(), LevelFilter::Off);
         assert!(
             run_cycle(&mut reporter, &mut discoverer, &pool)
                 .await
@@ -351,6 +355,7 @@ mod tests {
                 &mut reporter,
                 dir.path(),
                 &test_python_bin(),
+                LevelFilter::Off,
                 tests,
                 &[],
                 None,
@@ -398,6 +403,7 @@ def test_failing():
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_dir],
+            LevelFilter::Off,
         );
         pool.warm().await;
         let units = partition_with_hooks(tests, &[], DistMode::Test).units;
@@ -446,6 +452,7 @@ def test_failing():
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_dir],
+            LevelFilter::Off,
         );
         let result = report_cycle(
             &mut reporter,
@@ -484,6 +491,7 @@ def test_failing():
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_dir],
+            LevelFilter::Off,
         );
         let summary = report_cycle(
             &mut reporter,

--- a/crates/tryke/src/main.rs
+++ b/crates/tryke/src/main.rs
@@ -2,7 +2,7 @@ use std::{env, time::Instant};
 
 use anyhow::Result;
 use clap::Parser;
-use log::debug;
+use log::{debug, warn};
 use tryke::cli::{Cli, Commands, ReporterFormat};
 use tryke::discovery::{
     discover_tests, discover_tests_changed_first, discover_tests_for_paths, resolved_excludes,
@@ -54,7 +54,16 @@ fn build_reporter(
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let cli_filter = cli.verbose.log_level_filter();
-    let tryke_log = env::var("TRYKE_LOG").ok();
+    // Resolve `TRYKE_LOG` with `TRYKE_WORKER_LOG` as a one-cycle
+    // deprecated alias. Doing the alias check here (rather than in the
+    // python worker) means the deprecation warning fires exactly once
+    // per `tryke` invocation — moving it to the worker side fired it
+    // once per spawned worker process, which spammed multi-worker pools
+    // and watch-mode restarts.
+    let tryke_log_legacy = env::var("TRYKE_WORKER_LOG").ok();
+    let tryke_log = env::var("TRYKE_LOG")
+        .ok()
+        .or_else(|| tryke_log_legacy.clone());
     // Rust-side default for env_logger when `RUST_LOG` is unset. `RUST_LOG`
     // wins natively because we use `Builder::from_env`. Precedence chain:
     // `RUST_LOG` > `TRYKE_LOG` > `-v`/`-q` flag > `warn`.
@@ -63,6 +72,12 @@ fn main() -> Result<()> {
         env_logger::Env::default().default_filter_or(rust_default.as_str().to_ascii_lowercase()),
     )
     .init();
+    if env::var("TRYKE_LOG").is_err() && tryke_log_legacy.is_some() {
+        warn!(
+            "TRYKE_WORKER_LOG is deprecated; use TRYKE_LOG instead \
+             (it propagates to both rust and python workers)"
+        );
+    }
     debug!("{cli:?}");
 
     // Cross-language verbosity for spawned python workers. `RUST_LOG` is
@@ -72,7 +87,12 @@ fn main() -> Result<()> {
     // verbosity than the `Warn` default.
     let worker_log = tryke_config::worker_log_level(tryke_log.as_deref(), cli_filter);
 
-    let verbosity = Verbosity::from_level_filter(cli_filter);
+    // Reporter UI verbosity follows the cross-language umbrella, not the
+    // raw CLI flag — otherwise `TRYKE_LOG=info` would light up logs but
+    // leave the text reporter in its `Normal` mode, contradicting the
+    // "single knob" promise. `RUST_LOG` is deliberately not consulted
+    // here: it's a rust-internal filter, not a user-facing UI knob.
+    let verbosity = Verbosity::from_level_filter(rust_default);
 
     let rt = tokio::runtime::Runtime::new()?;
     match &cli.command {

--- a/crates/tryke/src/main.rs
+++ b/crates/tryke/src/main.rs
@@ -53,18 +53,26 @@ fn build_reporter(
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    env_logger::Builder::new()
-        .filter_level(cli.verbose.log_level_filter())
-        .init();
+    let cli_filter = cli.verbose.log_level_filter();
+    let tryke_log = env::var("TRYKE_LOG").ok();
+    // Rust-side default for env_logger when `RUST_LOG` is unset. `RUST_LOG`
+    // wins natively because we use `Builder::from_env`. Precedence chain:
+    // `RUST_LOG` > `TRYKE_LOG` > `-v`/`-q` flag > `warn`.
+    let rust_default = tryke_config::rust_log_default(tryke_log.as_deref(), cli_filter);
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or(rust_default.as_str().to_ascii_lowercase()),
+    )
+    .init();
     debug!("{cli:?}");
 
-    let verbosity = match cli.verbose.log_level() {
-        Some(log::Level::Info) | Some(log::Level::Debug) | Some(log::Level::Trace) => {
-            Verbosity::Verbose
-        }
-        Some(log::Level::Error) | None => Verbosity::Quiet,
-        _ => Verbosity::Normal,
-    };
+    // Cross-language verbosity for spawned python workers. `RUST_LOG` is
+    // intentionally not consulted (its per-module filter syntax doesn't
+    // map onto a python log level); `TRYKE_LOG` is the umbrella knob and
+    // `-v` only propagates when the user explicitly asked for more
+    // verbosity than the `Warn` default.
+    let worker_log = tryke_config::worker_log_level(tryke_log.as_deref(), cli_filter);
+
+    let verbosity = Verbosity::from_level_filter(cli_filter);
 
     let rt = tokio::runtime::Runtime::new()?;
     match &cli.command {
@@ -110,6 +118,7 @@ fn main() -> Result<()> {
                     &mut *rep,
                     Some(root_path),
                     &resolved_python,
+                    worker_log,
                     &excludes,
                     &test_filter,
                     resolved_maxfail,
@@ -175,6 +184,7 @@ fn main() -> Result<()> {
                     &mut *rep,
                     root_path,
                     &resolved_python,
+                    worker_log,
                     tests,
                     &discovered.hooks,
                     resolved_maxfail,
@@ -200,7 +210,8 @@ fn main() -> Result<()> {
             let excludes = resolved_excludes(&root_path, exclude, include);
             let config = tryke_config::load_effective_config(&root_path);
             let resolved_python = tryke_config::resolve_python(python.as_deref(), &config);
-            let server = tryke_server::Server::new(*port, root_path, excludes, resolved_python);
+            let server =
+                tryke_server::Server::new(*port, root_path, excludes, resolved_python, worker_log);
             rt.block_on(server.run())
         }
         Commands::Graph {
@@ -377,26 +388,14 @@ mod tests {
     #[test]
     fn test_verbose_flag_drives_verbose_output() {
         let cli = Cli::try_parse_from(["tryke", "test", "-v"]).unwrap();
-        let verbosity = match cli.verbose.log_level() {
-            Some(log::Level::Info) | Some(log::Level::Debug) | Some(log::Level::Trace) => {
-                Verbosity::Verbose
-            }
-            Some(log::Level::Error) | None => Verbosity::Quiet,
-            _ => Verbosity::Normal,
-        };
+        let verbosity = Verbosity::from_level_filter(cli.verbose.log_level_filter());
         assert!(matches!(verbosity, Verbosity::Verbose));
     }
 
     #[test]
     fn test_quiet_flag_drives_quiet_output() {
         let cli = Cli::try_parse_from(["tryke", "test", "-q"]).unwrap();
-        let verbosity = match cli.verbose.log_level() {
-            Some(log::Level::Info) | Some(log::Level::Debug) | Some(log::Level::Trace) => {
-                Verbosity::Verbose
-            }
-            Some(log::Level::Error) | None => Verbosity::Quiet,
-            _ => Verbosity::Normal,
-        };
+        let verbosity = Verbosity::from_level_filter(cli.verbose.log_level_filter());
         assert!(matches!(verbosity, Verbosity::Quiet));
     }
 

--- a/crates/tryke/src/main.rs
+++ b/crates/tryke/src/main.rs
@@ -2,7 +2,7 @@ use std::{env, time::Instant};
 
 use anyhow::Result;
 use clap::Parser;
-use log::{debug, warn};
+use log::debug;
 use tryke::cli::{Cli, Commands, ReporterFormat};
 use tryke::discovery::{
     discover_tests, discover_tests_changed_first, discover_tests_for_paths, resolved_excludes,
@@ -54,16 +54,7 @@ fn build_reporter(
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let cli_filter = cli.verbose.log_level_filter();
-    // Resolve `TRYKE_LOG` with `TRYKE_WORKER_LOG` as a one-cycle
-    // deprecated alias. Doing the alias check here (rather than in the
-    // python worker) means the deprecation warning fires exactly once
-    // per `tryke` invocation — moving it to the worker side fired it
-    // once per spawned worker process, which spammed multi-worker pools
-    // and watch-mode restarts.
-    let tryke_log_legacy = env::var("TRYKE_WORKER_LOG").ok();
-    let tryke_log = env::var("TRYKE_LOG")
-        .ok()
-        .or_else(|| tryke_log_legacy.clone());
+    let tryke_log = env::var("TRYKE_LOG").ok();
     // Rust-side default for env_logger when `RUST_LOG` is unset. `RUST_LOG`
     // wins natively because we use `Builder::from_env`. Precedence chain:
     // `RUST_LOG` > `TRYKE_LOG` > `-v`/`-q` flag > `warn`.
@@ -72,12 +63,6 @@ fn main() -> Result<()> {
         env_logger::Env::default().default_filter_or(rust_default.as_str().to_ascii_lowercase()),
     )
     .init();
-    if env::var("TRYKE_LOG").is_err() && tryke_log_legacy.is_some() {
-        warn!(
-            "TRYKE_WORKER_LOG is deprecated; use TRYKE_LOG instead \
-             (it propagates to both rust and python workers)"
-        );
-    }
     debug!("{cli:?}");
 
     // Cross-language verbosity for spawned python workers. `RUST_LOG` is

--- a/crates/tryke/src/watch.rs
+++ b/crates/tryke/src/watch.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::Result;
 use console::{Key, Term};
-use log::debug;
+use log::{LevelFilter, debug};
 use tryke_discovery::Discoverer;
 use tryke_reporter::Reporter;
 use tryke_runner::{DistMode, WorkerPool};
@@ -115,6 +115,7 @@ pub async fn run_watch(
     reporter: &mut dyn Reporter,
     root: Option<&Path>,
     python: &str,
+    log_level: LevelFilter,
     excludes: &[String],
     test_filter: &TestFilter,
     maxfail: Option<usize>,
@@ -127,7 +128,7 @@ pub async fn run_watch(
     let mut discoverer = Discoverer::new_with_excludes(root, excludes);
 
     let pool_size = workers.unwrap_or_else(worker_pool_size);
-    let pool = WorkerPool::new(pool_size, python, root);
+    let pool = WorkerPool::new(pool_size, python, root, log_level);
     pool.warm().await;
 
     clear_if_tty();
@@ -252,6 +253,7 @@ mod tests {
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_dir],
+            LevelFilter::Off,
         );
         // Returns () — the important behavior is that it does NOT propagate the
         // underlying `report_cycle` Err that `tryke test` relies on for exit code.

--- a/crates/tryke_config/Cargo.toml
+++ b/crates/tryke_config/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+log = "0.4"
 serde = { workspace = true }
 toml = { workspace = true }
 

--- a/crates/tryke_config/src/lib.rs
+++ b/crates/tryke_config/src/lib.rs
@@ -116,6 +116,48 @@ pub fn resolve_python(cli_override: Option<&str>, config: &TrykeConfig) -> Strin
         .unwrap_or_else(|| default_python().to_owned())
 }
 
+/// Default `RUST_LOG`-style filter directive when `RUST_LOG` is unset.
+///
+/// `env_logger` honors `RUST_LOG` natively for fine-grained per-module
+/// filtering; this only computes the fallback used when the user hasn't
+/// set it. Precedence: `TRYKE_LOG` env > CLI flag.
+///
+/// `TRYKE_LOG` is a bare level name (`off`/`error`/`warn`/`info`/`debug`/
+/// `trace`); `RUST_LOG`'s `tryke=info,hyper=warn` syntax is intentionally
+/// not supported here — power users with that need just set `RUST_LOG`.
+#[must_use]
+pub fn rust_log_default(tryke_log_env: Option<&str>, cli: log::LevelFilter) -> log::LevelFilter {
+    parse_level(tryke_log_env).unwrap_or(cli)
+}
+
+/// Level forwarded to spawned python workers via `TRYKE_LOG`.
+///
+/// Precedence: `TRYKE_LOG` env (if set) > CLI flag (only when explicitly
+/// more verbose than `Warn` — i.e., the user passed at least one `-v`).
+/// Returns `Off` when the worker should stay silent; callers should not
+/// set the env var on the child in that case so the worker preserves its
+/// "no chatter unless asked" default.
+///
+/// `RUST_LOG` is deliberately not consulted: it's a rust-specific
+/// convention from `env_logger`, and silently translating its
+/// per-module filter syntax into a python log level is a footgun.
+/// `TRYKE_LOG` is the cross-language umbrella.
+#[must_use]
+pub fn worker_log_level(tryke_log_env: Option<&str>, cli: log::LevelFilter) -> log::LevelFilter {
+    if let Some(level) = parse_level(tryke_log_env) {
+        return level;
+    }
+    if cli > log::LevelFilter::Warn {
+        cli
+    } else {
+        log::LevelFilter::Off
+    }
+}
+
+fn parse_level(s: Option<&str>) -> Option<log::LevelFilter> {
+    s.and_then(|v| v.trim().parse::<log::LevelFilter>().ok())
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct PyprojectToml {
     tool: Option<PyprojectTool>,
@@ -351,5 +393,61 @@ mod tests {
         .expect("write pyproject");
         let config = load_effective_config(dir.path());
         assert_eq!(config.python.as_deref(), Some("C:foo\\python.exe"));
+    }
+
+    #[test]
+    fn rust_log_default_uses_tryke_log_env_when_set() {
+        let level = rust_log_default(Some("debug"), log::LevelFilter::Warn);
+        assert_eq!(level, log::LevelFilter::Debug);
+    }
+
+    #[test]
+    fn rust_log_default_falls_back_to_cli_when_env_unset() {
+        let level = rust_log_default(None, log::LevelFilter::Info);
+        assert_eq!(level, log::LevelFilter::Info);
+    }
+
+    #[test]
+    fn rust_log_default_falls_back_to_cli_when_env_unparseable() {
+        // Garbage values fall through rather than blowing up — RUST_LOG
+        // could carry per-module filters we don't try to interpret here.
+        let level = rust_log_default(Some("tryke=info,hyper=warn"), log::LevelFilter::Warn);
+        assert_eq!(level, log::LevelFilter::Warn);
+    }
+
+    #[test]
+    fn worker_log_level_uses_tryke_log_env() {
+        let level = worker_log_level(Some("INFO"), log::LevelFilter::Warn);
+        assert_eq!(level, log::LevelFilter::Info);
+    }
+
+    #[test]
+    fn worker_log_level_propagates_explicit_verbose_flag() {
+        let level = worker_log_level(None, log::LevelFilter::Debug);
+        assert_eq!(level, log::LevelFilter::Debug);
+    }
+
+    #[test]
+    fn worker_log_level_stays_off_at_default_warn() {
+        // No env, no explicit `-v` → workers stay silent; preserves the
+        // pre-existing "no chatter unless asked" default for python.
+        let level = worker_log_level(None, log::LevelFilter::Warn);
+        assert_eq!(level, log::LevelFilter::Off);
+    }
+
+    #[test]
+    fn worker_log_level_stays_off_when_quiet() {
+        // `-q` (Error) is even less verbose than the Warn default, so the
+        // worker definitely shouldn't be lit up.
+        let level = worker_log_level(None, log::LevelFilter::Error);
+        assert_eq!(level, log::LevelFilter::Off);
+    }
+
+    #[test]
+    fn worker_log_level_env_wins_over_cli() {
+        // User explicitly set TRYKE_LOG, even though they also passed `-q`
+        // — env intent dominates the flag.
+        let level = worker_log_level(Some("info"), log::LevelFilter::Error);
+        assert_eq!(level, log::LevelFilter::Info);
     }
 }

--- a/crates/tryke_reporter/Cargo.toml
+++ b/crates/tryke_reporter/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 console = { workspace = true }
 ctrlc = { workspace = true }
 indicatif = { workspace = true }
+log = "0.4"
 miette = { workspace = true }
 owo-colors = { workspace = true }
 serde = { workspace = true }

--- a/crates/tryke_reporter/src/text.rs
+++ b/crates/tryke_reporter/src/text.rs
@@ -22,6 +22,24 @@ pub enum Verbosity {
     Verbose,
 }
 
+impl Verbosity {
+    /// Map a `log::LevelFilter` (the resolved CLI/env verbosity) to the
+    /// reporter's UI knob. `Off` and `Error` mean the user asked for less
+    /// noise (e.g., `-q`); `Warn` is the default; anything more verbose
+    /// (`Info`/`Debug`/`Trace` from `-v`) flips the reporter into its
+    /// detailed mode.
+    #[must_use]
+    pub fn from_level_filter(filter: log::LevelFilter) -> Self {
+        match filter {
+            log::LevelFilter::Off | log::LevelFilter::Error => Self::Quiet,
+            log::LevelFilter::Warn => Self::Normal,
+            log::LevelFilter::Info | log::LevelFilter::Debug | log::LevelFilter::Trace => {
+                Self::Verbose
+            }
+        }
+    }
+}
+
 pub struct TextReporter<W: io::Write = io::Stdout> {
     writer: W,
     current_file: Option<PathBuf>,

--- a/crates/tryke_runner/src/pool.rs
+++ b/crates/tryke_runner/src/pool.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use log::{debug, trace};
+use log::{LevelFilter, debug, trace};
 
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::Stream;
@@ -57,8 +57,15 @@ pub struct WorkerPool {
 }
 
 impl WorkerPool {
+    /// Build a pool whose workers receive `TRYKE_LOG=<log_level>` on spawn.
+    ///
+    /// Pass `LevelFilter::Off` to leave workers silent (the env var is
+    /// then not set on the child, so the worker's
+    /// `_configure_logging_from_env` no-ops). Production callers use
+    /// `tryke_config::worker_log_level` to derive this from CLI flags
+    /// + the `TRYKE_LOG` env var.
     #[must_use]
-    pub fn new(size: usize, python_bin: &str, root: &Path) -> Self {
+    pub fn new(size: usize, python_bin: &str, root: &Path, log_level: LevelFilter) -> Self {
         let mut python_path = vec![root.to_path_buf()];
         // pyproject.toml declares python-source = "python" — add it to
         // PYTHONPATH so the tryke package is importable even without a venv.
@@ -66,7 +73,7 @@ impl WorkerPool {
         if src_dir.is_dir() {
             python_path.push(src_dir);
         }
-        Self::with_python_path(size, python_bin, root, &python_path)
+        Self::with_python_path(size, python_bin, root, &python_path, log_level)
     }
 
     #[must_use]
@@ -75,6 +82,7 @@ impl WorkerPool {
         python_bin: &str,
         root: &Path,
         python_path: &[PathBuf],
+        log_level: LevelFilter,
     ) -> Self {
         let size = size.max(1);
         let python_path = python_path.to_vec();
@@ -90,6 +98,7 @@ impl WorkerPool {
                 bin,
                 python_path.clone(),
                 root.clone(),
+                log_level,
                 work_rx,
                 ctrl_rx,
             ));
@@ -169,12 +178,13 @@ async fn ensure_worker<'a>(
     python_bin: &str,
     path_refs: &[&Path],
     root: &Path,
+    log_level: LevelFilter,
 ) -> Option<&'a mut WorkerProcess> {
     if state.process.is_some() {
         return state.process.as_mut();
     }
     trace!("worker_task: spawning process");
-    let mut w = match WorkerProcess::spawn(python_bin, path_refs, root) {
+    let mut w = match WorkerProcess::spawn(python_bin, path_refs, root, log_level) {
         Ok(w) => w,
         Err(e) => {
             debug!("worker_task: spawn failed: {e}");
@@ -205,10 +215,11 @@ async fn run_single_test(
     python_bin: &str,
     path_refs: &[&Path],
     root: &Path,
+    log_level: LevelFilter,
     test: tryke_types::TestItem,
     result_tx: &mpsc::UnboundedSender<TestResult>,
 ) {
-    let Some(w) = ensure_worker(state, python_bin, path_refs, root).await else {
+    let Some(w) = ensure_worker(state, python_bin, path_refs, root, log_level).await else {
         let _ = result_tx.send(TestResult {
             test,
             outcome: TestOutcome::Error {
@@ -255,6 +266,7 @@ async fn register_hooks_for_unit(
     python_bin: &str,
     path_refs: &[&Path],
     root: &Path,
+    log_level: LevelFilter,
     hooks: &[HookItem],
     tests: &[tryke_types::TestItem],
 ) {
@@ -292,7 +304,7 @@ async fn register_hooks_for_unit(
             .hook_cache
             .insert(test.module_path.clone(), params.clone());
 
-        let Some(w) = ensure_worker(state, python_bin, path_refs, root).await else {
+        let Some(w) = ensure_worker(state, python_bin, path_refs, root, log_level).await else {
             continue;
         };
         if let Err(e) = w.register_hooks(params).await {
@@ -309,12 +321,13 @@ async fn handle_ctrl(
     python_bin: &str,
     path_refs: &[&Path],
     root: &Path,
+    log_level: LevelFilter,
     ctrl: WorkerCtrl,
 ) {
     match ctrl {
         WorkerCtrl::Ping(ack_tx) => {
             trace!("worker_task: ping (pre-warm)");
-            let _ = ensure_worker(state, python_bin, path_refs, root).await;
+            let _ = ensure_worker(state, python_bin, path_refs, root, log_level).await;
             let _ = ack_tx.send(());
         }
         WorkerCtrl::Restart(ack_tx) => {
@@ -325,7 +338,7 @@ async fn handle_ctrl(
             // Eagerly respawn so the next Unit doesn't pay Python startup
             // latency. ensure_worker replays cached register_hooks against
             // the fresh process, mirroring the crash-recovery path.
-            let _ = ensure_worker(state, python_bin, path_refs, root).await;
+            let _ = ensure_worker(state, python_bin, path_refs, root, log_level).await;
             let _ = ack_tx.send(());
         }
     }
@@ -336,11 +349,21 @@ async fn handle_unit(
     python_bin: &str,
     path_refs: &[&Path],
     root: &Path,
+    log_level: LevelFilter,
     unit: WorkUnit,
     result_tx: mpsc::UnboundedSender<TestResult>,
 ) {
     if !unit.hooks.is_empty() {
-        register_hooks_for_unit(state, python_bin, path_refs, root, &unit.hooks, &unit.tests).await;
+        register_hooks_for_unit(
+            state,
+            python_bin,
+            path_refs,
+            root,
+            log_level,
+            &unit.hooks,
+            &unit.tests,
+        )
+        .await;
     }
     let finalize_modules: std::collections::HashSet<String> = if unit.hooks.is_empty() {
         std::collections::HashSet::new()
@@ -349,7 +372,10 @@ async fn handle_unit(
     };
     for test in unit.tests {
         trace!("worker_task: running test {}", test.name);
-        run_single_test(state, python_bin, path_refs, root, test, &result_tx).await;
+        run_single_test(
+            state, python_bin, path_refs, root, log_level, test, &result_tx,
+        )
+        .await;
     }
     for module in finalize_modules {
         if let Some(w) = state.process.as_mut()
@@ -364,6 +390,7 @@ async fn worker_task(
     python_bin: String,
     python_path: Vec<std::path::PathBuf>,
     root: PathBuf,
+    log_level: LevelFilter,
     work_rx: async_channel::Receiver<WorkerMsg>,
     mut ctrl_rx: mpsc::UnboundedReceiver<WorkerCtrl>,
 ) {
@@ -380,13 +407,21 @@ async fn worker_task(
             biased;
             ctrl = ctrl_rx.recv() => {
                 let Some(ctrl) = ctrl else { break };
-                handle_ctrl(&mut state, &python_bin, &path_refs, &root, ctrl).await;
+                handle_ctrl(&mut state, &python_bin, &path_refs, &root, log_level, ctrl).await;
             }
             msg = work_rx.recv() => {
                 match msg {
                     Ok(WorkerMsg::Unit(unit, result_tx)) => {
-                        handle_unit(&mut state, &python_bin, &path_refs, &root, unit, result_tx)
-                            .await;
+                        handle_unit(
+                            &mut state,
+                            &python_bin,
+                            &path_refs,
+                            &root,
+                            log_level,
+                            unit,
+                            result_tx,
+                        )
+                        .await;
                     }
                     Ok(WorkerMsg::Shutdown) | Err(_) => break,
                 }
@@ -492,6 +527,7 @@ def test_third(n: int = Depends(counter)) -> None:
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_package_dir()],
+            LevelFilter::Off,
         );
         pool.warm().await;
 
@@ -576,6 +612,7 @@ def test_noop() -> None:
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_package_dir()],
+            LevelFilter::Off,
         );
         pool.warm().await;
 
@@ -624,6 +661,7 @@ def test_noop() -> None:
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_package_dir()],
+            LevelFilter::Off,
         );
         // No warm() — workers are not yet spawned.
         let restarted =

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -31,18 +31,34 @@ pub struct WorkerProcess {
 }
 
 impl WorkerProcess {
+    /// Spawn a fresh worker process.
+    ///
+    /// `log_level` is forwarded as `TRYKE_LOG=<level>` on the child env so
+    /// the python worker's `_configure_logging_from_env` lights up at the
+    /// same level as the rust process. Pass `LevelFilter::Off` to keep the
+    /// worker silent (no env var set), preserving the pre-existing
+    /// "no chatter unless asked" default.
     #[expect(clippy::missing_errors_doc)]
-    pub fn spawn(python_bin: &str, python_path: &[&Path], root: &Path) -> Result<Self> {
-        debug!("spawning worker: {python_bin} -m tryke.worker");
+    pub fn spawn(
+        python_bin: &str,
+        python_path: &[&Path],
+        root: &Path,
+        log_level: log::LevelFilter,
+    ) -> Result<Self> {
+        debug!("spawning worker: {python_bin} -m tryke.worker (log={log_level})");
         let pythonpath = build_pythonpath(python_path);
-        let mut child = Command::new(python_bin)
+        let mut command = Command::new(python_bin);
+        command
             .args(["-m", "tryke.worker"])
             .env("PYTHONPATH", &pythonpath)
             .current_dir(root)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()?;
+            .stderr(std::process::Stdio::piped());
+        if let Some(value) = worker_log_env_value(log_level) {
+            command.env("TRYKE_LOG", value);
+        }
+        let mut child = command.spawn()?;
         let stdin = BufWriter::new(child.stdin.take().ok_or_else(|| anyhow!("no stdin"))?);
         let stdout = BufReader::new(child.stdout.take().ok_or_else(|| anyhow!("no stdout"))?);
         let stderr = child.stderr.take().ok_or_else(|| anyhow!("no stderr"))?;
@@ -291,6 +307,20 @@ fn append_stderr(buf: &Mutex<VecDeque<u8>>, data: &[u8]) {
     g.extend(data.iter().copied());
 }
 
+/// Translate a resolved log level into the value placed on the spawned
+/// worker's `TRYKE_LOG` env var, if any.
+///
+/// `Off` returns `None` so the env var stays unset and the python
+/// worker's `_configure_logging_from_env` no-ops. Anything else returns
+/// the lowercase level name (`debug`, `info`, ...) which the worker's
+/// `logging.getLevelName` understands once uppercased.
+fn worker_log_env_value(log_level: log::LevelFilter) -> Option<String> {
+    if log_level == log::LevelFilter::Off {
+        return None;
+    }
+    Some(log_level.as_str().to_ascii_lowercase())
+}
+
 fn build_pythonpath(extra: &[&Path]) -> String {
     let existing = std::env::var("PYTHONPATH").unwrap_or_default();
     let mut parts: Vec<String> = extra
@@ -501,6 +531,33 @@ mod tests {
             expected_assertions: vec![],
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn worker_log_env_value_off_returns_none() {
+        // `Off` means: don't set TRYKE_LOG on the child env, preserving
+        // the python worker's "no chatter unless asked" default.
+        assert_eq!(worker_log_env_value(log::LevelFilter::Off), None);
+    }
+
+    #[test]
+    fn worker_log_env_value_lowercases_level_name() {
+        // The python worker uppercases before passing to
+        // `logging.getLevelName`, so case actually doesn't matter, but
+        // shipping lowercase keeps env values consistent with how rust
+        // log levels render and avoids a 50/50 stylistic decision.
+        assert_eq!(
+            worker_log_env_value(log::LevelFilter::Info).as_deref(),
+            Some("info"),
+        );
+        assert_eq!(
+            worker_log_env_value(log::LevelFilter::Debug).as_deref(),
+            Some("debug"),
+        );
+        assert_eq!(
+            worker_log_env_value(log::LevelFilter::Warn).as_deref(),
+            Some("warn"),
+        );
     }
 
     #[test]

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -300,6 +300,7 @@ mod tests {
     use std::{fs, sync::Arc};
 
     use bytes::Bytes;
+    use log::LevelFilter;
     use tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
         net::{TcpListener, TcpStream},
@@ -322,6 +323,7 @@ mod tests {
             1,
             &test_python_bin(),
             std::path::Path::new("."),
+            LevelFilter::Off,
         ))
     }
 
@@ -524,7 +526,12 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let dir = make_root();
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
-        let pool = Arc::new(WorkerPool::new(1, "python3", std::path::Path::new(".")));
+        let pool = Arc::new(WorkerPool::new(
+            1,
+            "python3",
+            std::path::Path::new("."),
+            LevelFilter::Off,
+        ));
 
         let (bcast_tx, _) = broadcast::channel::<Bytes>(64);
         let bcast_tx_clone = bcast_tx.clone();

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use bytes::Bytes;
-use log::debug;
+use log::{LevelFilter, debug};
 use tokio::{
     net::TcpListener,
     sync::{Mutex, broadcast},
@@ -20,16 +20,24 @@ pub struct Server {
     root: PathBuf,
     excludes: Vec<String>,
     python: String,
+    log_level: LevelFilter,
 }
 
 impl Server {
     #[must_use]
-    pub fn new(port: u16, root: PathBuf, excludes: Vec<String>, python: String) -> Self {
+    pub fn new(
+        port: u16,
+        root: PathBuf,
+        excludes: Vec<String>,
+        python: String,
+        log_level: LevelFilter,
+    ) -> Self {
         Self {
             port,
             root,
             excludes,
             python,
+            log_level,
         }
     }
 
@@ -42,7 +50,12 @@ impl Server {
     #[expect(clippy::missing_errors_doc)]
     pub async fn run_on_listener(self, listener: TcpListener) -> anyhow::Result<()> {
         let size = std::thread::available_parallelism().map_or(4, std::num::NonZero::get);
-        let pool = Arc::new(WorkerPool::new(size, &self.python, &self.root));
+        let pool = Arc::new(WorkerPool::new(
+            size,
+            &self.python,
+            &self.root,
+            self.log_level,
+        ));
         pool.warm().await;
 
         // Held across the full duration of a single `run` so concurrent
@@ -155,6 +168,7 @@ mod tests {
 
     use std::time::Duration;
 
+    use log::LevelFilter;
     use tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
         net::{TcpListener, TcpStream},
@@ -172,7 +186,7 @@ mod tests {
         let root = dir.path().to_path_buf();
         let python = test_python_bin();
         tokio::spawn(async move {
-            Server::new(port, root, vec![], python)
+            Server::new(port, root, vec![], python, LevelFilter::Off)
                 .run_on_listener(listener)
                 .await
                 .unwrap();

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -131,8 +131,6 @@ TRYKE_LOG=debug tryke test
 TRYKE_LOG=info RUST_LOG=tryke=warn tryke test
 ```
 
-The legacy `TRYKE_WORKER_LOG` env var is still accepted (one cycle) as a deprecated alias for `TRYKE_LOG`. A single deprecation line is logged when only the old name is set.
-
 ## Example
 
 A typical configuration for a project with benchmarks and generated code:

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -84,6 +84,55 @@ Override the project root (where Tryke looks for `pyproject.toml` and test files
 tryke test --root /path/to/project
 ```
 
+## Logging
+
+Tryke has a single user-facing verbosity knob with a precedence chain spanning CLI flags, environment variables, and cross-language propagation to the python workers it spawns.
+
+### CLI flags
+
+`-v`, `-vv`, `-vvv` raise the level (info → debug → trace). `-q`, `-qq` lower it (error → silent). The default is `warn`.
+
+### Environment variables
+
+- **`TRYKE_LOG`** — the umbrella knob. Accepts a bare level name (`off`, `error`, `warn`, `info`, `debug`, `trace`) and propagates to **both** the rust process and every python worker it spawns. This is what you should set when you want one knob.
+- **`RUST_LOG`** — power-user override for the rust side only. Honored natively by `env_logger`, so the standard per-module filter syntax (`tryke=debug,hyper=warn`) works. Does **not** propagate to python workers — its module-filter grammar doesn't map onto a python log level.
+
+### Precedence
+
+**Rust log filter** (consumed by `env_logger`):
+
+1. `RUST_LOG` if set (wins natively).
+2. `TRYKE_LOG` if set.
+3. The CLI flag (`-v` / `-q`).
+4. Default `warn`.
+
+**Python worker log** (spawned by tryke, configured by `TRYKE_LOG` on the worker env):
+
+1. `TRYKE_LOG` if set.
+2. The CLI flag, **only** when explicitly more verbose than `warn` (i.e., the user passed at least one `-v`). Default `warn` does not light up workers — preserves the long-standing "no chatter unless asked" behavior.
+3. Otherwise off.
+
+### Examples
+
+```bash
+# Default: rust at warn, workers silent.
+tryke test
+
+# `-v` lights up both layers at info.
+tryke -v test
+
+# Per-module rust filtering, workers stay silent.
+RUST_LOG=tryke=debug,tryke_runner=trace tryke test
+
+# Single knob: both layers at debug, regardless of CLI flag.
+TRYKE_LOG=debug tryke test
+
+# RUST_LOG wins for rust filtering; TRYKE_LOG still drives python.
+TRYKE_LOG=info RUST_LOG=tryke=warn tryke test
+```
+
+The legacy `TRYKE_WORKER_LOG` env var is still accepted (one cycle) as a deprecated alias for `TRYKE_LOG`. A single deprecation line is logged when only the old name is set.
+
 ## Example
 
 A typical configuration for a project with benchmarks and generated code:

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -855,22 +855,24 @@ def _configure_logging_from_env() -> None:
 
     Off by default so normal test runs don't emit anything on stderr.
     The rust runner sets ``TRYKE_LOG=<level>`` on the worker env when
-    ``-v`` / ``-q`` or the ``TRYKE_LOG`` env var asks for cross-language
-    verbosity, so users typically don't set this directly.
+    ``-v`` (or ``TRYKE_LOG``) asks for cross-language verbosity, so
+    users typically don't set this directly. ``-q``/quiet does not
+    light up workers — workers stay silent unless the user explicitly
+    asked for more verbosity than the rust default ``warn``.
 
     Accepts ``DEBUG`` / ``INFO`` / ``WARN`` / ``ERROR`` / ``TRACE``.
     Output goes to stderr so it never contaminates the JSON-RPC stream
     on stdout.
 
-    The legacy ``TRYKE_WORKER_LOG`` name is honored as a deprecated
-    alias (one cycle) so existing shell exports keep working; a single
-    deprecation line is logged when only the old name is set.
+    ``TRYKE_WORKER_LOG`` is honored as a deprecated alias for one
+    cycle so existing shell exports keep working when ``tryke.worker``
+    is invoked standalone. The deprecation warning lives in the rust
+    runner so it fires exactly once per ``tryke`` invocation rather
+    than once per worker process.
     """
     level_name = os.environ.get("TRYKE_LOG", "").strip().upper()
-    legacy_name = os.environ.get("TRYKE_WORKER_LOG", "").strip().upper()
-    use_legacy = not level_name and bool(legacy_name)
-    if use_legacy:
-        level_name = legacy_name
+    if not level_name:
+        level_name = os.environ.get("TRYKE_WORKER_LOG", "").strip().upper()
     if not level_name:
         return
     # Map TRACE to DEBUG since stdlib logging has no TRACE level.
@@ -886,11 +888,6 @@ def _configure_logging_from_env() -> None:
     _log.addHandler(handler)
     _log.setLevel(level)
     _log.propagate = False
-    if use_legacy:
-        _log.warning(
-            "TRYKE_WORKER_LOG is deprecated; use TRYKE_LOG instead "
-            "(it propagates to both rust and python workers)"
-        )
 
 
 def main() -> None:

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -863,16 +863,8 @@ def _configure_logging_from_env() -> None:
     Accepts ``DEBUG`` / ``INFO`` / ``WARN`` / ``ERROR`` / ``TRACE``.
     Output goes to stderr so it never contaminates the JSON-RPC stream
     on stdout.
-
-    ``TRYKE_WORKER_LOG`` is honored as a deprecated alias for one
-    cycle so existing shell exports keep working when ``tryke.worker``
-    is invoked standalone. The deprecation warning lives in the rust
-    runner so it fires exactly once per ``tryke`` invocation rather
-    than once per worker process.
     """
     level_name = os.environ.get("TRYKE_LOG", "").strip().upper()
-    if not level_name:
-        level_name = os.environ.get("TRYKE_WORKER_LOG", "").strip().upper()
     if not level_name:
         return
     # Map TRACE to DEBUG since stdlib logging has no TRACE level.

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -851,15 +851,26 @@ class Worker:
 
 
 def _configure_logging_from_env() -> None:
-    """Opt-in worker logging via ``TRYKE_WORKER_LOG``.
+    """Opt-in worker logging via ``TRYKE_LOG``.
 
     Off by default so normal test runs don't emit anything on stderr.
-    Set ``TRYKE_WORKER_LOG=DEBUG`` (or ``INFO`` / ``TRACE``) before
-    invoking ``tryke test``/``tryke test --watch``/``tryke server`` to
-    trace module registration and dispatch. Output goes to stderr so it
-    never contaminates the JSON-RPC stream on stdout.
+    The rust runner sets ``TRYKE_LOG=<level>`` on the worker env when
+    ``-v`` / ``-q`` or the ``TRYKE_LOG`` env var asks for cross-language
+    verbosity, so users typically don't set this directly.
+
+    Accepts ``DEBUG`` / ``INFO`` / ``WARN`` / ``ERROR`` / ``TRACE``.
+    Output goes to stderr so it never contaminates the JSON-RPC stream
+    on stdout.
+
+    The legacy ``TRYKE_WORKER_LOG`` name is honored as a deprecated
+    alias (one cycle) so existing shell exports keep working; a single
+    deprecation line is logged when only the old name is set.
     """
-    level_name = os.environ.get("TRYKE_WORKER_LOG", "").strip().upper()
+    level_name = os.environ.get("TRYKE_LOG", "").strip().upper()
+    legacy_name = os.environ.get("TRYKE_WORKER_LOG", "").strip().upper()
+    use_legacy = not level_name and bool(legacy_name)
+    if use_legacy:
+        level_name = legacy_name
     if not level_name:
         return
     # Map TRACE to DEBUG since stdlib logging has no TRACE level.
@@ -875,6 +886,11 @@ def _configure_logging_from_env() -> None:
     _log.addHandler(handler)
     _log.setLevel(level)
     _log.propagate = False
+    if use_legacy:
+        _log.warning(
+            "TRYKE_WORKER_LOG is deprecated; use TRYKE_LOG instead "
+            "(it propagates to both rust and python workers)"
+        )
 
 
 def main() -> None:


### PR DESCRIPTION
## Context

Verbosity in tryke today is fragmented across four independent knobs that don't talk to each other: `-v`/`-q` flags drive rust logging, `RUST_LOG` is silently dropped, `TRYKE_WORKER_LOG` configures python workers but is undocumented and not auto-set, and a `Verbosity` reporter enum is derived from log level via an awkward hand-rolled match.

In practice that means:

- `tryke -v test` lights up rust logs but **not** python worker logs. Diagnosing a flaky worker requires knowing about the undocumented `TRYKE_WORKER_LOG` env var and setting it manually.
- The VS Code extension's `RUST_LOG=tryke=<level>` (issue #91) was being dropped entirely because `env_logger::Builder::new()` ignores `RUST_LOG`.

## Approach

Adopt a single user-facing knob (`-v`/`-q` flags **or** `TRYKE_LOG` env) that propagates to **both** the rust process and every python worker it spawns. `RUST_LOG` stays as a power-user override for the rust side only — its per-module filter syntax (`tryke=info,hyper=warn`) doesn't map onto a python log level, so it deliberately doesn't propagate to workers. This mirrors uv's ""RUST_LOG forwarded to PEP 517 build backends"" model and avoids pytest-xdist's well-known footgun where worker verbosity diverges from the parent.

### Precedence

**Rust log filter** (consumed by `env_logger`):

1. `RUST_LOG` (wins natively via `Builder::from_env`).
2. `TRYKE_LOG`.
3. `-v`/`-q` flag.
4. Default `warn`.

**Python worker log** (set as `TRYKE_LOG` on the worker's env):

1. `TRYKE_LOG` if set.
2. CLI flag, **only** when explicitly more verbose than `warn` (i.e., the user passed at least one `-v`).
3. Otherwise off — preserves the long-standing ""no chatter unless asked"" default.

### Concrete changes

- New resolvers `tryke_config::rust_log_default` + `worker_log_level` mirroring `resolve_python`'s shape (8 unit tests covering the precedence chain).
- `WorkerPool::new` / `with_python_path` / `WorkerProcess::spawn` take a `log::LevelFilter`; the spawn `Command` sets `TRYKE_LOG` on the child env when level > Off. Backwards-incompatible for direct callers — the user OK'd this.
- `tryke/main.rs` resolves the rust default via the new helper and feeds `env_logger::Builder::from_env(default_filter_or(...))` so `RUST_LOG` wins natively. **This subsumes #91**, which can be closed when this lands.
- `Verbosity::from_level_filter` replaces the hand-rolled `log::Level` match (which collapsed three log levels into one reporter level).
- `python/tryke/worker.py:_configure_logging_from_env` reads `TRYKE_LOG` first; `TRYKE_WORKER_LOG` is retained as a deprecated alias for one cycle with a one-time deprecation log line.
- `docs/guides/configuration.md` documents the full precedence chain end-to-end with examples.
- `CONTRIBUTING.md`: `cargo run -- test` (delayed copilot follow-up from #93).

### Doesn't do

- **Doesn't decouple reporter `Verbosity` from log level.** That's pytest's model (`-v` = UI detail, `--log-level` = diagnostic filter) and is the right end-state, but it's a separate UX change worth its own PR.
- **Doesn't add a custom python TRACE level.** Mapping `TRACE` → `DEBUG` (the current behavior) is fine.

## Test plan

Unit:
- `tryke_config` precedence-chain tests for `rust_log_default` and `worker_log_level` (env wins, CLI fallback, garbage values, default behavior).
- `tryke_runner::worker::worker_log_env_value` returns `None` for `Off` and lowercase level names otherwise.

Integration:
- All 611 existing tests pass with the additional `LevelFilter::Off` argument threaded through.

End-to-end (manual):

```bash
tryke test                                     # rust at warn, workers off
tryke -v test                                  # rust + workers both at info
RUST_LOG=tryke=debug tryke test                # rust debug, workers off
TRYKE_LOG=info tryke test                      # both at info
TRYKE_LOG=info RUST_LOG=tryke=warn tryke test  # rust warn, workers info
TRYKE_WORKER_LOG=info tryke test               # workers info + deprecation warning
```

## Related

- Closes #89's broader logging story (the original RUST_LOG-being-ignored bug surfaced via #91 — that PR can be closed in favor of this one).
- VS Code extension follow-up (out of tree): swap `RUST_LOG=tryke=<level>` for `TRYKE_LOG=<level>` so worker logs also flow into the ""Tryke Server"" output panel.