### PR TITLE
Fix workflow permissions for code scanning alert 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main]
 permissions:
+  actions: write
   contents: read
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,15 @@ on:
   pull_request:
     branches: [main]
 permissions:
-  actions: write
   contents: read
 env:
   CARGO_TERM_COLOR: always
 jobs:
   fmt:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v6
       - run: rustup show
@@ -20,6 +22,9 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v6
       - run: rustup show
@@ -28,6 +33,9 @@ jobs:
 
   cli-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v6
       - run: rustup show
@@ -58,6 +66,9 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/thejchap/tryke/security/code-scanning/9](https://github.com/thejchap/tryke/security/code-scanning/9)

Add an explicit workflow-level `permissions` block with least privilege.  
Best fix here: define at the top level (right after `on`) so it applies consistently to all jobs unless overridden.

For this CI file, the minimal and appropriate permission is:

- `contents: read`

This supports `actions/checkout` and normal read-only CI operations while preventing unnecessary write scopes.

Edit only `.github/workflows/ci.yml`, inserting:

```yml
permissions:
  contents: read
```

between the existing `on:` section and `env:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
