### PR TITLE
Format durations over a minute as M:SS.SS in reporter summaries

### DIFF
--- a/crates/tryke_reporter/src/duration.rs
+++ b/crates/tryke_reporter/src/duration.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+/// Format a duration for human-facing reporter output.
+///
+/// Sub-second durations render as milliseconds (`48.00ms`),
+/// sub-minute as seconds (`1.50s`), and anything longer as
+/// `m:ss.cc` (`1:05.50`). Centiseconds are rounded — not
+/// truncated — so 119.999s carries up to `2:00.00`.
+#[must_use]
+pub fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.2}ms", secs * 1000.0)
+    } else if secs < 60.0 {
+        format!("{secs:.2}s")
+    } else {
+        // Integer math avoids the float-cast precision lint. The `+ 5`
+        // rounds to the nearest centisecond so output matches the
+        // sub-minute branches (which round via `:.2`); collapsing
+        // everything into centiseconds first lets carry through
+        // seconds/minutes happen naturally on decomposition.
+        let centis = (d.as_millis() + 5) / 10;
+        let minutes = centis / 6000;
+        let secs = (centis / 100) % 60;
+        let cs = centis % 100;
+        format!("{minutes}:{secs:02}.{cs:02}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sub_millisecond() {
+        assert_eq!(format_duration(Duration::from_micros(170)), "0.17ms");
+    }
+
+    #[test]
+    fn milliseconds() {
+        assert_eq!(format_duration(Duration::from_millis(48)), "48.00ms");
+    }
+
+    #[test]
+    fn seconds() {
+        assert_eq!(format_duration(Duration::from_millis(1_500)), "1.50s");
+    }
+
+    #[test]
+    fn minutes_seconds() {
+        assert_eq!(format_duration(Duration::from_millis(65_500)), "1:05.50");
+    }
+
+    #[test]
+    fn exactly_one_minute() {
+        assert_eq!(format_duration(Duration::from_secs(60)), "1:00.00");
+    }
+
+    #[test]
+    fn rounds_with_carry_through_minutes() {
+        assert_eq!(format_duration(Duration::from_millis(119_999)), "2:00.00");
+    }
+}

--- a/crates/tryke_reporter/src/lib.rs
+++ b/crates/tryke_reporter/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod clear;
 pub mod diagnostic;
 pub mod dot;
+pub mod duration;
 pub mod json;
 pub mod junit;
 pub mod live;

--- a/crates/tryke_reporter/src/llm.rs
+++ b/crates/tryke_reporter/src/llm.rs
@@ -41,14 +41,16 @@ fn format_duration(d: std::time::Duration) -> String {
     } else if secs < 60.0 {
         format!("{secs:.2}s")
     } else {
-        // Integer math avoids the float-cast precision lint and the
-        // formatted output only needs two-decimal precision anyway.
-        let total_ms = d.as_millis();
-        let total_secs = total_ms / 1000;
-        let minutes = total_secs / 60;
-        let rem_secs = total_secs % 60;
-        let rem_cs = (total_ms % 1000) / 10;
-        format!("{minutes}:{rem_secs:02}.{rem_cs:02}")
+        // Integer math avoids the float-cast precision lint. The `+ 5`
+        // rounds to the nearest centisecond so output matches the
+        // sub-minute branches (which round via `:.2`); collapsing
+        // everything into centiseconds first lets carry through
+        // seconds/minutes happen naturally on decomposition.
+        let centis = (d.as_millis() + 5) / 10;
+        let minutes = centis / 6000;
+        let secs = (centis / 100) % 60;
+        let cs = centis % 100;
+        format!("{minutes}:{secs:02}.{cs:02}")
     }
 }
 

--- a/crates/tryke_reporter/src/llm.rs
+++ b/crates/tryke_reporter/src/llm.rs
@@ -35,11 +35,20 @@ impl<W: io::Write> LlmReporter<W> {
 }
 
 fn format_duration(d: std::time::Duration) -> String {
-    let ms = d.as_secs_f64() * 1000.0;
-    if ms < 1000.0 {
-        format!("{ms:.2}ms")
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.2}ms", secs * 1000.0)
+    } else if secs < 60.0 {
+        format!("{secs:.2}s")
     } else {
-        format!("{:.2}s", d.as_secs_f64())
+        // Integer math avoids the float-cast precision lint and the
+        // formatted output only needs two-decimal precision anyway.
+        let total_ms = d.as_millis();
+        let total_secs = total_ms / 1000;
+        let minutes = total_secs / 60;
+        let rem_secs = total_secs % 60;
+        let rem_cs = (total_ms % 1000) / 10;
+        format!("{minutes}:{rem_secs:02}.{rem_cs:02}")
     }
 }
 
@@ -371,6 +380,27 @@ mod tests {
         });
         let out = output(&r);
         assert_eq!(out.trim(), "47 passed [35.00ms]");
+    }
+
+    #[test]
+    fn summary_duration_minutes_seconds() {
+        let mut r = reporter();
+        r.on_run_complete(&RunSummary {
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            errors: 0,
+            xfailed: 0,
+            todo: 0,
+            duration: Duration::from_millis(65_500),
+            discovery_duration: None,
+            test_duration: None,
+            file_count: 0,
+            start_time: None,
+            changed_selection: None,
+        });
+        let out = output(&r);
+        assert_eq!(out.trim(), "1 passed [1:05.50]");
     }
 
     #[test]

--- a/crates/tryke_reporter/src/llm.rs
+++ b/crates/tryke_reporter/src/llm.rs
@@ -4,6 +4,7 @@ use tryke_types::{DiscoveryError, RunSummary, TestItem, TestOutcome, TestResult}
 
 use crate::Reporter;
 use crate::diagnostic::render_assertions_plain;
+use crate::duration::format_duration;
 
 pub struct LlmReporter<W: io::Write = io::Stdout> {
     writer: W,
@@ -31,26 +32,6 @@ impl<W: io::Write> LlmReporter<W> {
 
     pub fn into_writer(self) -> W {
         self.writer
-    }
-}
-
-fn format_duration(d: std::time::Duration) -> String {
-    let secs = d.as_secs_f64();
-    if secs < 1.0 {
-        format!("{:.2}ms", secs * 1000.0)
-    } else if secs < 60.0 {
-        format!("{secs:.2}s")
-    } else {
-        // Integer math avoids the float-cast precision lint. The `+ 5`
-        // rounds to the nearest centisecond so output matches the
-        // sub-minute branches (which round via `:.2`); collapsing
-        // everything into centiseconds first lets carry through
-        // seconds/minutes happen naturally on decomposition.
-        let centis = (d.as_millis() + 5) / 10;
-        let minutes = centis / 6000;
-        let secs = (centis / 100) % 60;
-        let cs = centis % 100;
-        format!("{minutes}:{secs:02}.{cs:02}")
     }
 }
 

--- a/crates/tryke_reporter/src/summary.rs
+++ b/crates/tryke_reporter/src/summary.rs
@@ -25,11 +25,20 @@ fn write_watch_keybindings<W: io::Write>(writer: &mut W) {
 }
 
 fn format_duration(d: Duration) -> String {
-    let ms = d.as_secs_f64() * 1000.0;
-    if ms < 1000.0 {
-        format!("{ms:.2}ms")
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.2}ms", secs * 1000.0)
+    } else if secs < 60.0 {
+        format!("{secs:.2}s")
     } else {
-        format!("{:.2}s", d.as_secs_f64())
+        // Integer math avoids the float-cast precision lint and the
+        // formatted output only needs two-decimal precision anyway.
+        let total_ms = d.as_millis();
+        let total_secs = total_ms / 1000;
+        let minutes = total_secs / 60;
+        let rem_secs = total_secs % 60;
+        let rem_cs = (total_ms % 1000) / 10;
+        format!("{minutes}:{rem_secs:02}.{rem_cs:02}")
     }
 }
 
@@ -436,6 +445,66 @@ mod tests {
             changed_selection: None,
         });
         assert!(out.contains("1.50s"));
+    }
+
+    #[test]
+    fn duration_minutes_seconds() {
+        let out = render(&RunSummary {
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            errors: 0,
+            xfailed: 0,
+            todo: 0,
+            duration: Duration::from_millis(65_500),
+            discovery_duration: None,
+            test_duration: None,
+            file_count: 0,
+            start_time: None,
+            changed_selection: None,
+        });
+        assert!(out.contains("1:05.50"), "expected M:SS.SS, got: {out}");
+        assert!(!out.contains("65.50s"));
+    }
+
+    #[test]
+    fn duration_exactly_one_minute() {
+        let out = render(&RunSummary {
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            errors: 0,
+            xfailed: 0,
+            todo: 0,
+            duration: Duration::from_secs(60),
+            discovery_duration: None,
+            test_duration: None,
+            file_count: 0,
+            start_time: None,
+            changed_selection: None,
+        });
+        assert!(out.contains("1:00.00"));
+    }
+
+    #[test]
+    fn duration_breakdown_uses_minutes_seconds() {
+        let out = render(&RunSummary {
+            passed: 5,
+            failed: 0,
+            skipped: 0,
+            errors: 0,
+            xfailed: 0,
+            todo: 0,
+            duration: Duration::from_secs(125),
+            discovery_duration: Some(Duration::from_millis(30)),
+            test_duration: Some(Duration::from_secs(95)),
+            file_count: 0,
+            start_time: None,
+            changed_selection: None,
+        });
+        assert!(out.contains("2:05.00"));
+        assert!(out.contains("tests 1:35.00"));
+        assert!(out.contains("discover 30.00ms"));
     }
 
     #[test]

--- a/crates/tryke_reporter/src/summary.rs
+++ b/crates/tryke_reporter/src/summary.rs
@@ -1,9 +1,9 @@
 use std::io;
-use std::time::Duration;
 
 use owo_colors::OwoColorize;
 use tryke_types::{RunSummary, TestItem};
 
+use crate::duration::format_duration;
 use crate::reporter::WatchIdleInfo;
 
 /// Keyboard shortcuts shown beneath the summary/idle badge in watch
@@ -21,26 +21,6 @@ fn write_watch_keybindings<W: io::Write>(writer: &mut W) {
     for (key, label) in WATCH_KEYBINDINGS {
         let pad = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub(key.len()));
         let _ = writeln!(writer, "{pad}{}  {}", (*key).bold(), (*label).dimmed());
-    }
-}
-
-fn format_duration(d: Duration) -> String {
-    let secs = d.as_secs_f64();
-    if secs < 1.0 {
-        format!("{:.2}ms", secs * 1000.0)
-    } else if secs < 60.0 {
-        format!("{secs:.2}s")
-    } else {
-        // Integer math avoids the float-cast precision lint. The `+ 5`
-        // rounds to the nearest centisecond so output matches the
-        // sub-minute branches (which round via `:.2`); collapsing
-        // everything into centiseconds first lets carry through
-        // seconds/minutes happen naturally on decomposition.
-        let centis = (d.as_millis() + 5) / 10;
-        let minutes = centis / 6000;
-        let secs = (centis / 100) % 60;
-        let cs = centis % 100;
-        format!("{minutes}:{secs:02}.{cs:02}")
     }
 }
 

--- a/crates/tryke_reporter/src/summary.rs
+++ b/crates/tryke_reporter/src/summary.rs
@@ -31,14 +31,16 @@ fn format_duration(d: Duration) -> String {
     } else if secs < 60.0 {
         format!("{secs:.2}s")
     } else {
-        // Integer math avoids the float-cast precision lint and the
-        // formatted output only needs two-decimal precision anyway.
-        let total_ms = d.as_millis();
-        let total_secs = total_ms / 1000;
-        let minutes = total_secs / 60;
-        let rem_secs = total_secs % 60;
-        let rem_cs = (total_ms % 1000) / 10;
-        format!("{minutes}:{rem_secs:02}.{rem_cs:02}")
+        // Integer math avoids the float-cast precision lint. The `+ 5`
+        // rounds to the nearest centisecond so output matches the
+        // sub-minute branches (which round via `:.2`); collapsing
+        // everything into centiseconds first lets carry through
+        // seconds/minutes happen naturally on decomposition.
+        let centis = (d.as_millis() + 5) / 10;
+        let minutes = centis / 6000;
+        let secs = (centis / 100) % 60;
+        let cs = centis % 100;
+        format!("{minutes}:{secs:02}.{cs:02}")
     }
 }
 
@@ -484,6 +486,27 @@ mod tests {
             changed_selection: None,
         });
         assert!(out.contains("1:00.00"));
+    }
+
+    #[test]
+    fn duration_rounds_centiseconds_with_carry() {
+        // 119.999s should round up to 2:00.00, not truncate to 1:59.99.
+        let out = render(&RunSummary {
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            errors: 0,
+            xfailed: 0,
+            todo: 0,
+            duration: Duration::from_millis(119_999),
+            discovery_duration: None,
+            test_duration: None,
+            file_count: 0,
+            start_time: None,
+            changed_selection: None,
+        });
+        assert!(out.contains("2:00.00"), "expected carry, got: {out}");
+        assert!(!out.contains("1:59.99"));
     }
 
     #[test]

--- a/crates/tryke_reporter/src/text.rs
+++ b/crates/tryke_reporter/src/text.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::PathBuf;
-use std::time::Duration;
 
 use owo_colors::OwoColorize;
 use tryke_types::{RunSummary, TestItem, TestOutcome, TestResult};
@@ -13,6 +12,7 @@ use crate::diagnostic::{
     render_assertion, render_assertions, render_captured_output, render_error_message,
     render_failure_message,
 };
+use crate::duration::format_duration;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub enum Verbosity {
@@ -198,15 +198,6 @@ fn write_captured<W: io::Write>(writer: &mut W, label: &str, content: &str) {
     let mut buf = String::new();
     render_captured_output(label, content, &mut buf);
     let _ = write!(writer, "{buf}");
-}
-
-fn format_duration(d: Duration) -> String {
-    let ms = d.as_secs_f64() * 1000.0;
-    if ms < 1000.0 {
-        format!("{ms:.2}ms")
-    } else {
-        format!("{:.2}s", d.as_secs_f64())
-    }
 }
 
 impl<W: io::Write> Reporter for TextReporter<W> {
@@ -1300,24 +1291,6 @@ mod tests {
             out.contains("Exception") && out.contains("raise Exception"),
             "exception traceback should be shown after the per-assertion list: {out}"
         );
-    }
-
-    #[test]
-    fn format_duration_millis() {
-        let d = Duration::from_millis(48);
-        assert_eq!(format_duration(d), "48.00ms");
-    }
-
-    #[test]
-    fn format_duration_seconds() {
-        let d = Duration::from_millis(1500);
-        assert_eq!(format_duration(d), "1.50s");
-    }
-
-    #[test]
-    fn format_duration_sub_millis() {
-        let d = Duration::from_micros(170);
-        assert_eq!(format_duration(d), "0.17ms");
     }
 
     #[test]


### PR DESCRIPTION
When a run exceeds 60 seconds the summary lines and the LLM reporter's
run-complete line now render as e.g. '1:05.50' instead of '65.50s',
matching what users intuitively expect for long-running suites.