### PR TITLE
Fix workflow permissions for code scanning alert 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/thejchap/tryke/security/code-scanning/10](https://github.com/thejchap/tryke/security/code-scanning/10)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token scope.  
Best single fix (without changing behavior): set:

- `contents: read`

This is sufficient for checkout and typical read-only CI. No job in the shown workflow appears to need write access (`issues`, `pull-requests`, `packages`, etc.), so we should not grant any additional permissions.

Change region: near the top of `.github/workflows/ci.yml`, right after the `on:` section and before `env:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
