### PR TITLE
Harden worker spawn and hook replay error handling

### DIFF
--- a/crates/tryke_runner/src/pool.rs
+++ b/crates/tryke_runner/src/pool.rs
@@ -286,14 +286,10 @@ async fn run_single_test(
             // spawn a fresh one and replay cached hooks so the remaining
             // tests in this unit keep their fixtures.
             state.process = None;
-            let mut msg = format!("worker error: {err}");
-            if !stderr_output.is_empty() {
-                msg.push_str("\nworker stderr:\n");
-                msg.push_str(&stderr_output);
-            }
+            let message = format_worker_failure("worker error", &err, &stderr_output);
             let _ = result_tx.send(TestResult {
                 test,
-                outcome: TestOutcome::Error { message: msg },
+                outcome: TestOutcome::Error { message },
                 duration: Duration::ZERO,
                 stdout: String::new(),
                 stderr: stderr_output,
@@ -705,6 +701,16 @@ def test_noop() -> None:
     /// to be all the user saw. Regression test for the diagnosability
     /// fix.
     ///
+    /// The unit carries a `HookItem` on purpose: with `hooks: vec![]`,
+    /// `handle_unit` skips `register_hooks_for_unit` entirely and the
+    /// failure would surface via `run_single_test`'s `run_test` error
+    /// path — which already existed before this PR. To exercise the
+    /// new code (`register_hooks_for_unit` stashing `last_failure`
+    /// after `drain_stderr`, then `ensure_worker`'s replay loop
+    /// stashing again on respawn, then `run_single_test` reading
+    /// `last_failure` instead of the opaque placeholder) the test
+    /// needs a hook so `register_hooks_for_unit` actually runs.
+    ///
     /// Unix-only: simulates the failing python with a shell script.
     /// The workspace venv's python has `tryke` installed in editable
     /// mode and its `.pth` file is searched regardless of PYTHONPATH,
@@ -735,9 +741,25 @@ def test_noop() -> None:
         let test_file = dir.path().join("test_no_tryke.py");
         std::fs::write(&test_file, "def test_noop(): pass\n").expect("write test file");
 
+        // Hook on the same module forces `handle_unit` through
+        // `register_hooks_for_unit` → `ensure_worker` (spawn ok) →
+        // `register_hooks` (RPC error) → `drain_stderr` → stash
+        // `last_failure` → drop process. Then `run_single_test` →
+        // `ensure_worker` → respawn ok → replay `register_hooks`
+        // (RPC error) → stash `last_failure` → return None →
+        // `run_single_test` surfaces `last_failure` as the outcome
+        // message. Without this hook the new path isn't exercised.
+        let hook = HookItem {
+            name: "noop".into(),
+            module_path: "test_no_tryke".into(),
+            per: FixturePer::Test,
+            groups: vec![],
+            depends_on: vec![],
+            line_number: None,
+        };
         let unit = WorkUnit {
             tests: vec![make_test_item("test_no_tryke", "test_noop", &test_file)],
-            hooks: vec![],
+            hooks: vec![hook],
         };
 
         let pool = WorkerPool::with_python_path(
@@ -754,6 +776,14 @@ def test_noop() -> None:
             TestOutcome::Error { message } => message.clone(),
             other => panic!("expected Error outcome, got {other:?}"),
         };
+        // `run_single_test`'s `last_failure` path produces this prefix
+        // — proves we went through `ensure_worker`'s replay loop, not
+        // through `run_test`'s direct error path which would say
+        // "worker error: …".
+        assert!(
+            message.starts_with("hook replay failed for module test_no_tryke"),
+            "expected hook-replay prefix from ensure_worker.last_failure, got: {message}"
+        );
         assert!(
             message.contains("No module named 'tryke'"),
             "missing python traceback in error message: {message}"

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -265,6 +265,14 @@ impl WorkerProcess {
 
     pub async fn shutdown(&mut self) {
         let _ = self.child.kill().await;
+        // Killing the child closes stderr; the drainer will see EOF and
+        // exit on its own — but `abort()` is the explicit, immediate
+        // signal that we're done with it, and prevents a leftover task
+        // from briefly holding the stderr FD + `stderr_buf` Arc past
+        // the worker's lifetime.
+        if let Some(handle) = self.stderr_drainer.take() {
+            handle.abort();
+        }
     }
 }
 
@@ -274,6 +282,12 @@ impl Drop for WorkerProcess {
         // dropped (e.g. on the error-respawn path in pool.rs). start_kill() is
         // the synchronous variant — safe to call on already-dead processes.
         let _ = self.child.start_kill();
+        // Dropping a Tokio JoinHandle detaches the task, so abort it
+        // explicitly to avoid an orphan drainer outliving the worker on
+        // respawn paths (the drainer holds stderr_buf + the stderr FD).
+        if let Some(handle) = self.stderr_drainer.take() {
+            handle.abort();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Addresses the four unresolved Copilot review comments on #107.

- **Test exercises the wrong path** ([#107 (comment)](https://github.com/thejchap/tryke/pull/107#discussion_r3218899264)) — added a `HookItem` to the regression test so `handle_unit` actually runs `register_hooks_for_unit`. The hook makes the failure flow through the new code: `register_hooks_for_unit` drains stderr and stashes `last_failure`, drops the worker; `run_single_test` then calls `ensure_worker`, the replay loop fires and re-stashes `last_failure`, and `run_single_test` surfaces it as the outcome message. Asserts now pin the message prefix to `"hook replay failed for module test_no_tryke"` so a regression that fell back to the pre-existing `run_test` error path would fail loudly.
- **Test flakiness** ([#107 (comment)](https://github.com/thejchap/tryke/pull/107#discussion_r3218899299)) — already addressed by the second PR commit: `drain_stderr` now `start_kill`s the child to force EOF on the drainer, then awaits the drainer with a 500 ms timeout before snapshotting the buffer. No `sleep` needed in `fake_python.sh`.
- **`format_worker_failure` reuse** ([#107 (comment)](https://github.com/thejchap/tryke/pull/107#discussion_r3218899319)) — `run_single_test`'s `run_test` error path now uses the same helper, so the four worker-failure call sites share one formatter.
- **Drainer JoinHandle leak** ([#107 (comment)](https://github.com/thejchap/tryke/pull/107#discussion_r3234498142)) — `WorkerProcess::Drop` and `shutdown` both `take()` the drainer handle and call `abort()`, so the drainer can't outlive its worker on respawn paths.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features` — 621/621 pass
- [x] `uvx prek run -a`


---
_Generated by [Claude Code](https://claude.ai/code/session_013Krdi6sm8KKDsGRpaeCdtY)_