### PR TITLE
Surface worker spawn and hook replay errors in test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ uvx tryke test
 <!-- REPORTER:text:plain:START -->
 
 ```text
-tryke test v0.0.27
+tryke test v0.0.28
 
+warning: scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
 sample.py:
   users
     get

--- a/crates/tryke_runner/src/pool.rs
+++ b/crates/tryke_runner/src/pool.rs
@@ -22,6 +22,12 @@ use crate::worker::WorkerProcess;
 struct WorkerState {
     process: Option<WorkerProcess>,
     hook_cache: HashMap<String, RegisterHooksParams>,
+    /// Most recent spawn or hook-replay failure, captured so
+    /// `run_single_test` can surface the real reason (and any worker
+    /// stderr) instead of the opaque "worker unavailable" placeholder.
+    /// Cleared once we have a live worker again so we don't replay a
+    /// stale error against an unrelated test.
+    last_failure: Option<String>,
 }
 
 impl WorkerState {
@@ -29,8 +35,26 @@ impl WorkerState {
         Self {
             process: None,
             hook_cache: HashMap::new(),
+            last_failure: None,
         }
     }
+}
+
+/// Build the user-facing message for a worker error, appending captured
+/// stderr (if any) so the python-side traceback is visible to the user
+/// without needing to enable debug logging. The actual python crash —
+/// e.g. `ModuleNotFoundError: No module named 'tryke'` when the worker
+/// venv is missing the package — only ever appears on the worker's
+/// stderr pipe, so suppressing it here is what makes spawn failures look
+/// like an opaque "worker unavailable".
+fn format_worker_failure(prefix: &str, err: &dyn std::fmt::Display, stderr: &str) -> String {
+    let mut msg = format!("{prefix}: {err}");
+    let trimmed = stderr.trim();
+    if !trimmed.is_empty() {
+        msg.push_str("\nworker stderr:\n");
+        msg.push_str(trimmed);
+    }
+    msg
 }
 
 enum WorkerMsg {
@@ -187,20 +211,37 @@ async fn ensure_worker<'a>(
     let mut w = match WorkerProcess::spawn(python_bin, path_refs, root, log_level) {
         Ok(w) => w,
         Err(e) => {
-            debug!("worker_task: spawn failed: {e}");
+            let msg = format_worker_failure(
+                &format!("failed to spawn python worker ({python_bin} -m tryke.worker)"),
+                &e,
+                "",
+            );
+            debug!("worker_task: {msg}");
+            state.last_failure = Some(msg);
             return None;
         }
     };
     for (module, params) in &state.hook_cache {
         if let Err(e) = w.register_hooks(params.clone()).await {
-            // If hook replay fails the worker is in an inconsistent state
-            // (some modules registered, some not). Drop it so the next
-            // attempt starts from scratch rather than silently running
-            // tests without fixtures.
-            debug!("worker_task: replay register_hooks for {module} failed: {e}");
+            // Drain stderr before dropping the dead worker — otherwise
+            // the python traceback that explains *why* replay failed
+            // (e.g. ModuleNotFoundError on the worker side) goes with
+            // it and the user sees only "Broken pipe".
+            let stderr_output = w.drain_stderr().await;
+            let msg = format_worker_failure(
+                &format!("hook replay failed for module {module}"),
+                &e,
+                &stderr_output,
+            );
+            debug!("worker_task: {msg}");
+            state.last_failure = Some(msg);
+            // Worker is in an inconsistent state (some modules registered,
+            // some not). Drop it so the next attempt starts from scratch
+            // rather than silently running tests without fixtures.
             return None;
         }
     }
+    state.last_failure = None;
     state.process = Some(w);
     state.process.as_mut()
 }
@@ -220,11 +261,13 @@ async fn run_single_test(
     result_tx: &mpsc::UnboundedSender<TestResult>,
 ) {
     let Some(w) = ensure_worker(state, python_bin, path_refs, root, log_level).await else {
+        let message = state
+            .last_failure
+            .clone()
+            .unwrap_or_else(|| "worker unavailable (spawn or hook replay failed)".into());
         let _ = result_tx.send(TestResult {
             test,
-            outcome: TestOutcome::Error {
-                message: "worker unavailable (spawn or hook replay failed)".into(),
-            },
+            outcome: TestOutcome::Error { message },
             duration: Duration::ZERO,
             stdout: String::new(),
             stderr: String::new(),
@@ -308,7 +351,17 @@ async fn register_hooks_for_unit(
             continue;
         };
         if let Err(e) = w.register_hooks(params).await {
-            debug!("worker_task: register_hooks failed: {e}");
+            // Drain stderr before dropping so the python traceback that
+            // killed the worker reaches the user-facing test result via
+            // `last_failure`, instead of being lost with the process.
+            let stderr_output = w.drain_stderr().await;
+            let msg = format_worker_failure(
+                &format!("register_hooks failed for module {}", test.module_path),
+                &e,
+                &stderr_output,
+            );
+            debug!("worker_task: {msg}");
+            state.last_failure = Some(msg);
             // Worker is potentially wedged; drop it so the next test
             // forces a respawn-with-replay.
             state.process = None;
@@ -640,6 +693,74 @@ def test_noop() -> None:
             2,
             "module body must run once per fresh interpreter \
              (1 initial + 1 after restart_workers); got {count:?}"
+        );
+
+        pool.shutdown();
+    }
+
+    /// When the worker python dies during startup (e.g. project venv
+    /// without `tryke` installed prints `ModuleNotFoundError` and
+    /// exits), the user-facing error must include the python stderr —
+    /// not just the opaque "worker unavailable" placeholder that used
+    /// to be all the user saw. Regression test for the diagnosability
+    /// fix.
+    ///
+    /// Unix-only: simulates the failing python with a shell script.
+    /// The workspace venv's python has `tryke` installed in editable
+    /// mode and its `.pth` file is searched regardless of PYTHONPATH,
+    /// so we can't reproduce the missing-module case with a real
+    /// interpreter. A stub `python_bin` is sufficient — what we're
+    /// testing is the rust-side error propagation, not python's
+    /// resolution rules.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn worker_missing_tryke_surfaces_python_error_in_outcome() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("pyproject.toml"), "").expect("write pyproject.toml");
+
+        let fake_python = dir.path().join("fake_python.sh");
+        std::fs::write(
+            &fake_python,
+            "#!/bin/sh\n\
+             echo \"$0: Error while finding module specification for \
+             'tryke.worker' (ModuleNotFoundError: No module named 'tryke')\" >&2\n\
+             exit 1\n",
+        )
+        .expect("write fake python");
+        std::fs::set_permissions(&fake_python, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake python");
+
+        let test_file = dir.path().join("test_no_tryke.py");
+        std::fs::write(&test_file, "def test_noop(): pass\n").expect("write test file");
+
+        let unit = WorkUnit {
+            tests: vec![make_test_item("test_no_tryke", "test_noop", &test_file)],
+            hooks: vec![],
+        };
+
+        let pool = WorkerPool::with_python_path(
+            1,
+            fake_python.to_str().expect("fake python path"),
+            dir.path(),
+            &[dir.path().to_path_buf()],
+            LevelFilter::Off,
+        );
+
+        let results: Vec<TestResult> = pool.run(vec![unit]).collect().await;
+        assert_eq!(results.len(), 1);
+        let message = match &results[0].outcome {
+            TestOutcome::Error { message } => message.clone(),
+            other => panic!("expected Error outcome, got {other:?}"),
+        };
+        assert!(
+            message.contains("No module named 'tryke'"),
+            "missing python traceback in error message: {message}"
+        );
+        assert!(
+            message.contains("worker stderr:"),
+            "missing 'worker stderr:' header in error message: {message}"
         );
 
         pool.shutdown();

--- a/crates/tryke_runner/src/pool.rs
+++ b/crates/tryke_runner/src/pool.rs
@@ -286,14 +286,10 @@ async fn run_single_test(
             // spawn a fresh one and replay cached hooks so the remaining
             // tests in this unit keep their fixtures.
             state.process = None;
-            let mut msg = format!("worker error: {err}");
-            if !stderr_output.is_empty() {
-                msg.push_str("\nworker stderr:\n");
-                msg.push_str(&stderr_output);
-            }
+            let message = format_worker_failure("worker error", &err, &stderr_output);
             let _ = result_tx.send(TestResult {
                 test,
-                outcome: TestOutcome::Error { message: msg },
+                outcome: TestOutcome::Error { message },
                 duration: Duration::ZERO,
                 stdout: String::new(),
                 stderr: stderr_output,
@@ -705,6 +701,16 @@ def test_noop() -> None:
     /// to be all the user saw. Regression test for the diagnosability
     /// fix.
     ///
+    /// The unit carries a `HookItem` on purpose: with `hooks: vec![]`,
+    /// `handle_unit` skips `register_hooks_for_unit` entirely and the
+    /// failure would surface via `run_single_test`'s `run_test` error
+    /// path — which already existed before this PR. To exercise the
+    /// new code (`register_hooks_for_unit` stashing `last_failure`
+    /// after `drain_stderr`, then `ensure_worker`'s replay loop
+    /// stashing again on respawn, then `run_single_test` reading
+    /// `last_failure` instead of the opaque placeholder) the test
+    /// needs a hook so `register_hooks_for_unit` actually runs.
+    ///
     /// Unix-only: simulates the failing python with a shell script.
     /// The workspace venv's python has `tryke` installed in editable
     /// mode and its `.pth` file is searched regardless of PYTHONPATH,
@@ -735,9 +741,25 @@ def test_noop() -> None:
         let test_file = dir.path().join("test_no_tryke.py");
         std::fs::write(&test_file, "def test_noop(): pass\n").expect("write test file");
 
+        // Hook on the same module forces `handle_unit` through
+        // `register_hooks_for_unit` → `ensure_worker` (spawn ok) →
+        // `register_hooks` (RPC error) → `drain_stderr` → stash
+        // `last_failure` → drop process. Then `run_single_test` →
+        // `ensure_worker` → respawn ok → replay `register_hooks`
+        // (RPC error) → stash `last_failure` → return None →
+        // `run_single_test` surfaces `last_failure` as the outcome
+        // message. Without this hook the new path isn't exercised.
+        let hook = HookItem {
+            name: "noop".into(),
+            module_path: "test_no_tryke".into(),
+            per: FixturePer::Test,
+            groups: vec![],
+            depends_on: vec![],
+            line_number: None,
+        };
         let unit = WorkUnit {
             tests: vec![make_test_item("test_no_tryke", "test_noop", &test_file)],
-            hooks: vec![],
+            hooks: vec![hook],
         };
 
         let pool = WorkerPool::with_python_path(
@@ -754,6 +776,14 @@ def test_noop() -> None:
             TestOutcome::Error { message } => message.clone(),
             other => panic!("expected Error outcome, got {other:?}"),
         };
+        // `run_single_test`'s `last_failure` path produces this prefix
+        // — proves we went through `ensure_worker`'s replay loop, not
+        // through `run_test`'s direct error path which would say
+        // "worker error: …".
+        assert!(
+            message.starts_with("hook replay failed for module test_no_tryke"),
+            "expected hook-replay prefix from ensure_worker.last_failure, got: {message}"
+        );
         assert!(
             message.contains("No module named 'tryke'"),
             "missing python traceback in error message: {message}"

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -27,6 +27,12 @@ pub struct WorkerProcess {
     /// child's stderr pipe into this buffer so the pipe never fills and
     /// the worker can't block on a stderr write mid-RPC.
     stderr_buf: Arc<Mutex<VecDeque<u8>>>,
+    /// Handle to the stderr-drainer task. `drain_stderr` joins this
+    /// (with a short timeout) so any bytes still in the kernel pipe at
+    /// the moment of a worker failure end up in `stderr_buf` before we
+    /// snapshot it — without this, a worker that dies during startup
+    /// can lose its python traceback to a race with the RPC error path.
+    stderr_drainer: Option<tokio::task::JoinHandle<()>>,
     next_id: u64,
 }
 
@@ -72,21 +78,26 @@ impl WorkerProcess {
         // as "tryke hangs at finalize_hooks". Spawn a drainer that
         // keeps the pipe empty for the worker's lifetime.
         let stderr_buf = Arc::new(Mutex::new(VecDeque::<u8>::new()));
-        if let Err(err) = spawn_stderr_drainer(stderr, Arc::clone(&stderr_buf)) {
-            if let Err(kill_err) = child.start_kill() {
-                debug!(
-                    "failed to kill worker after stderr drainer setup error (pid {:?}): {kill_err}",
-                    child.id()
-                );
+        let stderr_drainer = match spawn_stderr_drainer(stderr, Arc::clone(&stderr_buf)) {
+            Ok(handle) => handle,
+            Err(err) => {
+                if let Err(kill_err) = child.start_kill() {
+                    debug!(
+                        "failed to kill worker after stderr drainer setup error (pid {:?}): \
+                         {kill_err}",
+                        child.id()
+                    );
+                }
+                return Err(err);
             }
-            return Err(err);
-        }
+        };
 
         Ok(Self {
             child,
             stdin,
             stdout,
             stderr_buf,
+            stderr_drainer: Some(stderr_drainer),
             next_id: 1,
         })
     }
@@ -222,17 +233,26 @@ impl WorkerProcess {
 
     /// Snapshot the buffered worker stderr and clear the buffer.
     ///
-    /// Kept `async` to preserve the pre-fix public signature; the body
-    /// is purely synchronous.
+    /// Called on the error path when the worker is about to be
+    /// discarded. We kill the child first so the drainer task reaches
+    /// EOF, then await the drainer (with a short timeout) so any bytes
+    /// still in the kernel pipe at the time of the failure land in
+    /// `stderr_buf` before we snapshot. Without this, a python worker
+    /// that dies during startup (e.g. `ModuleNotFoundError: tryke`)
+    /// can lose its traceback to a race between the RPC's
+    /// `Broken pipe` and the drainer task being scheduled.
     ///
     /// # Panics
     /// Panics only if the stderr-drainer task panicked while holding the
     /// internal mutex (poisoning it). That task does no fallible work.
-    #[expect(
-        clippy::unused_async,
-        reason = "Preserves pre-fix public async signature"
-    )]
     pub async fn drain_stderr(&mut self) -> String {
+        // Worker is about to be discarded; killing the child closes its
+        // stderr pipe which gives the drainer its EOF. Idempotent on a
+        // process that has already exited.
+        let _ = self.child.start_kill();
+        if let Some(handle) = self.stderr_drainer.take() {
+            let _ = tokio::time::timeout(Duration::from_millis(500), handle).await;
+        }
         let bytes: Vec<u8> = {
             let mut g = self
                 .stderr_buf
@@ -267,10 +287,10 @@ impl Drop for WorkerProcess {
 fn spawn_stderr_drainer(
     stderr: tokio::process::ChildStderr,
     buf: Arc<Mutex<VecDeque<u8>>>,
-) -> Result<()> {
+) -> Result<tokio::task::JoinHandle<()>> {
     let handle = tokio::runtime::Handle::try_current()
         .map_err(|e| anyhow!("WorkerProcess::spawn requires an active tokio runtime: {e}"))?;
-    handle.spawn(async move {
+    Ok(handle.spawn(async move {
         let mut reader = stderr;
         let mut chunk = [0u8; 8192];
         loop {
@@ -283,8 +303,7 @@ fn spawn_stderr_drainer(
                 }
             }
         }
-    });
-    Ok(())
+    }))
 }
 
 /// Append `data` to `buf`, capping it at `STDERR_RETAIN_BYTES` by

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -265,6 +265,14 @@ impl WorkerProcess {
 
     pub async fn shutdown(&mut self) {
         let _ = self.child.kill().await;
+        // Killing the child closes stderr; the drainer will see EOF and
+        // exit on its own — but `abort()` is the explicit, immediate
+        // signal that we're done with it, and prevents a leftover task
+        // from briefly holding the stderr FD + `stderr_buf` Arc past
+        // the worker's lifetime.
+        if let Some(handle) = self.stderr_drainer.take() {
+            handle.abort();
+        }
     }
 }
 
@@ -274,6 +282,12 @@ impl Drop for WorkerProcess {
         // dropped (e.g. on the error-respawn path in pool.rs). start_kill() is
         // the synchronous variant — safe to call on already-dead processes.
         let _ = self.child.start_kill();
+        // Dropping a Tokio JoinHandle detaches the task, so abort it
+        // explicitly to avoid an orphan drainer outliving the worker on
+        // respawn paths (the drainer holds stderr_buf + the stderr FD).
+        if let Some(handle) = self.stderr_drainer.take() {
+            handle.abort();
+        }
     }
 }
 

--- a/docs/guides/reporters.md
+++ b/docs/guides/reporters.md
@@ -20,8 +20,9 @@ Sample output (with `-v` to surface per-assertion lines):
 <!-- REPORTER:text:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.27[0m
+[1mtryke test[0m [2mv0.0.28[0m
 
+[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
 sample.py:
   users
     get
@@ -62,8 +63,9 @@ Sample output:
 <!-- REPORTER:dot:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.27[0m
+[1mtryke test[0m [2mv0.0.28[0m
 
+[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
 [32m.[39m[32m.[39m
 
  [2mTest Files[0m  [1m[32m1 passed[39m[0m [2m(1)[0m
@@ -150,8 +152,9 @@ Sample output:
 <!-- REPORTER:next:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.27[0m
+[1mtryke test[0m [2mv0.0.28[0m
 
+[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
      [1m[32mPASS [39m[0m [[2m  0.000s[0m] [1m[36msample[39m[0m [2m>[0m [36musers[39m [2m>[0m [36mget[39m [2m::[0m returns a stored user
      [1m[32mPASS [39m[0m [[2m  0.000s[0m] [1m[36msample[39m[0m [2m>[0m [36musers[39m [2m>[0m [36mset[39m [2m::[0m stores a new user
 
@@ -180,8 +183,9 @@ Sample output:
 <!-- REPORTER:sugar:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.27[0m
+[1mtryke test[0m [2mv0.0.28[0m
 
+[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
  [1msample.py[0m [32m✓[39m[32m✓[39m                                                [1m2[0m [1m100%[0m [37m████████████[39m
 
  [2mTest Files[0m  [1m[32m1 passed[39m[0m [2m(1)[0m

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,8 +105,9 @@ uvx tryke test
 <!-- REPORTER:text:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.27[0m
+[1mtryke test[0m [2mv0.0.28[0m
 
+[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
 sample.py:
   users
     get


### PR DESCRIPTION
## Summary

- When the python worker dies during startup (e.g. project venv missing the `tryke` package), the failure was hidden behind the opaque `"worker unavailable (spawn or hook replay failed)"` placeholder and the worker's stderr was dropped with the dead process. Users had no actionable signal without re-running with `-vv`.
- Stash the real spawn / replay error (with drained worker stderr) in `WorkerState::last_failure` and use it as the user-facing `TestOutcome::Error` message.
- `register_hooks_for_unit` and `ensure_worker` now drain stderr before dropping the dead worker, so the python traceback reaches the user instead of going with the process.

The output now looks like:

```
hook replay failed for module tests.components.downloader.test_config_flow: worker process closed stdout
worker stderr:
.../python3: Error while finding module specification for 'tryke.worker' (ModuleNotFoundError: No module named 'tryke')
```

## Test plan

- [x] New unix regression test `worker_missing_tryke_surfaces_python_error_in_outcome` (fake `python_bin` stubs the failing interpreter; asserts both the python traceback and `"worker stderr:"` header land in the outcome message).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features` — 621 pass.
- [x] `uvx prek run -a`
- [x] Manual: `tryke test --workers 1 --reporter llm tests/components/downloader` in a venv without `tryke` installed shows the `ModuleNotFoundError` traceback inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)