### PR TITLE
Replace test-count recycling with resource-based worker limits

### DIFF
--- a/crates/tryke_runner/src/lib.rs
+++ b/crates/tryke_runner/src/lib.rs
@@ -5,4 +5,4 @@ pub mod worker;
 
 pub use pool::{WorkerPool, path_to_module};
 pub use schedule::{DistMode, WorkUnit, partition, partition_with_hooks};
-pub use worker::WorkerProcess;
+pub use worker::{RecycleReason, WorkerHealth, WorkerLimits, WorkerProcess};

--- a/crates/tryke_runner/src/pool.rs
+++ b/crates/tryke_runner/src/pool.rs
@@ -11,7 +11,21 @@ use tryke_types::{HookItem, TestOutcome, TestResult};
 
 use crate::protocol::RegisterHooksParams;
 use crate::schedule::WorkUnit;
-use crate::worker::{MAX_TESTS_PER_WORKER, WorkerProcess};
+use crate::worker::{WorkerLimits, WorkerProcess};
+
+/// Bundle of inputs every spawn (and respawn) needs. These five values
+/// never vary across the lifetime of a `worker_task`, so threading them
+/// individually through every helper just inflates the signature and
+/// trips `clippy::too_many_arguments`. Grouping them keeps the call
+/// sites short and lets us add new spawn-time knobs later without
+/// touching every helper signature.
+struct WorkerSpawnCtx<'a> {
+    python_bin: &'a str,
+    path_refs: &'a [&'a Path],
+    root: &'a Path,
+    log_level: LevelFilter,
+    limits: WorkerLimits,
+}
 
 /// Per-worker-task state: the (optional) live Python process plus a cache of
 /// the most recent `register_hooks` call per module. The cache exists so
@@ -84,6 +98,29 @@ impl WorkerPool {
         python_path: &[PathBuf],
         log_level: LevelFilter,
     ) -> Self {
+        Self::with_python_path_and_limits(
+            size,
+            python_bin,
+            root,
+            python_path,
+            log_level,
+            WorkerLimits::default(),
+        )
+    }
+
+    /// Like [`Self::with_python_path`] but with explicit recycle
+    /// thresholds. Tests use this to set tiny ceilings (or
+    /// [`WorkerLimits::unlimited`]) so they can observe — or suppress —
+    /// recycle behaviour without spinning up a real workload.
+    #[must_use]
+    pub fn with_python_path_and_limits(
+        size: usize,
+        python_bin: &str,
+        root: &Path,
+        python_path: &[PathBuf],
+        log_level: LevelFilter,
+        limits: WorkerLimits,
+    ) -> Self {
         let size = size.max(1);
         let python_path = python_path.to_vec();
         let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
@@ -99,6 +136,7 @@ impl WorkerPool {
                 python_path.clone(),
                 root.clone(),
                 log_level,
+                limits,
                 work_rx,
                 ctrl_rx,
             ));
@@ -175,16 +213,19 @@ pub use tryke_types::path_to_module;
 /// metadata and silently skip `before_each` / `after_each`.
 async fn ensure_worker<'a>(
     state: &'a mut WorkerState,
-    python_bin: &str,
-    path_refs: &[&Path],
-    root: &Path,
-    log_level: LevelFilter,
+    ctx: &WorkerSpawnCtx<'_>,
 ) -> Option<&'a mut WorkerProcess> {
     if state.process.is_some() {
         return state.process.as_mut();
     }
     trace!("worker_task: spawning process");
-    let mut w = match WorkerProcess::spawn(python_bin, path_refs, root, log_level) {
+    let mut w = match WorkerProcess::spawn(
+        ctx.python_bin,
+        ctx.path_refs,
+        ctx.root,
+        ctx.log_level,
+        ctx.limits,
+    ) {
         Ok(w) => w,
         Err(e) => {
             debug!("worker_task: spawn failed: {e}");
@@ -212,14 +253,11 @@ async fn ensure_worker<'a>(
 /// `TestOutcome::Error` with the worker's stderr attached for diagnosis.
 async fn run_single_test(
     state: &mut WorkerState,
-    python_bin: &str,
-    path_refs: &[&Path],
-    root: &Path,
-    log_level: LevelFilter,
+    ctx: &WorkerSpawnCtx<'_>,
     test: tryke_types::TestItem,
     result_tx: &mpsc::UnboundedSender<TestResult>,
 ) {
-    let Some(w) = ensure_worker(state, python_bin, path_refs, root, log_level).await else {
+    let Some(w) = ensure_worker(state, ctx).await else {
         let _ = result_tx.send(TestResult {
             test,
             outcome: TestOutcome::Error {
@@ -263,10 +301,7 @@ async fn run_single_test(
 /// unit, caching the call so any respawn later in the unit can replay it.
 async fn register_hooks_for_unit(
     state: &mut WorkerState,
-    python_bin: &str,
-    path_refs: &[&Path],
-    root: &Path,
-    log_level: LevelFilter,
+    ctx: &WorkerSpawnCtx<'_>,
     hooks: &[HookItem],
     tests: &[tryke_types::TestItem],
 ) {
@@ -304,7 +339,7 @@ async fn register_hooks_for_unit(
             .hook_cache
             .insert(test.module_path.clone(), params.clone());
 
-        let Some(w) = ensure_worker(state, python_bin, path_refs, root, log_level).await else {
+        let Some(w) = ensure_worker(state, ctx).await else {
             continue;
         };
         if let Err(e) = w.register_hooks(params).await {
@@ -316,18 +351,11 @@ async fn register_hooks_for_unit(
     }
 }
 
-async fn handle_ctrl(
-    state: &mut WorkerState,
-    python_bin: &str,
-    path_refs: &[&Path],
-    root: &Path,
-    log_level: LevelFilter,
-    ctrl: WorkerCtrl,
-) {
+async fn handle_ctrl(state: &mut WorkerState, ctx: &WorkerSpawnCtx<'_>, ctrl: WorkerCtrl) {
     match ctrl {
         WorkerCtrl::Ping(ack_tx) => {
             trace!("worker_task: ping (pre-warm)");
-            let _ = ensure_worker(state, python_bin, path_refs, root, log_level).await;
+            let _ = ensure_worker(state, ctx).await;
             let _ = ack_tx.send(());
         }
         WorkerCtrl::Restart(ack_tx) => {
@@ -338,7 +366,7 @@ async fn handle_ctrl(
             // Eagerly respawn so the next Unit doesn't pay Python startup
             // latency. ensure_worker replays cached register_hooks against
             // the fresh process, mirroring the crash-recovery path.
-            let _ = ensure_worker(state, python_bin, path_refs, root, log_level).await;
+            let _ = ensure_worker(state, ctx).await;
             let _ = ack_tx.send(());
         }
     }
@@ -346,24 +374,12 @@ async fn handle_ctrl(
 
 async fn handle_unit(
     state: &mut WorkerState,
-    python_bin: &str,
-    path_refs: &[&Path],
-    root: &Path,
-    log_level: LevelFilter,
+    ctx: &WorkerSpawnCtx<'_>,
     unit: WorkUnit,
     result_tx: mpsc::UnboundedSender<TestResult>,
 ) {
     if !unit.hooks.is_empty() {
-        register_hooks_for_unit(
-            state,
-            python_bin,
-            path_refs,
-            root,
-            log_level,
-            &unit.hooks,
-            &unit.tests,
-        )
-        .await;
+        register_hooks_for_unit(state, ctx, &unit.hooks, &unit.tests).await;
     }
     let finalize_modules: std::collections::HashSet<String> = if unit.hooks.is_empty() {
         std::collections::HashSet::new()
@@ -372,10 +388,7 @@ async fn handle_unit(
     };
     for test in unit.tests {
         trace!("worker_task: running test {}", test.name);
-        run_single_test(
-            state, python_bin, path_refs, root, log_level, test, &result_tx,
-        )
-        .await;
+        run_single_test(state, ctx, test, &result_tx).await;
     }
     for module in finalize_modules {
         if let Some(w) = state.process.as_mut()
@@ -385,20 +398,20 @@ async fn handle_unit(
         }
     }
 
-    // Recycle a worker that has run enough tests to be at risk of FD/state
-    // accumulation. Deferred to the end of the unit (after finalize_hooks)
-    // so per="scope" fixture teardown is not skipped: recycling mid-unit
+    // Recycle a worker that has tripped any of its soft resource caps.
+    // Deferred to the end of the unit (after finalize_hooks) so
+    // per="scope" fixture teardown is not skipped: recycling mid-unit
     // would drop the live process before its scope fixtures got their
     // teardown call. The next unit handed to this worker_task hits
     // ensure_worker, which spawns a fresh process and replays cached
     // hooks — same path as crash recovery.
-    if state
+    if let Some(reason) = state
         .process
         .as_ref()
-        .is_some_and(WorkerProcess::should_recycle)
+        .and_then(WorkerProcess::should_recycle)
         && let Some(mut proc) = state.process.take()
     {
-        debug!("worker_task: recycling worker after {MAX_TESTS_PER_WORKER} tests");
+        debug!("worker_task: recycling worker ({reason})");
         proc.shutdown().await;
     }
 }
@@ -408,10 +421,18 @@ async fn worker_task(
     python_path: Vec<std::path::PathBuf>,
     root: PathBuf,
     log_level: LevelFilter,
+    limits: WorkerLimits,
     work_rx: async_channel::Receiver<WorkerMsg>,
     mut ctrl_rx: mpsc::UnboundedReceiver<WorkerCtrl>,
 ) {
     let path_refs: Vec<&Path> = python_path.iter().map(PathBuf::as_path).collect();
+    let ctx = WorkerSpawnCtx {
+        python_bin: &python_bin,
+        path_refs: &path_refs,
+        root: &root,
+        log_level,
+        limits,
+    };
     let mut state = WorkerState::new();
 
     loop {
@@ -424,21 +445,12 @@ async fn worker_task(
             biased;
             ctrl = ctrl_rx.recv() => {
                 let Some(ctrl) = ctrl else { break };
-                handle_ctrl(&mut state, &python_bin, &path_refs, &root, log_level, ctrl).await;
+                handle_ctrl(&mut state, &ctx, ctrl).await;
             }
             msg = work_rx.recv() => {
                 match msg {
                     Ok(WorkerMsg::Unit(unit, result_tx)) => {
-                        handle_unit(
-                            &mut state,
-                            &python_bin,
-                            &path_refs,
-                            &root,
-                            log_level,
-                            unit,
-                            result_tx,
-                        )
-                        .await;
+                        handle_unit(&mut state, &ctx, unit, result_tx).await;
                     }
                     Ok(WorkerMsg::Shutdown) | Err(_) => break,
                 }
@@ -688,16 +700,23 @@ def test_noop() -> None:
         pool.shutdown();
     }
 
-    /// A worker process must be recycled after `MAX_TESTS_PER_WORKER` tests
-    /// so accumulated module-level state (and the FDs it owns) does not
-    /// grow unboundedly across long runs. The recycle is deferred until
-    /// the end of a unit (so per="scope" teardown is not skipped — see
-    /// `recycle_does_not_skip_scope_fixture_teardown`), so we exercise it
-    /// here by submitting many single-test units. The module body records
-    /// the worker pid on every fresh import; we expect one distinct pid
-    /// per recycle boundary.
+    /// A worker process must be recycled when its self-reported
+    /// resource snapshot crosses a configured ceiling so accumulated
+    /// module-level state (and the FDs it owns) does not grow
+    /// unboundedly across long runs. We use the wall-clock `max_age`
+    /// signal here because it is the easiest to drive deterministically
+    /// from a test (memory and FD growth would require platform-
+    /// specific allocations, and the priority logic is unit-tested
+    /// separately in `worker.rs`).
+    ///
+    /// The recycle is deferred until the end of a unit (so per="scope"
+    /// teardown is not skipped — see
+    /// `recycle_does_not_skip_scope_fixture_teardown`), so we exercise
+    /// it here by sleeping past the cap between units. The module body
+    /// records the worker pid on every fresh import; we expect one
+    /// distinct pid per recycle boundary.
     #[tokio::test]
-    async fn worker_recycles_after_max_tests() {
+    async fn worker_recycles_when_age_exceeds_limit() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("pyproject.toml"), "").expect("write pyproject.toml");
 
@@ -722,45 +741,57 @@ def test_noop() -> None:
         );
         std::fs::write(&test_file, source).expect("write test file");
 
-        let n_tests = usize::try_from(MAX_TESTS_PER_WORKER + 4).expect("test count fits in usize");
-        let max_per_worker =
-            usize::try_from(MAX_TESTS_PER_WORKER).expect("MAX_TESTS_PER_WORKER fits in usize");
-        // One unit per test so the recycle check at the end of each unit
-        // gets a chance to fire as soon as the threshold is crossed.
-        let units: Vec<WorkUnit> = (0..n_tests)
-            .map(|_| WorkUnit {
-                tests: vec![make_test_item("test_recycle", "test_noop", &test_file)],
-                hooks: vec![],
-            })
-            .collect();
-
-        let pool = WorkerPool::with_python_path(
+        // Tight age cap — a sleep between units crosses it deterministically
+        // without making the test slow.
+        let limits = WorkerLimits {
+            max_rss_bytes: None,
+            max_open_fds: None,
+            max_age: Some(std::time::Duration::from_millis(100)),
+        };
+        let pool = WorkerPool::with_python_path_and_limits(
             1,
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_package_dir()],
             LevelFilter::Off,
+            limits,
         );
         pool.warm().await;
 
-        let results: Vec<TestResult> = pool.run(units).collect().await;
-        assert_eq!(results.len(), n_tests, "expected {n_tests} results");
-        for r in &results {
-            assert!(
-                matches!(r.outcome, TestOutcome::Passed),
-                "test failed unexpectedly: {r:?}",
-            );
-        }
+        let make_unit = || WorkUnit {
+            tests: vec![make_test_item("test_recycle", "test_noop", &test_file)],
+            hooks: vec![],
+        };
+
+        // First unit: worker is fresh, no recycle.
+        let r1: Vec<TestResult> = pool.run(vec![make_unit()]).collect().await;
+        assert_eq!(r1.len(), 1);
+        assert!(matches!(r1[0].outcome, TestOutcome::Passed));
+
+        // Sleep past the age cap so the next unit's end-of-unit check
+        // fires. 250ms gives comfortable margin over the 100ms cap on
+        // jittery CI without pushing test latency higher than necessary.
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+        // Second unit: still on the same worker (recycle is checked at
+        // end-of-unit), but at *its* end the age check trips.
+        let r2: Vec<TestResult> = pool.run(vec![make_unit()]).collect().await;
+        assert_eq!(r2.len(), 1);
+        assert!(matches!(r2[0].outcome, TestOutcome::Passed));
+
+        // Third unit: forced to spawn a new worker (the previous one
+        // was recycled) so a second pid is logged.
+        let r3: Vec<TestResult> = pool.run(vec![make_unit()]).collect().await;
+        assert_eq!(r3.len(), 1);
+        assert!(matches!(r3[0].outcome, TestOutcome::Passed));
 
         let pid_lines = std::fs::read_to_string(&pid_log).unwrap_or_default();
         let distinct_pids: std::collections::HashSet<&str> =
             pid_lines.lines().filter(|l| !l.is_empty()).collect();
-        let expected_workers = n_tests.div_ceil(max_per_worker);
         assert_eq!(
             distinct_pids.len(),
-            expected_workers,
-            "expected {expected_workers} distinct worker pid(s) (one per recycle); \
-             got {} from log: {pid_lines:?}",
+            2,
+            "expected 2 distinct worker pid(s) (one recycle); got {} from log: {pid_lines:?}",
             distinct_pids.len(),
         );
 
@@ -768,14 +799,17 @@ def test_noop() -> None:
     }
 
     /// Recycling must never strand a `per="scope"` fixture without its
-    /// teardown. The risk is mid-unit recycling: if we drop the live
-    /// process before `finalize_hooks` runs, the unit's scope fixtures
-    /// die without their `yield`-after teardown, *and* a fresh worker
-    /// re-runs setup when hooks replay — so a buggy version would show
-    /// setup ran twice while teardown ran once (or zero times). We
-    /// submit enough tests in a single unit to cross the recycle
-    /// threshold and assert setup/teardown counts stay matched at one
-    /// each.
+    /// teardown. The unit body's tests must still see their fixture
+    /// values, and the scope fixture's `yield`-after teardown must run
+    /// exactly once before the worker is recycled. A buggy version
+    /// that recycled mid-unit (before `finalize_hooks`) would either
+    /// strand teardown entirely or — if the fresh worker re-ran setup
+    /// — record setup twice with teardown still at one or zero.
+    ///
+    /// The recycle is forced via a tiny `max_age` so a short sleep
+    /// inside the unit's first test crosses the cap; the end-of-unit
+    /// check then trips as soon as the unit completes (after
+    /// finalize). We assert setup and teardown both ran exactly once.
     #[tokio::test]
     async fn recycle_does_not_skip_scope_fixture_teardown() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -788,6 +822,7 @@ def test_noop() -> None:
         let test_file = dir.path().join("test_scope_recycle.py");
         let source = format!(
             r#"import os
+import time
 from tryke import test, fixture, expect, Depends
 
 @fixture(per="scope")
@@ -799,6 +834,14 @@ def scope_resource() -> int:
     with open("{teardown_escaped}", "a") as f:
         f.write(str(os.getpid()) + "\n")
         f.flush()
+
+@test
+def test_sleep_then_age_out(r: int = Depends(scope_resource)) -> None:
+    # Sleep past the runner's tiny max_age so the end-of-unit recycle
+    # check trips. Teardown must still have a chance to run before the
+    # worker is killed.
+    time.sleep(0.25)
+    expect(r).to_equal(42)
 
 @test
 def test_uses_scope(r: int = Depends(scope_resource)) -> None:
@@ -815,26 +858,35 @@ def test_uses_scope(r: int = Depends(scope_resource)) -> None:
             depends_on: vec![],
             line_number: None,
         };
-        let n_tests = usize::try_from(MAX_TESTS_PER_WORKER + 4).expect("test count fits in usize");
-        let tests: Vec<TestItem> = (0..n_tests)
-            .map(|_| make_test_item("test_scope_recycle", "test_uses_scope", &test_file))
-            .collect();
+        // Two tests in one unit: first sleeps past max_age, second
+        // proves teardown wasn't stranded mid-unit (it would have been
+        // had recycle fired before finalize_hooks).
+        let tests: Vec<TestItem> = vec![
+            make_test_item("test_scope_recycle", "test_sleep_then_age_out", &test_file),
+            make_test_item("test_scope_recycle", "test_uses_scope", &test_file),
+        ];
         let unit = WorkUnit {
             tests,
             hooks: vec![hook],
         };
 
-        let pool = WorkerPool::with_python_path(
+        let limits = WorkerLimits {
+            max_rss_bytes: None,
+            max_open_fds: None,
+            max_age: Some(std::time::Duration::from_millis(100)),
+        };
+        let pool = WorkerPool::with_python_path_and_limits(
             1,
             &test_python_bin(),
             dir.path(),
             &[dir.path().to_path_buf(), python_package_dir()],
             LevelFilter::Off,
+            limits,
         );
         pool.warm().await;
 
         let results: Vec<TestResult> = pool.run(vec![unit]).collect().await;
-        assert_eq!(results.len(), n_tests, "expected {n_tests} results");
+        assert_eq!(results.len(), 2, "expected 2 results, got {results:?}");
         for r in &results {
             assert!(
                 matches!(r.outcome, TestOutcome::Passed),

--- a/crates/tryke_runner/src/protocol.rs
+++ b/crates/tryke_runner/src/protocol.rs
@@ -121,6 +121,36 @@ pub struct RunDoctestParams {
     pub object_path: String,
 }
 
+/// Worker self-reported resource snapshot, attached by the python side
+/// to every `run_test` / `run_doctest` response. Each field is `Option`
+/// because the underlying syscalls are not portable across every
+/// platform we target (e.g. `/proc/self/fd` is linux-only; the
+/// `resource` module is unavailable on windows). A missing signal is
+/// not an error — it just means the runner cannot recycle on that
+/// dimension for this worker.
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+pub struct WorkerHealthWire {
+    /// Resident set size in bytes, normalised across platforms.
+    #[serde(default)]
+    pub rss_bytes: Option<u64>,
+    /// Open file descriptor count.
+    #[serde(default)]
+    pub open_fds: Option<u64>,
+}
+
+/// Wrapper around [`RunTestResultWire`] carrying the worker's health
+/// snapshot alongside the test outcome. The python side merges the
+/// outcome dict with a top-level `health` field; `#[serde(flatten)]`
+/// pulls the outcome variant out of the same JSON object so the wire
+/// format stays a single flat object.
+#[derive(Debug, Deserialize)]
+pub struct RunTestResponseWire {
+    #[serde(default)]
+    pub health: WorkerHealthWire,
+    #[serde(flatten)]
+    pub result: RunTestResultWire,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum RunTestResultWire {

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -1,7 +1,8 @@
 use std::collections::VecDeque;
+use std::fmt;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
 use log::{debug, trace};
@@ -11,7 +12,7 @@ use tryke_types::{Assertion, ExpectedAssertion, TestItem, TestOutcome, TestResul
 
 use crate::protocol::{
     AssertionWire, FinalizeHooksParams, RegisterHooksParams, RpcRequest, RpcResponse,
-    RunDoctestParams, RunTestParams, RunTestResultWire,
+    RunDoctestParams, RunTestParams, RunTestResponseWire, RunTestResultWire, WorkerHealthWire,
 };
 
 /// Cap on retained worker-stderr bytes. Beyond this we keep the most recent
@@ -19,15 +20,117 @@ use crate::protocol::{
 /// without unbounded memory growth on workers that spew warnings.
 const STDERR_RETAIN_BYTES: usize = 1 << 20; // 1 MiB
 
-/// Recycle a worker process after this many tests. Long-lived python
-/// interpreters accumulate module-level state across imports — logging
-/// handlers, sqlite/ssl objects, atexit callbacks — much of which holds
-/// open file descriptors that `del sys.modules[name]` cannot reclaim
-/// because the FDs are owned by objects living outside the module dict.
-/// Recycling bounds growth: the only mechanism in `CPython` that reliably
-/// frees module-level FDs is process exit. The cap is intentionally
-/// hardcoded for now; revisit if it proves wrong on real workloads.
-pub(crate) const MAX_TESTS_PER_WORKER: u64 = 128;
+/// Latest worker-reported resource snapshot. Each field is `Option`
+/// because some signals are platform-conditional (see
+/// [`WorkerHealthWire`]); a missing reading just means the matching
+/// limit cannot fire for this worker.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WorkerHealth {
+    pub rss_bytes: Option<u64>,
+    pub open_fds: Option<u64>,
+}
+
+impl From<WorkerHealthWire> for WorkerHealth {
+    fn from(w: WorkerHealthWire) -> Self {
+        Self {
+            rss_bytes: w.rss_bytes,
+            open_fds: w.open_fds,
+        }
+    }
+}
+
+/// Why a worker is being recycled. Carried in debug logs so post-mortem
+/// triage can tell apart memory leaks, FD pressure, and slow drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecycleReason {
+    /// Resident set size crossed the configured ceiling.
+    MemoryBytes(u64),
+    /// Open file descriptor count crossed the configured ceiling.
+    OpenFds(u64),
+    /// Worker has been alive longer than the configured ceiling.
+    Age(Duration),
+}
+
+impl fmt::Display for RecycleReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MemoryBytes(b) => write!(f, "memory={b} bytes"),
+            Self::OpenFds(n) => write!(f, "open_fds={n}"),
+            Self::Age(d) => write!(f, "age={:.1}s", d.as_secs_f64()),
+        }
+    }
+}
+
+/// Soft ceilings on a worker's resource footprint. Each is `Option` so
+/// callers can opt out of a signal entirely (e.g. tests that exercise
+/// only one dimension). `None` on a field means "never recycle on this
+/// signal." The defaults are tuned for real test suites — see
+/// [`WorkerLimits::default`].
+#[derive(Debug, Clone, Copy)]
+pub struct WorkerLimits {
+    pub max_rss_bytes: Option<u64>,
+    pub max_open_fds: Option<u64>,
+    pub max_age: Option<Duration>,
+}
+
+impl WorkerLimits {
+    /// Disable every soft limit. Convenient for tests that only want to
+    /// exercise one signal at a time.
+    #[must_use]
+    pub fn unlimited() -> Self {
+        Self {
+            max_rss_bytes: None,
+            max_open_fds: None,
+            max_age: None,
+        }
+    }
+}
+
+impl Default for WorkerLimits {
+    fn default() -> Self {
+        Self {
+            // 1 GiB RSS — comfortable headroom for suites that pull in
+            // heavy native deps (numpy, ssl, sqlite) on first import,
+            // while still bounding slow leaks across long runs.
+            max_rss_bytes: Some(1 << 30),
+            // Below the macOS 256-FD per-process soft limit, leaving
+            // headroom for the python interpreter's own baseline (~30
+            // FDs on a fresh process) plus the runner's stdio pipes.
+            max_open_fds: Some(200),
+            // 10 minutes of wall time. Long suites still finish per
+            // worker without churning; pathologically slow leaks that
+            // never trip the memory/FD cap still get bounded.
+            max_age: Some(Duration::from_secs(600)),
+        }
+    }
+}
+
+/// Pure recycle-decision helper, factored out of [`WorkerProcess`] so
+/// it is unit-testable without spawning a subprocess. Signals are
+/// checked in priority order: memory > FDs > age, so the strongest
+/// available reason is what gets reported.
+pub(crate) fn evaluate_recycle(
+    health: WorkerHealth,
+    age: Duration,
+    limits: WorkerLimits,
+) -> Option<RecycleReason> {
+    if let (Some(cap), Some(rss)) = (limits.max_rss_bytes, health.rss_bytes)
+        && rss >= cap
+    {
+        return Some(RecycleReason::MemoryBytes(rss));
+    }
+    if let (Some(cap), Some(fds)) = (limits.max_open_fds, health.open_fds)
+        && fds >= cap
+    {
+        return Some(RecycleReason::OpenFds(fds));
+    }
+    if let Some(cap) = limits.max_age
+        && age >= cap
+    {
+        return Some(RecycleReason::Age(age));
+    }
+    None
+}
 
 pub struct WorkerProcess {
     child: Child,
@@ -38,7 +141,19 @@ pub struct WorkerProcess {
     /// the worker can't block on a stderr write mid-RPC.
     stderr_buf: Arc<Mutex<VecDeque<u8>>>,
     next_id: u64,
-    tests_completed: u64,
+    /// Wall-clock spawn time; drives `RecycleReason::Age`. Set once at
+    /// spawn and read on every `should_recycle` check — never mutated.
+    spawned_at: Instant,
+    /// Latest worker-reported resource snapshot. Updated after every
+    /// completed `run_test` / `run_doctest` reply. The default
+    /// (`Option::None` on every field) is what a fresh worker reads as
+    /// before its first reply lands, which matches "no signal, do not
+    /// recycle on it."
+    latest_health: WorkerHealth,
+    /// Soft ceilings consulted by [`Self::should_recycle`]. Owned by
+    /// the worker (rather than passed in on each check) so the recycle
+    /// decision is colocated with the data it depends on.
+    limits: WorkerLimits,
 }
 
 impl WorkerProcess {
@@ -55,6 +170,7 @@ impl WorkerProcess {
         python_path: &[&Path],
         root: &Path,
         log_level: log::LevelFilter,
+        limits: WorkerLimits,
     ) -> Result<Self> {
         debug!("spawning worker: {python_bin} -m tryke.worker (log={log_level})");
         let pythonpath = build_pythonpath(python_path);
@@ -99,15 +215,25 @@ impl WorkerProcess {
             stdout,
             stderr_buf,
             next_id: 1,
-            tests_completed: 0,
+            spawned_at: Instant::now(),
+            latest_health: WorkerHealth::default(),
+            limits,
         })
     }
 
-    /// Whether this worker has run enough tests to warrant recycling.
-    /// See `MAX_TESTS_PER_WORKER` for the rationale.
+    /// Whether this worker has tripped any of its [`WorkerLimits`].
+    /// Returns the first reason found (memory > FDs > age priority),
+    /// or `None` if the worker is still within budget. Long-lived
+    /// python interpreters accumulate module-level state across
+    /// imports — logging handlers, sqlite/ssl objects, atexit
+    /// callbacks — much of which holds resources (FDs, memory) that
+    /// `del sys.modules[name]` cannot reclaim, because they are owned
+    /// by objects living outside the module dict. Recycling on the
+    /// reported snapshot bounds that growth; only process exit
+    /// reliably frees module-level state in `CPython`.
     #[must_use]
-    pub fn should_recycle(&self) -> bool {
-        self.tests_completed >= MAX_TESTS_PER_WORKER
+    pub fn should_recycle(&self) -> Option<RecycleReason> {
+        evaluate_recycle(self.latest_health, self.spawned_at.elapsed(), self.limits)
     }
 
     async fn call<R: for<'de> serde::Deserialize<'de>>(
@@ -195,9 +321,9 @@ impl WorkerProcess {
             groups: test.groups.clone(),
             case_label: test.case_label.clone(),
         })?;
-        let wire: RunTestResultWire = self.call("run_test", Some(params)).await?;
-        self.tests_completed = self.tests_completed.saturating_add(1);
-        Ok(convert_result(test.clone(), wire))
+        let response: RunTestResponseWire = self.call("run_test", Some(params)).await?;
+        self.latest_health = response.health.into();
+        Ok(convert_result(test.clone(), response.result))
     }
 
     /// Send hook metadata for a module to the Python worker.
@@ -226,9 +352,9 @@ impl WorkerProcess {
             module: test.module_path.clone(),
             object_path: object_path.to_owned(),
         })?;
-        let wire: RunTestResultWire = self.call("run_doctest", Some(params)).await?;
-        self.tests_completed = self.tests_completed.saturating_add(1);
-        Ok(convert_result(test.clone(), wire))
+        let response: RunTestResponseWire = self.call("run_doctest", Some(params)).await?;
+        self.latest_health = response.health.into();
+        Ok(convert_result(test.clone(), response.result))
     }
 
     #[expect(clippy::missing_errors_doc)]
@@ -552,6 +678,112 @@ mod tests {
             expected_assertions: vec![],
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn evaluate_recycle_returns_none_when_no_signals_tripped() {
+        // A fresh worker (default health, zero age) under default
+        // limits has nothing to report — the runner must not recycle.
+        assert_eq!(
+            evaluate_recycle(
+                WorkerHealth::default(),
+                Duration::ZERO,
+                WorkerLimits::default(),
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn evaluate_recycle_prioritises_memory_then_fds_then_age() {
+        // All three signals tripped at once: memory wins. This
+        // priority matters because memory pressure is the most
+        // user-visible failure mode (process death, swap thrash); the
+        // post-mortem log line should attribute that, not whichever
+        // signal happened to be checked last.
+        let limits = WorkerLimits {
+            max_rss_bytes: Some(1000),
+            max_open_fds: Some(10),
+            max_age: Some(Duration::from_secs(1)),
+        };
+        let health = WorkerHealth {
+            rss_bytes: Some(2000),
+            open_fds: Some(20),
+        };
+        assert_eq!(
+            evaluate_recycle(health, Duration::from_secs(2), limits),
+            Some(RecycleReason::MemoryBytes(2000)),
+        );
+
+        // Drop the memory signal: FDs win over age.
+        let health_no_mem = WorkerHealth {
+            rss_bytes: None,
+            open_fds: Some(20),
+        };
+        assert_eq!(
+            evaluate_recycle(health_no_mem, Duration::from_secs(2), limits),
+            Some(RecycleReason::OpenFds(20)),
+        );
+
+        // Drop FDs too: age is the last fallback.
+        let health_age_only = WorkerHealth {
+            rss_bytes: None,
+            open_fds: None,
+        };
+        assert_eq!(
+            evaluate_recycle(health_age_only, Duration::from_secs(2), limits),
+            Some(RecycleReason::Age(Duration::from_secs(2))),
+        );
+    }
+
+    #[test]
+    fn evaluate_recycle_skips_signals_with_no_limit() {
+        // `WorkerLimits::unlimited` opts out of every cap — even an
+        // OOM-scale RSS reading must not trigger a recycle. This is
+        // the contract tests rely on when exercising one signal in
+        // isolation.
+        let unlimited = WorkerLimits::unlimited();
+        let health = WorkerHealth {
+            rss_bytes: Some(u64::MAX),
+            open_fds: Some(u64::MAX),
+        };
+        assert_eq!(
+            evaluate_recycle(health, Duration::from_secs(86_400), unlimited),
+            None,
+        );
+    }
+
+    #[test]
+    fn evaluate_recycle_skips_signals_with_no_reading() {
+        // Worker on a platform without `/proc/self/fd` reports
+        // `open_fds: None` — the runner must not synthesize a value
+        // and must not recycle on that signal even with a tight cap.
+        let limits = WorkerLimits {
+            max_rss_bytes: Some(1000),
+            max_open_fds: Some(10),
+            max_age: None,
+        };
+        let health = WorkerHealth {
+            rss_bytes: None,
+            open_fds: None,
+        };
+        assert_eq!(evaluate_recycle(health, Duration::ZERO, limits), None);
+    }
+
+    #[test]
+    fn recycle_reason_display_is_human_readable() {
+        // The Display impl lands in debug logs ("recycling worker
+        // (memory=...)") so it needs to be terse and parseable at a
+        // glance — not just Debug-derived noise.
+        assert_eq!(
+            RecycleReason::MemoryBytes(1024).to_string(),
+            "memory=1024 bytes",
+        );
+        assert_eq!(RecycleReason::OpenFds(42).to_string(), "open_fds=42");
+        assert_eq!(
+            RecycleReason::Age(Duration::from_millis(2_500)).to_string(),
+            "age=2.5s",
+        );
     }
 
     #[test]

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -120,6 +120,7 @@ class _PassedResult(TypedDict):
     duration_ms: int
     stdout: str
     stderr: str
+    health: NotRequired[_HealthSnapshot]
 
 
 class _FailedResult(TypedDict):
@@ -131,6 +132,7 @@ class _FailedResult(TypedDict):
     executed_lines: list[int]
     stdout: str
     stderr: str
+    health: NotRequired[_HealthSnapshot]
 
 
 class _SkippedResult(TypedDict):
@@ -139,6 +141,7 @@ class _SkippedResult(TypedDict):
     reason: str | None
     stdout: str
     stderr: str
+    health: NotRequired[_HealthSnapshot]
 
 
 class _XFailedResult(TypedDict):
@@ -147,6 +150,7 @@ class _XFailedResult(TypedDict):
     reason: str | None
     stdout: str
     stderr: str
+    health: NotRequired[_HealthSnapshot]
 
 
 class _XPassedResult(TypedDict):
@@ -154,6 +158,7 @@ class _XPassedResult(TypedDict):
     duration_ms: int
     stdout: str
     stderr: str
+    health: NotRequired[_HealthSnapshot]
 
 
 class _TodoResult(TypedDict):
@@ -162,6 +167,7 @@ class _TodoResult(TypedDict):
     description: str | None
     stdout: str
     stderr: str
+    health: NotRequired[_HealthSnapshot]
 
 
 type _TestResult = (
@@ -172,6 +178,21 @@ type _TestResult = (
     | _XPassedResult
     | _TodoResult
 )
+
+
+class _HealthSnapshot(TypedDict):
+    """Worker self-reported resource snapshot.
+
+    Mirrors ``WorkerHealthWire`` in
+    ``crates/tryke_runner/src/protocol.rs``. Both fields are ``None``
+    when the underlying syscall is unavailable on this platform — the
+    runner treats a missing signal as "do not recycle on this
+    dimension," not as an error.
+    """
+
+    rss_bytes: int | None
+    open_fds: int | None
+
 
 type _DispatchResult = _TestResult | str | None
 
@@ -270,6 +291,50 @@ def _todo(
         "description": description,
         "stdout": stdout,
         "stderr": stderr,
+    }
+
+
+def _measure_rss_bytes() -> int | None:
+    """Resident set size in bytes, or ``None`` where unavailable.
+
+    Uses :mod:`resource` (POSIX-only). Linux reports ``ru_maxrss`` in
+    KiB, macOS in bytes — normalise to bytes for the wire. Windows has
+    no :mod:`resource`; return ``None`` so the runner skips the memory
+    cap there rather than guessing wrong.
+    """
+    try:
+        import resource  # noqa: PLC0415  - lazy: optional POSIX-only import
+    except ImportError:
+        return None
+    try:
+        ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    except OSError:
+        return None
+    if sys.platform == "darwin":
+        return int(ru_maxrss)
+    return int(ru_maxrss) * 1024
+
+
+def _measure_open_fds() -> int | None:
+    """Open file descriptor count, or ``None`` where unavailable.
+
+    Linux exposes ``/proc/self/fd``; macOS ships ``/dev/fd``. Windows
+    has neither and returns ``None`` — the runner then skips the FD
+    cap on this worker.
+    """
+    for path in ("/proc/self/fd", "/dev/fd"):
+        try:
+            return sum(1 for _ in Path(path).iterdir())
+        except OSError:
+            continue
+    return None
+
+
+def _measure_health() -> _HealthSnapshot:
+    """Snapshot the worker's current resource footprint for the runner."""
+    return {
+        "rss_bytes": _measure_rss_bytes(),
+        "open_fds": _measure_open_fds(),
     }
 
 
@@ -390,6 +455,13 @@ class Worker:
 
             try:
                 result = self._dispatch(method, params)
+                # Attach the worker's resource snapshot to every test
+                # response so the runner can recycle on memory / FD
+                # pressure (see ``WorkerHealthWire`` on the rust side).
+                # Only test-shaped results (dict, not "pong"/None) carry
+                # health; ping/register_hooks/finalize_hooks don't.
+                if isinstance(result, dict):
+                    result["health"] = _measure_health()
                 self._write(
                     {
                         "jsonrpc": "2.0",


### PR DESCRIPTION
Replace the fixed `MAX_TESTS_PER_WORKER` constant with a flexible, resource-aware worker recycling system that monitors memory usage, open file descriptors, and wall-clock age.

## Summary

Worker processes are now recycled based on soft resource ceilings rather than a hard test count. This allows the runner to respond to actual resource pressure (memory leaks, FD accumulation) while remaining deterministic and testable.

## Key Changes

- **New resource monitoring types** (`WorkerHealth`, `WorkerLimits`, `RecycleReason`):
  - `WorkerHealth`: Captures worker self-reported RSS bytes and open FD count
  - `WorkerLimits`: Configurable soft ceilings (default: 1 GiB RSS, 200 FDs, 10 min age)
  - `RecycleReason`: Enum indicating which limit triggered recycling, with human-readable `Display` impl for debug logs

- **Pure recycle-decision logic** (`evaluate_recycle` function):
  - Factored out of `WorkerProcess` for unit testability
  - Checks signals in priority order (memory > FDs > age) to report the strongest reason
  - Respects `None` limits (opt-out) and missing readings (platform unavailability)

- **Worker-side health reporting** (Python):
  - New `_measure_rss_bytes()` and `_measure_open_fds()` functions using `resource` module and `/proc`/`/dev` filesystem
  - `_measure_health()` snapshot attached to every `run_test`/`run_doctest` response
  - Platform-aware: returns `None` for unavailable signals rather than guessing

- **Protocol updates**:
  - New `WorkerHealthWire` struct for wire format
  - New `RunTestResponseWire` wrapper combining health snapshot with test result
  - Python side merges outcome dict with top-level `health` field

- **Pool API expansion**:
  - New `WorkerPool::with_python_path_and_limits()` for tests to set custom limits
  - `WorkerSpawnCtx` struct bundles spawn-time parameters to reduce signature bloat
  - Recycling now deferred to end-of-unit (after finalize hooks) to preserve scope fixture teardown

- **Test updates**:
  - `worker_recycles_after_max_tests` → `worker_recycles_when_age_exceeds_limit`: Uses tiny `max_age` cap and sleep to drive deterministic recycling
  - `recycle_does_not_skip_scope_fixture_teardown`: Simplified to use age-based recycling within a single unit

## Notable Implementation Details

- Recycling is checked at end-of-unit (not mid-test) to ensure `per="scope"` fixture teardown runs before process death
- Health snapshot is updated after every test response, enabling responsive recycling
- Default limits are tuned for real workloads: 1 GiB RSS (headroom for heavy native deps), 200 FDs (below macOS soft limit), 10 min age (bounds slow leaks)
- `WorkerLimits::unlimited()` helper disables all caps for tests exercising one signal in isolation
- Recycling reason is logged for post-mortem triage of memory leaks vs FD pressure vs age drift

https://claude.ai/code/session_01PMbxzSuASTEYbDFEu4SQqy