### PR TITLE
Skip teardown drain when event loop is closed

### DIFF
--- a/python/tryke/hooks.py
+++ b/python/tryke/hooks.py
@@ -371,6 +371,17 @@ class DependencyResolver:
     def _teardown_async_generators(self, gens: list[_AsyncGenEntry]) -> None:
         while gens:
             entry = gens.pop()
+            # If the loop was closed (e.g. the worker finalized the shared loop
+            # mid-teardown across a recycle / shutdown race), there's no way to
+            # drive __anext__ / aclose. Skip the drain and just clean up state
+            # — the generator's after-yield code won't run, but raising
+            # "Event loop is closed" here just turns an unrelated test into a
+            # spurious failure.
+            if entry.loop.is_closed():
+                self._cache.pop(entry.fn, None)
+                if entry.is_scope:
+                    self._scope_fixtures.discard(entry.fn)
+                continue
             try:
                 try:
                     entry.loop.run_until_complete(entry.agen.__anext__())


### PR DESCRIPTION
## Problem

`_teardown_async_generators` unconditionally called
`entry.loop.run_until_complete(entry.agen.__anext__())`. If the worker's
shared loop was closed mid-teardown — most often across a recycle /
shutdown race — this raised `RuntimeError: Event loop is closed`, surfacing
as a spurious failure on whichever test happened to be in the worker at
the time.

Reproduced on a 23,000-test HA migration suite: 8–19 transient failures
per full-suite run, different tests each time, never reproducing in
isolation.

## Fix

Skip the drain step when the loop is already closed; still run the
state-cleanup that follows (cache pop, scope-fixture discard). The
generator's after-yield code can't execute on a closed loop anyway —
raising here just turns an unrelated test into a spurious failure.

## Verification

After this fix + a downstream HA-side filter on captured loop-closed
exceptions: flake count drops from 8–19 → 3–5 per run (remaining
failures are unrelated state-leak categories — separate bugs).

Three full-suite runs after the combined fix:

```
Run 1: 11147 passed, 4 failed, 12424 skipped, 3 xfailed
Run 2: 11148 passed, 3 failed, 12424 skipped, 3 xfailed
Run 3: 11146 passed, 5 failed, 12424 skipped, 3 xfailed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)