### PR TITLE
Refactor pytest-to-tryke migration prompt into a skill

### DIFF
--- a/.claude/skills/pytest-to-tryke-migration/SKILL.md
+++ b/.claude/skills/pytest-to-tryke-migration/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: pytest-to-tryke-migration
+description: Migrate a Python repository from pytest to Tryke under a phased, gated contract — discovery parity, results parity, and CI cutover are explicit checkpoints, not vibes.
+---
+
+# pytest → Tryke migration
+
+Tryke (<https://tryke.dev>) is a Rust-based Python test runner with a
+Jest-style API: `@test`, `expect(...).to_equal(...)`, `@fixture` +
+`Depends()`, `@test.cases`. The conversion cheat sheet lives at
+<https://tryke.dev/migration.html>.
+
+## When to use this skill
+
+Activate when **all** of the following hold:
+
+- The target repository has a working pytest suite (pytest is in
+  `pyproject.toml` / `requirements*.txt` / `setup.cfg`, or `conftest.py`
+  / `test_*.py` files exist).
+- The user has asked to migrate to Tryke (or to "use tryke instead of
+  pytest").
+- The repo is in a clean state — uncommitted local changes get rolled
+  into Phase 0 and contaminate the baseline.
+
+If pytest is missing, the suite is already failing, or the user is
+asking a one-off question ("how do I write a fixture in tryke?"), do
+**not** activate — point them at the cheat sheet instead.
+
+## Goal contract
+
+This skill is a `/goal`-shaped contract. Read this section first; the
+phases below are the execution plan that satisfies it.
+
+- **Outcome.** All pytest tests run under `tryke test` with discovery
+  and results parity vs the captured pytest baseline, and pytest is
+  removed from dev dependencies.
+- **Verification surface.** Five gates, in order:
+  - **Gate 0** — `pytest --collect-only` has zero collection errors and
+    `.migration/pytest-results.xml` exists.
+  - **Gate 1** — `tryke test --collect-only` runs without crashing
+    (zero collected is fine here).
+  - **Gate 3** — discovery parity: the normalized collect lists from
+    pytest and tryke match 1:1, modulo the documented `test_` prefix
+    strip and any `describe()` group prefixes.
+  - **Gate 4** — results parity: per-test pass / fail / skip / xfail
+    outcomes match `.migration/pytest-results.xml` after the same
+    normalization used for Gate 3.
+  - **Gate 5** — CI is green on tryke and pytest is no longer
+    installed.
+- **Constraints (must not regress).**
+  - Do not edit the pytest baseline to paper over a Phase 3 miss. The
+    baseline is the source of truth.
+  - Do not mass-add `.fatal()` to make Gate 4 numbers match — soft
+    assertions are intentional; diagnose each divergence.
+  - Do not use `cast()`, `# type: ignore`, `getattr`, or `Any` to
+    silence the type checker on `Depends()`. Fix the fixture's return
+    type instead.
+  - Do not rewrite a `pytest.raises(match=r"...")` regex when moving
+    to `to_raise(match=...)` — pass it through unchanged.
+  - Do not keep `conftest.py` files "just in case" after re-homing
+    their fixtures. Delete them.
+- **Boundaries.**
+  - Work inside the repo. Create `.migration/` at the repo root for
+    baseline and comparison artifacts; add it to `.gitignore`.
+  - For large suites, parallelize batches of file conversions across
+    sub-agents.
+  - Use `tryke test --reporter llm` for any single-test diagnostic
+    reruns — its output is tuned for LLM context windows.
+- **Iteration policy.** One package / directory at a time. Commit
+  **after every file** (or small batch) with a descriptive message and
+  push immediately. Update `.migration/CURRENT.md` at the end of each
+  session. Append to `.migration/PATTERNS.md` whenever you solve a
+  non-obvious conversion the next file is likely to hit too.
+- **Blocked stop condition.** Stop and ask the user if a gate fails and
+  you cannot trivially explain the mismatch. Stop and ask before
+  silencing a typing error on `Depends()` or before mass-adding
+  `.fatal()`.
+
+## Working across sessions
+
+A migration of any real size will span multiple sessions. Context
+windows are finite, and a fresh session that starts by re-exploring the
+tree and re-deriving conversion patterns burns its budget before any
+code gets written. Three files in `.migration/` keep sessions
+continuous:
+
+- **`.migration/NOTES.md`** — running log of decisions, mismatches,
+  flagged-for-human items, and the test counts recorded at each gate.
+- **`.migration/PATTERNS.md`** — a concrete, **repo-specific** playbook
+  of proven conversions: which conftest fixtures you re-homed and
+  where, any project-specific helper wrappers you wrote (e.g. an
+  `_expect_raises_async` for awaitable exception assertions), autouse
+  rewrites, name-collision aliasing rules, pre-run cleanup commands,
+  discovery-tripwire `grep` commands. This is **not** a copy of the
+  cheat sheet — it is the adaptations you learned the hard way for
+  *this* codebase. When you discover a new pattern mid-session, add it
+  here before you forget.
+- **`.migration/CURRENT.md`** — a ≤50-line "resume here" pointer:
+  current branch and last commit SHA, the exact next file to port with
+  its size / test count / any known blockers, copy-paste run and commit
+  commands, and a 2–3 item ranked list of what to take on after that. A
+  fresh session reads this file first and jumps straight to work.
+
+Update `CURRENT.md` at the end of every session. Append to
+`PATTERNS.md` whenever you solve a non-obvious conversion the next file
+is likely to hit too.
+
+## Committing and pushing
+
+Commit **after every file** (or small batch of files) with a
+descriptive message — do not wait until end of session. After each
+commit, push the branch. Two reasons:
+
+1. If a tracking PR exists, every push triggers CI and grows the review
+   surface one slice at a time — reviewers can keep up. If no PR exists
+   yet, still push: opening a PR later is a single command, but
+   unpushed work lost to a crashed session is unrecoverable.
+2. When you resume, `git log origin/<branch>` is the unambiguous
+   ground-truth for what is done. Local-only commits are invisible to
+   the next session.
+
+If a PR is open, note its URL in `CURRENT.md` so the next session
+pushes to it automatically.
+
+## Phase -1 — Getting started
+
+Do a scan of the repo and understand the pytest patterns it uses, and
+how to convert them to tryke.
+
+If there are functionality gaps, code simple shims.
+
+Make a note of what you encounter and learn in `PATTERNS.md`.
+
+If there are conversion patterns you'd like input on, flag these to the
+user before moving forward.
+
+## Phase 0 — Baseline capture (pytest) — Gate 0
+
+On a clean checkout, before any code changes:
+
+1. `pytest --collect-only -q > .migration/pytest-collect.txt 2>&1`
+2. `pytest --junit-xml=.migration/pytest-results.xml` (let failures
+   surface if any — we just need the XML)
+3. Record in `.migration/NOTES.md`:
+   - total collected
+   - passed / failed / skipped / xfailed / errored counts
+   - any collection errors (these **must** be fixed on pytest first —
+     do not proceed with a broken baseline)
+4. List every active pytest plugin from `pyproject.toml` /
+   `requirements*.txt` / `setup.cfg` so we know what behavior we are
+   replacing (e.g. `pytest-asyncio`, `pytest-xdist`, `pytest-mock`,
+   `pytest-django`).
+
+**Gate 0:** baseline collection has zero errors and results XML exists.
+
+## Phase 1 — Install and configure Tryke — Gate 1
+
+1. Add `tryke` as a dev dependency (`uv add --dev tryke` or the
+   project's equivalent). See
+   <https://tryke.dev/guides/installation.html>.
+2. Add a `[tool.tryke]` section to `pyproject.toml` mirroring the
+   pytest `testpaths` / `norecursedirs` values. See
+   <https://tryke.dev/guides/configuration.html>.
+3. Run `tryke --help` and `tryke test --help` to confirm the binary
+   works.
+
+**Gate 1:** `tryke test --collect-only` runs without crashing (it is
+fine if it finds **zero** tests at this point — no files have been
+converted yet).
+
+## Phase 2 — Mechanical conversion
+
+Convert test files using the cheat sheet at
+<https://tryke.dev/migration.html>. Do one package / directory at a
+time and keep each conversion small enough to review.
+
+**Display names — use them.** Lift one-line docstrings (or derive a
+short phrase from the function name) into `@test("...")`, and label
+assertions with `expect(value, "...")` as you go. Tryke surfaces both
+in every reporter and discovery extracts them statically — they cost
+nothing at runtime, but retrofitting them later is a separate pass
+over every test.
+
+**Soft assertions — read this carefully.** Tryke assertions are soft
+by default: every `expect()` in a test runs even if an earlier one
+fails. See <https://tryke.dev/concepts/soft-assertions.html>. **Do
+not** reflexively add `.fatal()` to every assertion to mimic pytest.
+Only add `.fatal()` when a later assertion genuinely depends on the
+earlier one (e.g. you checked `response.status == 200` and the next
+assertions dereference the body).
+
+### Don't
+
+- Do **not** use `cast()`, `# type: ignore`, `getattr`, or `Any` to
+  silence the type checker on `Depends()` — fix the fixture's return
+  type instead.
+- Do **not** translate `pytest.raises(match=r"...")` by rewriting the
+  regex — pass it through unchanged on `to_raise(match=...)`.
+- Do **not** keep `conftest.py` files "just in case" after moving the
+  fixtures. Delete them.
+- Do **not** paper over a missing test in Phase 3 by editing the
+  baseline file. The baseline is the source of truth.
+
+## Phase 3 — Discovery parity gate — Gate 3
+
+1. `tryke test --collect-only > .migration/tryke-collect.txt`
+2. Normalize both lists and diff them:
+   - pytest: `test_file.py::test_name[case_label]`
+   - tryke:  `test_file.py::name[case_label]`
+   - The only expected differences are the `test_` prefix stripping
+     and the describe-group prefixes where you added `with
+     describe(...)` blocks.
+3. For each test present in pytest's list but missing from Tryke's,
+   diagnose in this order:
+   1. Dynamic imports in the module or a transitive import
+      (`grep -R importlib.import_module`). Replace with static imports.
+   2. Fixture still living in `conftest.py` — move it module-local.
+   3. `@test.cases` label that is not a string literal, or case kwargs
+      that don't match the function signature.
+   4. A plain `def test_foo` that never got decorated with `@test`.
+   5. A test nested inside an `if`/`for`/`while` body — flatten.
+4. For each test present in Tryke's list but missing from pytest's,
+   you probably double-collected a `describe()` group. Fix the
+   decorator.
+
+**Gate 3:** the two collect lists match 1:1 (modulo the documented
+prefix changes). Record the final count in `.migration/NOTES.md`.
+
+## Phase 4 — Results parity gate — Gate 4
+
+1. `tryke test --reporter junit > .migration/tryke-results.xml`
+2. Compare per-test outcomes against `.migration/pytest-results.xml`.
+   The JUnit `<testcase>` names do **not** match byte-for-byte —
+   Phase 2 stripped the `test_` prefix and Phase 3 may have added
+   `describe()` group prefixes. Apply the same normalization you used
+   to pass Gate 3 before comparing:
+   - Strip the leading `test_` from pytest names
+     (`test_file.py::test_add` → `test_file.py::add`).
+   - For any test you moved under a `with describe("group"):` block,
+     prepend `group::` on the pytest side (or strip it on the Tryke
+     side) so the IDs line up.
+   - Parametrize labels (`[case_label]`) already match between
+     systems — do not rewrite them.
+
+   Then for each normalized name, compare pass / fail / skip / xfail
+   status.
+3. For each divergence:
+   - Rerun the single test with the LLM-friendly reporter:
+     `tryke test -k <name> --reporter llm`
+     (see <https://tryke.dev/guides/reporters.html>). Feed that output
+     back through this skill to diagnose.
+   - Common causes, in order of likelihood:
+     - Wrong assertion matcher (`to_be` vs `to_equal`, `to_contain`
+       vs `to_have_length`, forgotten `.not_`).
+     - A fixture's teardown ran at a different scope than pytest's.
+     - A soft-assertion cascade: an assertion that would have
+       short-circuited under pytest now runs and fails on a `None`
+       the earlier assertion was supposed to guard. Add `.fatal()` on
+       the guarding assertion.
+     - `pytest.raises(match=...)` regex was rewritten instead of
+       copied.
+4. Do not mass-add `.fatal()` to make numbers match — diagnose each
+   case.
+
+**Gate 4:** per-test outcomes match the pytest baseline. Record the
+final counts in `.migration/NOTES.md`.
+
+## Phase 5 — Cleanup — Gate 5
+
+1. Remove `pytest`, `pytest-asyncio`, `pytest-xdist`, `pytest-mock`
+   (if the usage was mechanical), and other pytest-only plugins from
+   dev dependencies. Leave anything whose functionality Tryke does not
+   yet provide and flag it in `.migration/NOTES.md`.
+2. Delete empty `conftest.py` files.
+3. Update CI to call `tryke test --reporter junit` (or `--reporter
+   llm` if CI logs are consumed by an LLM) in place of `pytest`.
+4. Update the project README's testing section.
+5. Delete `.migration/` once you have committed the migration.
+
+**Gate 5:** CI is green on Tryke; pytest is no longer installed.
+
+## Reporting back
+
+After each gate, summarize in chat:
+
+- which files changed in this phase
+- the current test counts (collected / passed / failed / skipped /
+  xfailed)
+- anything you had to skip or flag for human review
+
+## Using with `/goal` (Codex)
+
+This skill is shaped as a `/goal` contract: the **Goal contract**
+section above maps 1:1 to the Codex goal template (outcome,
+verification surface, constraints, boundaries, iteration policy,
+blocked stop). To run the migration under a Codex goal, paste:
+
+```
+/goal Migrate this repository from pytest to Tryke under the
+pytest-to-tryke-migration skill at
+.claude/skills/pytest-to-tryke-migration/SKILL.md. Done when Gates 0
+through 5 all pass: pytest baseline captured cleanly, tryke
+configured, discovery parity matches, per-test results parity
+matches the captured pytest JUnit XML, and pytest is removed from
+dev dependencies with CI green on tryke. Work one package at a
+time; commit and push after every file; maintain .migration/NOTES.md,
+PATTERNS.md, and CURRENT.md across sessions. Use `tryke test
+--reporter llm` for any single-test diagnostic rerun. Stop and ask if
+a gate fails and the mismatch is non-trivial, if a typing error on
+Depends() would require a cast/ignore to silence, or if you would
+need to mass-add .fatal() to satisfy Gate 4.
+```
+
+Use `/goal` to inspect status, pause, resume, or clear. Between
+checkpoints, the agent should report a compact status: current
+gate, what's verified, what's left, and any blockers.

--- a/.claude/skills/pytest-to-tryke-migration/SKILL.md
+++ b/.claude/skills/pytest-to-tryke-migration/SKILL.md
@@ -1,316 +1,166 @@
 ---
 name: pytest-to-tryke-migration
-description: Migrate a Python repository from pytest to Tryke under a phased, gated contract — discovery parity, results parity, and CI cutover are explicit checkpoints, not vibes.
+description: Convert a single pytest test file (or small package) to Tryke and verify the converted file's outcomes match what pytest produced.
 ---
 
-# pytest → Tryke migration
+# pytest → Tryke (per-file)
 
-Tryke (<https://tryke.dev>) is a Rust-based Python test runner with a
-Jest-style API: `@test`, `expect(...).to_equal(...)`, `@fixture` +
-`Depends()`, `@test.cases`. The conversion cheat sheet lives at
-<https://tryke.dev/migration.html>.
+Convert one test file (or a small package — a directory whose tests
+import a shared `conftest.py`) from pytest to
+[Tryke](https://tryke.dev). The conversion cheat sheet lives at
+<https://tryke.dev/migration.html> and has the full matcher table,
+fixture rewrite, and `@test.cases` recipe.
 
-## When to use this skill
+This skill is the **unit of work**, not the whole migration. Repo-level
+concerns — capturing a pytest baseline, installing tryke, running
+discovery and results parity across the whole suite, removing pytest
+from dev deps — belong in a `/goal` that invokes this skill once per
+file. See the example goal at the bottom.
 
-Activate when **all** of the following hold:
+## When to use
 
-- The target repository has a working pytest suite (pytest is in
-  `pyproject.toml` / `requirements*.txt` / `setup.cfg`, or `conftest.py`
-  / `test_*.py` files exist).
-- The user has asked to migrate to Tryke (or to "use tryke instead of
-  pytest").
-- The repo is in a clean state — uncommitted local changes get rolled
-  into Phase 0 and contaminate the baseline.
+Activate when you are pointed at a specific pytest test file (or a
+small directory of them) and asked to convert it to tryke. The repo
+must already have `tryke` installed and a `[tool.tryke]` section in
+`pyproject.toml`; if it doesn't, stop and ask — installing is one
+line but it's a repo-level decision.
 
-If pytest is missing, the suite is already failing, or the user is
-asking a one-off question ("how do I write a fixture in tryke?"), do
-**not** activate — point them at the cheat sheet instead.
+## Steps
 
-## Goal contract
+### Step 1: Read the file and identify pytest surface
 
-This skill is a `/goal`-shaped contract. Read this section first; the
-phases below are the execution plan that satisfies it.
+Skim for: `def test_*`, `@pytest.fixture`, `@pytest.mark.parametrize`,
+`@pytest.mark.skip(if)?`, `@pytest.mark.xfail`, `@pytest.mark.asyncio`,
+`pytest.raises`, `conftest.py` imports, `request.param`,
+autouse / scope= kwargs, dynamic `importlib` in the module.
 
-- **Outcome.** All pytest tests run under `tryke test` with discovery
-  and results parity vs the captured pytest baseline, and pytest is
-  removed from dev dependencies.
-- **Verification surface.** Five gates, in order:
-  - **Gate 0** — `pytest --collect-only` has zero collection errors and
-    `.migration/pytest-results.xml` exists.
-  - **Gate 1** — `tryke test --collect-only` runs without crashing
-    (zero collected is fine here).
-  - **Gate 3** — discovery parity: the normalized collect lists from
-    pytest and tryke match 1:1, modulo the documented `test_` prefix
-    strip and any `describe()` group prefixes.
-  - **Gate 4** — results parity: per-test pass / fail / skip / xfail
-    outcomes match `.migration/pytest-results.xml` after the same
-    normalization used for Gate 3.
-  - **Gate 5** — CI is green on tryke and pytest is no longer
-    installed.
-- **Constraints (must not regress).**
-  - Do not edit the pytest baseline to paper over a Phase 3 miss. The
-    baseline is the source of truth.
-  - Do not mass-add `.fatal()` to make Gate 4 numbers match — soft
-    assertions are intentional; diagnose each divergence.
-  - Do not use `cast()`, `# type: ignore`, `getattr`, or `Any` to
-    silence the type checker on `Depends()`. Fix the fixture's return
-    type instead.
-  - Do not rewrite a `pytest.raises(match=r"...")` regex when moving
-    to `to_raise(match=...)` — pass it through unchanged.
-  - Do not keep `conftest.py` files "just in case" after re-homing
-    their fixtures. Delete them.
-- **Boundaries.**
-  - Work inside the repo. Create `.migration/` at the repo root for
-    baseline and comparison artifacts; add it to `.gitignore`.
-  - For large suites, parallelize batches of file conversions across
-    sub-agents.
-  - Use `tryke test --reporter llm` for any single-test diagnostic
-    reruns — its output is tuned for LLM context windows.
-- **Iteration policy.** One package / directory at a time. Commit
-  **after every file** (or small batch) with a descriptive message and
-  push immediately. Update `.migration/CURRENT.md` at the end of each
-  session. Append to `.migration/PATTERNS.md` whenever you solve a
-  non-obvious conversion the next file is likely to hit too.
-- **Blocked stop condition.** Stop and ask the user if a gate fails and
-  you cannot trivially explain the mismatch. Stop and ask before
-  silencing a typing error on `Depends()` or before mass-adding
-  `.fatal()`.
+Note anything you don't recognize — flag it before converting rather
+than guessing.
 
-## Working across sessions
+### Step 2: Apply conversions
 
-A migration of any real size will span multiple sessions. Context
-windows are finite, and a fresh session that starts by re-exploring the
-tree and re-deriving conversion patterns burns its budget before any
-code gets written. Three files in `.migration/` keep sessions
-continuous:
+Mechanical rewrites, see the cheat sheet for the full table:
 
-- **`.migration/NOTES.md`** — running log of decisions, mismatches,
-  flagged-for-human items, and the test counts recorded at each gate.
-- **`.migration/PATTERNS.md`** — a concrete, **repo-specific** playbook
-  of proven conversions: which conftest fixtures you re-homed and
-  where, any project-specific helper wrappers you wrote (e.g. an
-  `_expect_raises_async` for awaitable exception assertions), autouse
-  rewrites, name-collision aliasing rules, pre-run cleanup commands,
-  discovery-tripwire `grep` commands. This is **not** a copy of the
-  cheat sheet — it is the adaptations you learned the hard way for
-  *this* codebase. When you discover a new pattern mid-session, add it
-  here before you forget.
-- **`.migration/CURRENT.md`** — a ≤50-line "resume here" pointer:
-  current branch and last commit SHA, the exact next file to port with
-  its size / test count / any known blockers, copy-paste run and commit
-  commands, and a 2–3 item ranked list of what to take on after that. A
-  fresh session reads this file first and jumps straight to work.
+- `def test_foo()` → `@test\ndef foo():` (strip the `test_` prefix —
+  it is now redundant)
+- `assert x == y` → `expect(x).to_equal(y)` (and the rest of the
+  matcher table)
+- `@pytest.mark.parametrize(...)` → `@test.cases(test.case("label",
+  ...), ...)`
+- `@pytest.mark.skip` / `skipif` / `xfail` → `@test.skip(...)` /
+  `skip_if(...)` / `xfail(...)`
+- `@pytest.mark.asyncio` → drop it; `async def` under `@test` is
+  built-in
+- `with pytest.raises(E, match=r"..."):` →
+  `expect(lambda: ...).to_raise(E, match=r"...")` — **copy the regex
+  verbatim**
+- `@pytest.fixture` with implicit-name DI → `@fixture` + parameters
+  typed as `Annotated[T, Depends(other)]`. Scope is lexical; drop
+  `scope=`. Move the fixture into the test module and delete the
+  `conftest.py` entry.
 
-Update `CURRENT.md` at the end of every session. Append to
-`PATTERNS.md` whenever you solve a non-obvious conversion the next file
-is likely to hit too.
+While you're in the file, lift docstrings or short phrases into
+`@test("...")` display names and label assertions with `expect(value,
+"...")` — they cost nothing at runtime and show up in every reporter.
 
-## Committing and pushing
+Tryke assertions are **soft by default**: every `expect()` in a test
+runs even if an earlier one fails. Only add `.fatal()` when a later
+assertion genuinely depends on the earlier one (e.g. you checked
+`response.status == 200` and the next assertions dereference the
+body). See <https://tryke.dev/concepts/soft-assertions.html>.
 
-Commit **after every file** (or small batch of files) with a
-descriptive message — do not wait until end of session. After each
-commit, push the branch. Two reasons:
+### Step 3: Verify
 
-1. If a tracking PR exists, every push triggers CI and grows the review
-   surface one slice at a time — reviewers can keep up. If no PR exists
-   yet, still push: opening a PR later is a single command, but
-   unpushed work lost to a crashed session is unrecoverable.
-2. When you resume, `git log origin/<branch>` is the unambiguous
-   ground-truth for what is done. Local-only commits are invisible to
-   the next session.
+Run the converted file:
 
-If a PR is open, note its URL in `CURRENT.md` so the next session
-pushes to it automatically.
-
-## Phase -1 — Getting started
-
-Do a scan of the repo and understand the pytest patterns it uses, and
-how to convert them to tryke.
-
-If there are functionality gaps, code simple shims.
-
-Make a note of what you encounter and learn in `PATTERNS.md`.
-
-If there are conversion patterns you'd like input on, flag these to the
-user before moving forward.
-
-## Phase 0 — Baseline capture (pytest) — Gate 0
-
-On a clean checkout, before any code changes:
-
-1. `pytest --collect-only -q > .migration/pytest-collect.txt 2>&1`
-2. `pytest --junit-xml=.migration/pytest-results.xml` (let failures
-   surface if any — we just need the XML)
-3. Record in `.migration/NOTES.md`:
-   - total collected
-   - passed / failed / skipped / xfailed / errored counts
-   - any collection errors (these **must** be fixed on pytest first —
-     do not proceed with a broken baseline)
-4. List every active pytest plugin from `pyproject.toml` /
-   `requirements*.txt` / `setup.cfg` so we know what behavior we are
-   replacing (e.g. `pytest-asyncio`, `pytest-xdist`, `pytest-mock`,
-   `pytest-django`).
-
-**Gate 0:** baseline collection has zero errors and results XML exists.
-
-## Phase 1 — Install and configure Tryke — Gate 1
-
-1. Add `tryke` as a dev dependency (`uv add --dev tryke` or the
-   project's equivalent). See
-   <https://tryke.dev/guides/installation.html>.
-2. Add a `[tool.tryke]` section to `pyproject.toml` mirroring the
-   pytest `testpaths` / `norecursedirs` values. See
-   <https://tryke.dev/guides/configuration.html>.
-3. Run `tryke --help` and `tryke test --help` to confirm the binary
-   works.
-
-**Gate 1:** `tryke test --collect-only` runs without crashing (it is
-fine if it finds **zero** tests at this point — no files have been
-converted yet).
-
-## Phase 2 — Mechanical conversion
-
-Convert test files using the cheat sheet at
-<https://tryke.dev/migration.html>. Do one package / directory at a
-time and keep each conversion small enough to review.
-
-**Display names — use them.** Lift one-line docstrings (or derive a
-short phrase from the function name) into `@test("...")`, and label
-assertions with `expect(value, "...")` as you go. Tryke surfaces both
-in every reporter and discovery extracts them statically — they cost
-nothing at runtime, but retrofitting them later is a separate pass
-over every test.
-
-**Soft assertions — read this carefully.** Tryke assertions are soft
-by default: every `expect()` in a test runs even if an earlier one
-fails. See <https://tryke.dev/concepts/soft-assertions.html>. **Do
-not** reflexively add `.fatal()` to every assertion to mimic pytest.
-Only add `.fatal()` when a later assertion genuinely depends on the
-earlier one (e.g. you checked `response.status == 200` and the next
-assertions dereference the body).
-
-### Don't
-
-- Do **not** use `cast()`, `# type: ignore`, `getattr`, or `Any` to
-  silence the type checker on `Depends()` — fix the fixture's return
-  type instead.
-- Do **not** translate `pytest.raises(match=r"...")` by rewriting the
-  regex — pass it through unchanged on `to_raise(match=...)`.
-- Do **not** keep `conftest.py` files "just in case" after moving the
-  fixtures. Delete them.
-- Do **not** paper over a missing test in Phase 3 by editing the
-  baseline file. The baseline is the source of truth.
-
-## Phase 3 — Discovery parity gate — Gate 3
-
-1. `tryke test --collect-only > .migration/tryke-collect.txt`
-2. Normalize both lists and diff them:
-   - pytest: `test_file.py::test_name[case_label]`
-   - tryke:  `test_file.py::name[case_label]`
-   - The only expected differences are the `test_` prefix stripping
-     and the describe-group prefixes where you added `with
-     describe(...)` blocks.
-3. For each test present in pytest's list but missing from Tryke's,
-   diagnose in this order:
-   1. Dynamic imports in the module or a transitive import
-      (`grep -R importlib.import_module`). Replace with static imports.
-   2. Fixture still living in `conftest.py` — move it module-local.
-   3. `@test.cases` label that is not a string literal, or case kwargs
-      that don't match the function signature.
-   4. A plain `def test_foo` that never got decorated with `@test`.
-   5. A test nested inside an `if`/`for`/`while` body — flatten.
-4. For each test present in Tryke's list but missing from pytest's,
-   you probably double-collected a `describe()` group. Fix the
-   decorator.
-
-**Gate 3:** the two collect lists match 1:1 (modulo the documented
-prefix changes). Record the final count in `.migration/NOTES.md`.
-
-## Phase 4 — Results parity gate — Gate 4
-
-1. `tryke test --reporter junit > .migration/tryke-results.xml`
-2. Compare per-test outcomes against `.migration/pytest-results.xml`.
-   The JUnit `<testcase>` names do **not** match byte-for-byte —
-   Phase 2 stripped the `test_` prefix and Phase 3 may have added
-   `describe()` group prefixes. Apply the same normalization you used
-   to pass Gate 3 before comparing:
-   - Strip the leading `test_` from pytest names
-     (`test_file.py::test_add` → `test_file.py::add`).
-   - For any test you moved under a `with describe("group"):` block,
-     prepend `group::` on the pytest side (or strip it on the Tryke
-     side) so the IDs line up.
-   - Parametrize labels (`[case_label]`) already match between
-     systems — do not rewrite them.
-
-   Then for each normalized name, compare pass / fail / skip / xfail
-   status.
-3. For each divergence:
-   - Rerun the single test with the LLM-friendly reporter:
-     `tryke test -k <name> --reporter llm`
-     (see <https://tryke.dev/guides/reporters.html>). Feed that output
-     back through this skill to diagnose.
-   - Common causes, in order of likelihood:
-     - Wrong assertion matcher (`to_be` vs `to_equal`, `to_contain`
-       vs `to_have_length`, forgotten `.not_`).
-     - A fixture's teardown ran at a different scope than pytest's.
-     - A soft-assertion cascade: an assertion that would have
-       short-circuited under pytest now runs and fails on a `None`
-       the earlier assertion was supposed to guard. Add `.fatal()` on
-       the guarding assertion.
-     - `pytest.raises(match=...)` regex was rewritten instead of
-       copied.
-4. Do not mass-add `.fatal()` to make numbers match — diagnose each
-   case.
-
-**Gate 4:** per-test outcomes match the pytest baseline. Record the
-final counts in `.migration/NOTES.md`.
-
-## Phase 5 — Cleanup — Gate 5
-
-1. Remove `pytest`, `pytest-asyncio`, `pytest-xdist`, `pytest-mock`
-   (if the usage was mechanical), and other pytest-only plugins from
-   dev dependencies. Leave anything whose functionality Tryke does not
-   yet provide and flag it in `.migration/NOTES.md`.
-2. Delete empty `conftest.py` files.
-3. Update CI to call `tryke test --reporter junit` (or `--reporter
-   llm` if CI logs are consumed by an LLM) in place of `pytest`.
-4. Update the project README's testing section.
-5. Delete `.migration/` once you have committed the migration.
-
-**Gate 5:** CI is green on Tryke; pytest is no longer installed.
-
-## Reporting back
-
-After each gate, summarize in chat:
-
-- which files changed in this phase
-- the current test counts (collected / passed / failed / skipped /
-  xfailed)
-- anything you had to skip or flag for human review
-
-## Using with `/goal` (Codex)
-
-This skill is shaped as a `/goal` contract: the **Goal contract**
-section above maps 1:1 to the Codex goal template (outcome,
-verification surface, constraints, boundaries, iteration policy,
-blocked stop). To run the migration under a Codex goal, paste:
-
-```
-/goal Migrate this repository from pytest to Tryke under the
-pytest-to-tryke-migration skill at
-.claude/skills/pytest-to-tryke-migration/SKILL.md. Done when Gates 0
-through 5 all pass: pytest baseline captured cleanly, tryke
-configured, discovery parity matches, per-test results parity
-matches the captured pytest JUnit XML, and pytest is removed from
-dev dependencies with CI green on tryke. Work one package at a
-time; commit and push after every file; maintain .migration/NOTES.md,
-PATTERNS.md, and CURRENT.md across sessions. Use `tryke test
---reporter llm` for any single-test diagnostic rerun. Stop and ask if
-a gate fails and the mismatch is non-trivial, if a typing error on
-Depends() would require a cast/ignore to silence, or if you would
-need to mass-add .fatal() to satisfy Gate 4.
+```bash
+tryke test path/to/file.py
 ```
 
-Use `/goal` to inspect status, pause, resume, or clear. Between
-checkpoints, the agent should report a compact status: current
-gate, what's verified, what's left, and any blockers.
+Then verify three things:
+
+1. **Discovery.** The set of test IDs in `tryke test --collect-only
+   path/to/file.py` matches the original `pytest --collect-only -q
+   path/to/file.py`, modulo the `test_` prefix strip and any
+   `describe()` group prefixes you added. A missing test usually
+   means: fixture still living in a `conftest.py`, a `@test.cases`
+   label that isn't a string literal, a plain `def test_foo` that
+   never got `@test`, or a test nested inside `if`/`for`/`while`.
+2. **Outcomes.** Each test's pass/fail/skip/xfail status matches what
+   pytest produced for the same file. If a test that passed under
+   pytest now fails, rerun the single test with the LLM-friendly
+   reporter and diagnose:
+
+   ```bash
+   tryke test -k <name> --reporter llm
+   ```
+
+3. **No leftover pytest in this file.** `grep -E
+   'pytest|@pytest\.' path/to/file.py` returns nothing.
+
+## Don't
+
+- Don't use `cast()`, `# type: ignore`, `getattr`, or `Any` to
+  silence the type checker on `Depends()`. Fix the fixture's return
+  type.
+- Don't rewrite a `pytest.raises(match=r"...")` regex when moving to
+  `to_raise(match=...)`. Pass it through unchanged.
+- Don't reflexively add `.fatal()` to every assertion to mimic
+  pytest. Diagnose each soft-assertion cascade individually.
+- Don't keep a `conftest.py` "just in case" after re-homing its
+  fixtures. Delete the empty file.
+- Don't paper over a discovery or outcome miss by editing the pytest
+  baseline. The baseline is the source of truth.
+
+## Common divergences (Step 3 troubleshooting)
+
+In order of likelihood:
+
+1. Wrong assertion matcher (`to_be` vs `to_equal`, `to_contain` vs
+   `to_have_length`, forgotten `.not_`).
+2. A fixture's teardown ran at a different scope than pytest's.
+3. A soft-assertion cascade: an assertion that would have
+   short-circuited under pytest now runs and fails on a `None` the
+   earlier assertion was supposed to guard. Add `.fatal()` on the
+   guarding assertion.
+4. `pytest.raises(match=...)` regex was rewritten instead of copied.
+5. Dynamic imports (`importlib.import_module`) in the module or a
+   transitive import hide tests from static discovery. Replace with
+   static imports.
+
+## Using with `/goal` for a whole-repo migration
+
+Drive the repo-level migration from a Codex `/goal` that invokes this
+skill once per file. The goal owns baseline capture, iteration, parity
+gates, and cleanup; the skill owns the mechanical conversion of one
+file.
+
+```text
+/goal Migrate this repository from pytest to tryke. Use the
+pytest-to-tryke-migration skill once per test file.
+
+Before starting:
+- Capture baseline: `pytest --collect-only -q > .migration/baseline-collect.txt`
+  and `pytest --junit-xml=.migration/baseline-results.xml`. Commit
+  `.migration/` to .gitignore.
+- Install tryke as a dev dep and add a `[tool.tryke]` section
+  mirroring the pytest testpaths.
+
+Iterate: for each test file under the configured testpaths, invoke the
+skill, then commit and push. Use sub-agents to parallelize batches if
+the suite is large.
+
+Done when:
+- `tryke test --collect-only` matches the baseline 1:1, modulo the
+  `test_` prefix strip and any added describe() group prefixes.
+- `tryke test --reporter junit` per-test outcomes match
+  .migration/baseline-results.xml after the same normalization.
+- pytest and its mechanically-replaced plugins (pytest-asyncio,
+  pytest-xdist, pytest-mock) are removed from dev deps.
+- CI calls `tryke test` and is green.
+
+Stop and ask if: a file's converted discovery or outcomes diverge in
+ways the skill's Step 3 troubleshooting can't explain; a Depends()
+typing error would require cast/ignore to silence; or you would need
+to mass-add .fatal() to satisfy the outcome parity check.
+```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,12 +4,14 @@ A side-by-side guide for moving from pytest to Tryke.
 
 !!! tip "Let an LLM do the migration for you"
     The fastest way to migrate is to hand the job to your AI coding assistant
-    (Claude Code, Cursor, Codex, Aider, etc.). We maintain a battle-tested
-    prompt that walks the assistant through a **phased, gated** migration with
+    (Claude Code, Cursor, Codex, Aider, etc.). We maintain a
+    [**pytest-to-tryke-migration skill**](skills/pytest-to-tryke-migration.md)
+    — installable as a Claude Code Skill or pasteable as a Codex `/goal` —
+    that walks the assistant through a **phased, gated** migration with
     explicit discovery- and results-parity checks so nothing is silently
-    dropped or inverted — it pairs with `tryke test --reporter llm` for
+    dropped or inverted. It pairs with `tryke test --reporter llm` for
     concise, structured failure diagnostics tuned to LLM context windows.
-    **[Jump to the migration prompt &rarr;](#migration-prompt)**
+    **[Install the migration skill &rarr;](skills/pytest-to-tryke-migration.md)**
 
 ## Cheat sheet
 
@@ -306,225 +308,40 @@ async def under_runner(runner):
     ...
 ```
 
-## Migration prompt
+## Migration skill
 
-The prompt below is designed to be pasted into an AI coding assistant (Claude Code, Cursor, Aider, etc.) pointed at a repository that already has a working pytest suite. It walks the assistant through a phased migration with explicit stop-and-verify gates: a **discovery-parity** gate after mechanical conversion, then a **results-parity** gate after the first `tryke test` run. Do not skip the gates — most silent migration failures are a test that stopped being collected or an assertion that quietly inverted.
+The phased prompt that used to live here has moved to a Claude Code
+[**Skill**](https://docs.claude.com/en/docs/agents/skills) — also
+pasteable as a Codex [`/goal`](https://developers.openai.com/codex/use-cases/follow-goals).
+See the [pytest-to-tryke-migration skill page](skills/pytest-to-tryke-migration.md)
+for install instructions, the full SKILL.md, and the copyable
+`/goal` template.
 
-Copy everything inside the fence and hand it to your assistant.
+A single source of truth, shaped as a `/goal` contract (outcome →
+verification surface → constraints → boundaries → iteration policy →
+blocked stop), keeps the gates explicit no matter which assistant you
+hand the job to:
 
-````markdown
-# Task: migrate this repository from pytest to Tryke
+- **Gate 0** — pytest baseline captured cleanly
+- **Gate 1** — tryke installed and `tryke test --collect-only` runs
+- **Gate 3** — discovery parity (no silently-dropped tests)
+- **Gate 4** — results parity (no silently-inverted assertions)
+- **Gate 5** — CI green on tryke, pytest uninstalled
 
-You are migrating a Python repository from **pytest** to **Tryke**
-(<https://tryke.dev>). Tryke is a Rust-based test runner with a Jest-style API
-(`@test`, `expect(...).to_equal(...)`, `@fixture` + `Depends()`, `@test.cases`).
-The migration cheat sheet is at <https://tryke.dev/migration.html>.
+### Strong vs weak goals
 
-Work in the phases below. **Do not advance to the next phase until the stated
-verification gate passes.** Stop and ask me if a gate fails and you cannot
-trivially explain the mismatch.
+If you are driving the migration with Codex `/goal`, the docs on
+[follow-goals](https://developers.openai.com/codex/use-cases/follow-goals)
+emphasize a finish line the agent can verify. Compare:
 
-For large test suites, consider using sub-agents to parallelize large batches of work.
-
-Create a `.migration/` directory at the repo root for baseline and comparison
-artifacts; add it to `.gitignore`. Keep a running `.migration/NOTES.md` of
-decisions and mismatches.
-
-## Working across sessions
-
-A migration of any real size will span multiple assistant sessions. Context
-windows are finite, and a fresh session that starts by re-exploring the tree
-and re-deriving conversion patterns burns its budget before any code gets
-written. Two additional files in `.migration/` keep sessions continuous:
-
-- **`.migration/PATTERNS.md`** — a concrete, **repo-specific** playbook of
-  proven conversions: which conftest fixtures you re-homed and where, any
-  project-specific helper wrappers you wrote (e.g. an `_expect_raises_async`
-  for awaitable exception assertions), autouse rewrites, name-collision
-  aliasing rules, pre-run cleanup commands, discovery-tripwire `grep`
-  commands. This is **not** a copy of the cheat sheet — it is the
-  adaptations you learned the hard way for *this* codebase. When you
-  discover a new pattern mid-session, add it here before you forget.
-- **`.migration/CURRENT.md`** — a ≤50-line "resume here" pointer: current
-  branch and last commit SHA, the exact next file to port with its size /
-  test count / any known blockers, copy-paste run and commit commands, and
-  a 2–3 item ranked list of what to take on after that. A fresh session
-  reads this file first and jumps straight to work.
-
-Update `CURRENT.md` at the end of every session. Append to `PATTERNS.md`
-whenever you solve a non-obvious conversion the next file is likely to hit
-too.
-
-## Committing and pushing
-
-Commit **after every file** (or small batch of files) with a descriptive
-message — do not wait until end of session. After each commit, push the
-branch. Two reasons:
-
-1. If a tracking PR exists, every push triggers CI and grows the review
-   surface one slice at a time — reviewers can keep up. If no PR exists
-   yet, still push: opening a PR later is a single command, but unpushed
-   work lost to a crashed session is unrecoverable.
-2. When you resume, `git log origin/<branch>` is the unambiguous
-   ground-truth for what is done. Local-only commits are invisible to the
-   next session.
-
-If a PR is open, note its URL in `CURRENT.md` so the next session pushes
-to it automatically.
-
-## Phase -1 — Getting started
-
-Do a scan of the repo and understand the pytest patterns it uses,
-and how to convert them to tryke.
-
-If there are functionality gaps, code simple shims.
-
-Make a note of what you encounter and learn in `PATTERNS.md`.
-
-If there are conversion patterns you'd like input on, flag these to the user before moving forward.
-
-## Phase 0 — Baseline capture (pytest)
-
-On a clean checkout, before any code changes:
-
-1. `pytest --collect-only -q > .migration/pytest-collect.txt 2>&1`
-2. `pytest --junit-xml=.migration/pytest-results.xml` (let failures surface
-   if any — we just need the XML)
-3. Record in `.migration/NOTES.md`:
-   - total collected
-   - passed / failed / skipped / xfailed / errored counts
-   - any collection errors (these **must** be fixed on pytest first — do not
-     proceed with a broken baseline)
-4. List every active pytest plugin from `pyproject.toml` /
-   `requirements*.txt` / `setup.cfg` so we know what behavior we are
-   replacing (e.g. `pytest-asyncio`, `pytest-xdist`, `pytest-mock`,
-   `pytest-django`).
-
-**Gate 0:** baseline collection has zero errors and results XML exists.
-
-## Phase 1 — Install and configure Tryke
-
-1. Add `tryke` as a dev dependency (`uv add --dev tryke` or the
-   project's equivalent). See <https://tryke.dev/guides/installation.html>.
-2. Add a `[tool.tryke]` section to `pyproject.toml` mirroring the
-   pytest `testpaths` / `norecursedirs` values. See
-   <https://tryke.dev/guides/configuration.html>.
-3. Run `tryke --help` and `tryke test --help` to confirm the binary works.
-
-**Gate 1:** `tryke test --collect-only` runs without crashing (it is fine if
-it finds **zero** tests at this point — no files have been converted yet).
-
-## Phase 2 — Mechanical conversion
-
-Convert test files using the cheat sheet at
-<https://tryke.dev/migration.html>. Do one package / directory at a time and keep
-each conversion small enough to review.
-
-**Display names — use them.** Lift one-line docstrings (or derive a short
-phrase from the function name) into `@test("...")`, and label assertions
-with `expect(value, "...")` as you go. Tryke surfaces both in every
-reporter and discovery extracts them statically — they cost nothing at
-runtime, but retrofitting them later is a separate pass over every test.
-
-**Soft assertions — read this carefully.** Tryke assertions are soft by
-default: every `expect()` in a test runs even if an earlier one fails. See
-<https://tryke.dev/concepts/soft-assertions.html>. **Do not** reflexively add
-`.fatal()` to every assertion to mimic pytest. Only add `.fatal()` when a
-later assertion genuinely depends on the earlier one (e.g. you checked
-`response.status == 200` and the next assertions dereference the body).
-
-### Don't
-
-- Do **not** use `cast()`, `# type: ignore`, `getattr`, or `Any` to silence
-  the type checker on `Depends()` — fix the fixture's return type instead.
-- Do **not** translate `pytest.raises(match=r"...")` by rewriting the regex
-  — pass it through unchanged on `to_raise(match=...)`.
-- Do **not** keep `conftest.py` files "just in case" after moving the
-  fixtures. Delete them.
-- Do **not** paper over a missing test in Phase 3 by editing the baseline
-  file. The baseline is the source of truth.
-
-## Phase 3 — Discovery parity gate
-
-1. `tryke test --collect-only > .migration/tryke-collect.txt`
-2. Normalize both lists and diff them:
-   - pytest: `test_file.py::test_name[case_label]`
-   - tryke:  `test_file.py::name[case_label]`
-   - The only expected differences are the `test_` prefix stripping and the
-     describe-group prefixes where you added `with describe(...)` blocks.
-3. For each test present in pytest's list but missing from Tryke's,
-   diagnose in this order:
-   1. Dynamic imports in the module or a transitive import
-      (`grep -R importlib.import_module`). Replace with static imports.
-   2. Fixture still living in `conftest.py` — move it module-local.
-   3. `@test.cases` label that is not a string literal, or case kwargs that
-      don't match the function signature.
-   4. A plain `def test_foo` that never got decorated with `@test`.
-   5. A test nested inside an `if`/`for`/`while` body — flatten.
-4. For each test present in Tryke's list but missing from pytest's, you
-   probably double-collected a `describe()` group. Fix the decorator.
-
-**Gate 3:** the two collect lists match 1:1 (modulo the documented prefix
-changes). Record the final count in `.migration/NOTES.md`.
-
-## Phase 4 — Results parity gate
-
-1. `tryke test --reporter junit > .migration/tryke-results.xml`
-2. Compare per-test outcomes against `.migration/pytest-results.xml`. The
-   JUnit `<testcase>` names do **not** match byte-for-byte — Phase 2 stripped
-   the `test_` prefix and Phase 3 may have added `describe()` group prefixes.
-   Apply the same normalization you used to pass Gate 3 before comparing:
-   - Strip the leading `test_` from pytest names
-     (`test_file.py::test_add` → `test_file.py::add`).
-   - For any test you moved under a `with describe("group"):` block, prepend
-     `group::` on the pytest side (or strip it on the Tryke side) so the
-     IDs line up.
-   - Parametrize labels (`[case_label]`) already match between systems — do
-     not rewrite them.
-
-   Then for each normalized name, compare pass / fail / skip / xfail status.
-3. For each divergence:
-   - Rerun the single test with the LLM-friendly reporter:
-     `tryke test -k <name> --reporter llm`
-     (see <https://tryke.dev/guides/reporters.html>). Feed that output back
-     through this prompt to diagnose.
-   - Common causes, in order of likelihood:
-     - Wrong assertion matcher (`to_be` vs `to_equal`, `to_contain` vs
-       `to_have_length`, forgotten `.not_`).
-     - A fixture's teardown ran at a different scope than pytest's.
-     - A soft-assertion cascade: an assertion that would have short-circuited
-       under pytest now runs and fails on a `None` the earlier assertion
-       was supposed to guard. Add `.fatal()` on the guarding assertion.
-     - `pytest.raises(match=...)` regex was rewritten instead of copied.
-4. Do not mass-add `.fatal()` to make numbers match — diagnose each case.
-
-**Gate 4:** per-test outcomes match the pytest baseline. Record the final
-counts in `.migration/NOTES.md`.
-
-## Phase 5 — Cleanup
-
-1. Remove `pytest`, `pytest-asyncio`, `pytest-xdist`, `pytest-mock` (if the
-   usage was mechanical), and other pytest-only plugins from dev
-   dependencies. Leave anything whose functionality Tryke does not yet
-   provide and flag it in `.migration/NOTES.md`.
-2. Delete empty `conftest.py` files.
-3. Update CI to call `tryke test --reporter junit` (or `--reporter llm`
-   if CI logs are consumed by an LLM) in place of `pytest`.
-4. Update the project README's testing section.
-5. Delete `.migration/` once you have committed the migration.
-
-**Gate 5:** CI is green on Tryke; pytest is no longer installed.
-
-## Reporting back
-
-After each gate, summarize in chat:
-
-- which files changed in this phase
-- the current test counts (collected / passed / failed / skipped / xfailed)
-- anything you had to skip or flag for human review
-````
+- **Weak.** `/goal migrate this repo to tryke` — no verification
+  surface, no stop condition. The agent decides what "done" means.
+- **Strong.** Reference the skill and name the gates as the
+  verification surface. The full template is on the
+  [skill page](skills/pytest-to-tryke-migration.md#invoke-codex-goal).
 
 !!! note "LLM reporter"
-    Phase 4 uses `tryke test --reporter llm` specifically because its output
-    is tuned for LLM context windows — concise, structured failure
-    diagnostics. See the [reporters guide](guides/reporters.md#llm).
+    Gate 4 in the skill uses `tryke test --reporter llm` specifically
+    because its output is tuned for LLM context windows — concise,
+    structured failure diagnostics. See the
+    [reporters guide](guides/reporters.md#llm).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -3,14 +3,13 @@
 A side-by-side guide for moving from pytest to Tryke.
 
 !!! tip "Let an LLM do the migration for you"
-    The fastest way to migrate is to hand the job to your AI coding assistant
-    (Claude Code, Cursor, Codex, Aider, etc.). We maintain a
+    The fastest way to migrate is to hand the job to your AI coding
+    assistant (Claude Code, Cursor, Codex, Aider, etc.). Install the
     [**pytest-to-tryke-migration skill**](skills/pytest-to-tryke-migration.md)
-    — installable as a Claude Code Skill or pasteable as a Codex `/goal` —
-    that walks the assistant through a **phased, gated** migration with
-    explicit discovery- and results-parity checks so nothing is silently
-    dropped or inverted. It pairs with `tryke test --reporter llm` for
-    concise, structured failure diagnostics tuned to LLM context windows.
+    — it converts one test file at a time and verifies its discovery
+    and outcomes match what pytest produced. The skill page also has a
+    Codex `/goal` template that wraps the skill for a whole-repo
+    migration.
     **[Install the migration skill &rarr;](skills/pytest-to-tryke-migration.md)**
 
 ## Cheat sheet
@@ -310,38 +309,17 @@ async def under_runner(runner):
 
 ## Migration skill
 
-The phased prompt that used to live here has moved to a Claude Code
-[**Skill**](https://docs.claude.com/en/docs/agents/skills) — also
-pasteable as a Codex [`/goal`](https://developers.openai.com/codex/use-cases/follow-goals).
-See the [pytest-to-tryke-migration skill page](skills/pytest-to-tryke-migration.md)
-for install instructions, the full SKILL.md, and the copyable
-`/goal` template.
-
-A single source of truth, shaped as a `/goal` contract (outcome →
-verification surface → constraints → boundaries → iteration policy →
-blocked stop), keeps the gates explicit no matter which assistant you
-hand the job to:
-
-- **Gate 0** — pytest baseline captured cleanly
-- **Gate 1** — tryke installed and `tryke test --collect-only` runs
-- **Gate 3** — discovery parity (no silently-dropped tests)
-- **Gate 4** — results parity (no silently-inverted assertions)
-- **Gate 5** — CI green on tryke, pytest uninstalled
-
-### Strong vs weak goals
-
-If you are driving the migration with Codex `/goal`, the docs on
-[follow-goals](https://developers.openai.com/codex/use-cases/follow-goals)
-emphasize a finish line the agent can verify. Compare:
-
-- **Weak.** `/goal migrate this repo to tryke` — no verification
-  surface, no stop condition. The agent decides what "done" means.
-- **Strong.** Reference the skill and name the gates as the
-  verification surface. The full template is on the
-  [skill page](skills/pytest-to-tryke-migration.md#invoke-codex-goal).
+For driving the migration with an AI coding assistant, install the
+[**pytest-to-tryke-migration skill**](skills/pytest-to-tryke-migration.md).
+The skill converts **one test file at a time** and verifies that
+file's discovery and outcomes match what pytest produced; a Codex
+[`/goal`](https://developers.openai.com/codex/use-cases/follow-goals)
+template on the skill page wraps it for a whole-repo migration —
+baseline capture, file-by-file iteration, and pytest removal all live
+in the goal.
 
 !!! note "LLM reporter"
-    Gate 4 in the skill uses `tryke test --reporter llm` specifically
-    because its output is tuned for LLM context windows — concise,
-    structured failure diagnostics. See the
-    [reporters guide](guides/reporters.md#llm).
+    When a converted test's outcome diverges from the pytest baseline,
+    rerun it with `tryke test -k <name> --reporter llm` — the LLM
+    reporter is tuned for context windows and gives concise, structured
+    failure diagnostics. See the [reporters guide](guides/reporters.md#llm).

--- a/docs/skills/pytest-to-tryke-migration.md
+++ b/docs/skills/pytest-to-tryke-migration.md
@@ -1,26 +1,18 @@
 # pytest → Tryke migration skill
 
-A Claude Code [Skill][skills] (also pasteable as a Codex
-[`/goal`][goals]) that walks an AI coding assistant through a
-**phased, gated** migration from pytest to Tryke. It pairs with
-`tryke test --reporter llm` for concise, structured failure
-diagnostics tuned to LLM context windows.
+A Claude Code [Skill][skills] that converts **one pytest test file**
+(or a small package) to Tryke and verifies the converted file's
+outcomes match what pytest produced for it.
 
-The skill encodes a `/goal`-shaped contract — outcome, verification
-surface, constraints, boundaries, iteration policy, and an explicit
-blocked-stop condition — so the assistant has a real finish line
-instead of a vibe. The five gates (baseline capture, tryke install,
-**discovery parity**, **results parity**, CI cutover) catch the
-silent failure modes that ruin migrations: tests that stopped being
-collected, or assertions that quietly inverted.
+The skill is the unit of work, not the whole migration. Repo-level
+orchestration — baseline capture, iteration across files, whole-suite
+parity gates, removing pytest from dev deps — lives in a Codex
+[`/goal`][goals] that invokes the skill once per file.
 
 [skills]: https://docs.claude.com/en/docs/agents/skills
 [goals]: https://developers.openai.com/codex/use-cases/follow-goals
 
 ## Install
-
-Drop the canonical SKILL.md into your project's `.claude/skills/`
-directory:
 
 ```bash
 mkdir -p .claude/skills/pytest-to-tryke-migration
@@ -31,83 +23,71 @@ curl -fsSL https://raw.githubusercontent.com/thejchap/tryke/main/.claude/skills/
 Commit the file alongside your other project tooling so every fresh
 session picks it up.
 
-## Invoke (Claude Code)
+## Invoke per-file (Claude Code)
 
-Open Claude Code in the repo and ask:
+Point Claude Code at a specific file:
 
-> Migrate this repo from pytest to tryke.
+> Migrate `tests/test_widgets.py` from pytest to tryke.
 
-The skill auto-activates on the migration intent + the pytest
-fingerprint (a `conftest.py`, `test_*.py` files, or `pytest` in
-`pyproject.toml` / `requirements*.txt` / `setup.cfg`). The assistant
-will run the phases, write artifacts under `.migration/`, and stop at
-each gate to confirm parity.
+The skill activates, applies the conversions, and verifies that the
+file's tryke discovery and outcomes match what pytest produced. Repeat
+file by file, committing after each.
 
-## Invoke (Codex `/goal`)
+## Drive the whole migration with `/goal`
 
-The skill's **Goal contract** section maps 1:1 to the Codex goal
-template. Paste this as your goal:
+For a full-repo migration, paste this as a Codex goal. It captures a
+baseline, iterates file-by-file invoking the skill, and stops when
+discovery + outcomes parity is satisfied and pytest is removed:
 
+```text
+/goal Migrate this repository from pytest to tryke. Use the
+pytest-to-tryke-migration skill once per test file.
+
+Before starting:
+- Capture baseline: `pytest --collect-only -q > .migration/baseline-collect.txt`
+  and `pytest --junit-xml=.migration/baseline-results.xml`. Add
+  `.migration/` to .gitignore.
+- Install tryke as a dev dep and add a `[tool.tryke]` section
+  mirroring the pytest testpaths.
+
+Iterate: for each test file under the configured testpaths, invoke the
+skill, then commit and push. Use sub-agents to parallelize batches if
+the suite is large.
+
+Done when:
+- `tryke test --collect-only` matches the baseline 1:1, modulo the
+  `test_` prefix strip and any added describe() group prefixes.
+- `tryke test --reporter junit` per-test outcomes match
+  .migration/baseline-results.xml after the same normalization.
+- pytest and its mechanically-replaced plugins (pytest-asyncio,
+  pytest-xdist, pytest-mock) are removed from dev deps.
+- CI calls `tryke test` and is green.
+
+Stop and ask if: a file's converted discovery or outcomes diverge in
+ways the skill's Step 3 troubleshooting can't explain; a Depends()
+typing error would require cast/ignore to silence; or you would need
+to mass-add .fatal() to satisfy the outcome parity check.
 ```
-/goal Migrate this repository from pytest to Tryke under the
-pytest-to-tryke-migration skill at
-.claude/skills/pytest-to-tryke-migration/SKILL.md. Done when Gates 0
-through 5 all pass: pytest baseline captured cleanly, tryke
-configured, discovery parity matches, per-test results parity
-matches the captured pytest JUnit XML, and pytest is removed from
-dev dependencies with CI green on tryke. Work one package at a
-time; commit and push after every file; maintain .migration/NOTES.md,
-PATTERNS.md, and CURRENT.md across sessions. Use `tryke test
---reporter llm` for any single-test diagnostic rerun. Stop and ask if
-a gate fails and the mismatch is non-trivial, if a typing error on
-Depends() would require a cast/ignore to silence, or if you would
-need to mass-add .fatal() to satisfy Gate 4.
-```
-
-Use `/goal` to inspect status, pause, resume, or clear between
-checkpoints.
 
 ### Strong vs weak goals
 
-The `/goal` documentation makes a sharp distinction:
+The [follow-goals][goals] docs emphasize a finish line the agent can
+verify. Compare:
 
 - **Weak.** `/goal migrate this repo to tryke` — no verification
-  surface, no stop condition, no constraints. The agent decides
-  what "done" means and you find out at the end.
-- **Strong.** The template above — names the five gates as the
-  verification surface, pins down what must not regress, and gives
+  surface, no stop condition. The agent decides what "done" means.
+- **Strong.** The template above — names the baseline as the
+  verification surface, defines what must be true at done, and gives
   the agent an unambiguous blocked-stop condition.
 
-Treat the strong template as a starting point. Add repo-specific
-constraints (e.g. "do not touch `tests/integration/` — that suite
-already uses tryke") inline before pasting.
-
-## What the skill contains
-
-A summary of the SKILL.md sections, in order:
-
-1. **When to use this skill** — activation triggers.
-2. **Goal contract** — outcome, verification surface (Gates 0–5),
-   constraints, boundaries, iteration policy, blocked stop condition.
-3. **Working across sessions** — the three `.migration/` files
-   (`NOTES.md`, `PATTERNS.md`, `CURRENT.md`) that keep multi-session
-   migrations continuous.
-4. **Committing and pushing** — commit-after-every-file cadence and
-   why local-only work is invisible to the next session.
-5. **Phases -1 → 5** — the executable plan. Each phase names its
-   gate.
-6. **Reporting back** — what to summarize after each gate.
-7. **Using with `/goal` (Codex)** — the copyable strong-goal
-   template.
-
-See the full file on GitHub:
-<https://github.com/thejchap/tryke/blob/main/.claude/skills/pytest-to-tryke-migration/SKILL.md>.
+Edit the template with repo-specific constraints before pasting (e.g.
+"skip `tests/integration/` — it already uses tryke").
 
 ## See also
 
 - [Migration cheat sheet](../migration.md) — the conversion reference
-  the skill points the assistant at for mechanical translations.
+  the skill points at for mechanical translations.
 - [LLM reporter](../guides/reporters.md#llm) — the reporter the skill
-  uses for single-test diagnostic reruns at Gate 4.
+  uses for single-test diagnostic reruns when an outcome diverges.
 - [Soft assertions](../concepts/soft-assertions.md) — why the skill
   forbids reflexive `.fatal()`.

--- a/docs/skills/pytest-to-tryke-migration.md
+++ b/docs/skills/pytest-to-tryke-migration.md
@@ -1,0 +1,113 @@
+# pytest → Tryke migration skill
+
+A Claude Code [Skill][skills] (also pasteable as a Codex
+[`/goal`][goals]) that walks an AI coding assistant through a
+**phased, gated** migration from pytest to Tryke. It pairs with
+`tryke test --reporter llm` for concise, structured failure
+diagnostics tuned to LLM context windows.
+
+The skill encodes a `/goal`-shaped contract — outcome, verification
+surface, constraints, boundaries, iteration policy, and an explicit
+blocked-stop condition — so the assistant has a real finish line
+instead of a vibe. The five gates (baseline capture, tryke install,
+**discovery parity**, **results parity**, CI cutover) catch the
+silent failure modes that ruin migrations: tests that stopped being
+collected, or assertions that quietly inverted.
+
+[skills]: https://docs.claude.com/en/docs/agents/skills
+[goals]: https://developers.openai.com/codex/use-cases/follow-goals
+
+## Install
+
+Drop the canonical SKILL.md into your project's `.claude/skills/`
+directory:
+
+```bash
+mkdir -p .claude/skills/pytest-to-tryke-migration
+curl -fsSL https://raw.githubusercontent.com/thejchap/tryke/main/.claude/skills/pytest-to-tryke-migration/SKILL.md \
+  -o .claude/skills/pytest-to-tryke-migration/SKILL.md
+```
+
+Commit the file alongside your other project tooling so every fresh
+session picks it up.
+
+## Invoke (Claude Code)
+
+Open Claude Code in the repo and ask:
+
+> Migrate this repo from pytest to tryke.
+
+The skill auto-activates on the migration intent + the pytest
+fingerprint (a `conftest.py`, `test_*.py` files, or `pytest` in
+`pyproject.toml` / `requirements*.txt` / `setup.cfg`). The assistant
+will run the phases, write artifacts under `.migration/`, and stop at
+each gate to confirm parity.
+
+## Invoke (Codex `/goal`)
+
+The skill's **Goal contract** section maps 1:1 to the Codex goal
+template. Paste this as your goal:
+
+```
+/goal Migrate this repository from pytest to Tryke under the
+pytest-to-tryke-migration skill at
+.claude/skills/pytest-to-tryke-migration/SKILL.md. Done when Gates 0
+through 5 all pass: pytest baseline captured cleanly, tryke
+configured, discovery parity matches, per-test results parity
+matches the captured pytest JUnit XML, and pytest is removed from
+dev dependencies with CI green on tryke. Work one package at a
+time; commit and push after every file; maintain .migration/NOTES.md,
+PATTERNS.md, and CURRENT.md across sessions. Use `tryke test
+--reporter llm` for any single-test diagnostic rerun. Stop and ask if
+a gate fails and the mismatch is non-trivial, if a typing error on
+Depends() would require a cast/ignore to silence, or if you would
+need to mass-add .fatal() to satisfy Gate 4.
+```
+
+Use `/goal` to inspect status, pause, resume, or clear between
+checkpoints.
+
+### Strong vs weak goals
+
+The `/goal` documentation makes a sharp distinction:
+
+- **Weak.** `/goal migrate this repo to tryke` — no verification
+  surface, no stop condition, no constraints. The agent decides
+  what "done" means and you find out at the end.
+- **Strong.** The template above — names the five gates as the
+  verification surface, pins down what must not regress, and gives
+  the agent an unambiguous blocked-stop condition.
+
+Treat the strong template as a starting point. Add repo-specific
+constraints (e.g. "do not touch `tests/integration/` — that suite
+already uses tryke") inline before pasting.
+
+## What the skill contains
+
+A summary of the SKILL.md sections, in order:
+
+1. **When to use this skill** — activation triggers.
+2. **Goal contract** — outcome, verification surface (Gates 0–5),
+   constraints, boundaries, iteration policy, blocked stop condition.
+3. **Working across sessions** — the three `.migration/` files
+   (`NOTES.md`, `PATTERNS.md`, `CURRENT.md`) that keep multi-session
+   migrations continuous.
+4. **Committing and pushing** — commit-after-every-file cadence and
+   why local-only work is invisible to the next session.
+5. **Phases -1 → 5** — the executable plan. Each phase names its
+   gate.
+6. **Reporting back** — what to summarize after each gate.
+7. **Using with `/goal` (Codex)** — the copyable strong-goal
+   template.
+
+See the full file on GitHub:
+<https://github.com/thejchap/tryke/blob/main/.claude/skills/pytest-to-tryke-migration/SKILL.md>.
+
+## See also
+
+- [Migration cheat sheet](../migration.md) — the conversion reference
+  the skill points the assistant at for mechanical translations.
+- [LLM reporter](../guides/reporters.md#llm) — the reporter the skill
+  uses for single-test diagnostic reruns at Gate 4.
+- [Soft assertions](../concepts/soft-assertions.md) — why the skill
+  forbids reflexive `.fatal()`.

--- a/zensical.toml
+++ b/zensical.toml
@@ -23,6 +23,7 @@ nav = [
     "guides/configuration.md",
     "guides/editor-integration.md",
     "migration.md",
+    "skills/pytest-to-tryke-migration.md",
   ] },
   { "Concepts" = [
     "concepts/discovery.md",


### PR DESCRIPTION
The phased migration prompt that lived inline in docs/migration.md is
now a Claude Code Skill at .claude/skills/pytest-to-tryke-migration/,
authored in /goal shape (outcome, verification surface, constraints,
boundaries, iteration policy, blocked stop condition) so the same file
works for skill auto-activation and Codex /goal. docs/migration.md
keeps the cheat sheet and gains a short pointer + strong-vs-weak goal
example; the new docs/skills/ page has install instructions and the
copyable goal template. zensical.toml exposes the page in nav.