### PR TITLE
Close stale worker race with in-band did_change RPC

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'/Users/justinchapman/src/tryke/.codex/hooks/session-start.sh'"
+            "command": "\"$(git rev-parse --show-toplevel)/.codex/hooks/session-start.sh\""
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'/Users/justinchapman/src/tryke/.codex/hooks/session-start.sh'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/session-start.sh
+++ b/.codex/hooks/session-start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+# Installs cargo-nextest (the project's canonical test runner per CLAUDE.md)
+# and pre-warms the Rust + Python test suites.
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+
+# Install cargo-nextest if missing. `cargo install --locked` is idempotent:
+# it skips reinstall when the binary is already at the requested version.
+if ! command -v cargo-nextest >/dev/null 2>&1; then
+  cargo install cargo-nextest --locked
+fi

--- a/.codex/hooks/session-start.sh
+++ b/.codex/hooks/session-start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SessionStart hook for Claude Code on the web.
 # Installs cargo-nextest (the project's canonical test runner per CLAUDE.md)
-# and pre-warms the Rust + Python test suites.
+# if it is not already available.
 set -euo pipefail
 
 cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"

--- a/.codex/hooks/session-start.sh
+++ b/.codex/hooks/session-start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SessionStart hook for Claude Code on the web.
+# SessionStart hook for Codex (wired via .codex/hooks.json).
 # Installs cargo-nextest (the project's canonical test runner per CLAUDE.md)
 # if it is not already available.
 set -euo pipefail

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Context
+
+<!--
+Links, related issues, or brief background.
+-->
+
+## Changes
+
+<!--
+Concise summary of what changed.
+-->
+
+## Test plan
+
+<!--
+Commands run and any rollout notes.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ cargo nextest run --workspace --all-features
 - get your tests to pass. if you didn't run the tests, your code does not work.
 - follow existing code style. check neighboring files for patterns.
 - always run uvx prek run -a at the end of a task.
+- When opening a PR, use `.github/pull_request_template.md` and keep each section concise.
 - avoid falling back to patterns that require panic!, unreachable!, or .unwrap().
 Instead, try to encode those constraints in the type system.
 - prefer let chains (if let combined with &&) over nested if let statements

--- a/README.md
+++ b/README.md
@@ -72,9 +72,8 @@ uvx tryke test
 <!-- REPORTER:text:plain:START -->
 
 ```text
-tryke test v0.0.28
+tryke test v0.0.27
 
-warning: scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
 sample.py:
   users
     get

--- a/crates/tryke_discovery/src/discoverer.rs
+++ b/crates/tryke_discovery/src/discoverer.rs
@@ -454,6 +454,24 @@ impl Discoverer {
             .collect()
     }
 
+    /// `true` if `path` is excluded from discovery by the project's
+    /// `.gitignore`, `.ignore`, or `[tool.tryke] exclude` rules — the
+    /// same layered matcher the FS watcher uses to decide which file
+    /// changes to act on.
+    ///
+    /// Builds the matcher per call. That's intentional: discovery
+    /// callers invoke this at most a handful of times per save
+    /// (`apply_change` calls it once per change set), so the per-call
+    /// build is negligible and keeps construction free of `OnceCell`
+    /// / `Arc` machinery. If a hot path ever needs many calls, cache
+    /// at the caller.
+    #[must_use]
+    pub fn is_excluded(&self, path: &Path) -> bool {
+        crate::build_change_set_ignore(&self.root, &self.excludes)
+            .matched_path_or_any_parents(path, false)
+            .is_ignore()
+    }
+
     pub fn rediscover_changed(&mut self, changed: &[PathBuf]) -> Vec<TestItem> {
         let changed = Self::canonicalize_paths(changed);
         debug!(

--- a/crates/tryke_discovery/src/discoverer.rs
+++ b/crates/tryke_discovery/src/discoverer.rs
@@ -437,6 +437,23 @@ impl Discoverer {
             .collect()
     }
 
+    /// Drop paths that don't fall under the project root.
+    ///
+    /// Used by callers that take untrusted input (notably the server's
+    /// `did_change` RPC handler, where a local process could otherwise
+    /// pass `/etc/passwd` and pollute the import graph by getting
+    /// `path_to_module` to return an empty string and `rediscover_changed`
+    /// to slurp arbitrary disk content). Canonicalises both sides so
+    /// macOS's `/var → /private/var` symlink and similar cases compare
+    /// correctly.
+    pub fn filter_in_root(&self, paths: &[PathBuf]) -> Vec<PathBuf> {
+        let canonical_root = Self::canonicalize_path(&self.root);
+        Self::canonicalize_paths(paths)
+            .into_iter()
+            .filter(|p| p.starts_with(&canonical_root))
+            .collect()
+    }
+
     pub fn rediscover_changed(&mut self, changed: &[PathBuf]) -> Vec<TestItem> {
         let changed = Self::canonicalize_paths(changed);
         debug!(

--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -43,6 +43,28 @@ fn build_excludes(root: &Path, excludes: &[String]) -> Gitignore {
     builder.build().unwrap_or_else(|_| Gitignore::empty())
 }
 
+/// Build the full ignore matcher used to decide whether an incoming
+/// path (from the FS watcher or a `did_change` RPC) should reach
+/// discovery. Layers `.gitignore`, `.ignore`, and the project's
+/// `[tool.tryke] exclude` list — same composition the FS watcher uses,
+/// extracted so the `did_change` path stays consistent.
+///
+/// Returns an empty matcher (matches nothing) on build failure rather
+/// than propagating an error, matching the watcher's existing
+/// behaviour: degraded into "let everything through" is preferable to
+/// blocking discovery entirely.
+#[must_use]
+pub fn build_change_set_ignore(root: &Path, excludes: &[String]) -> Gitignore {
+    let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let mut builder = GitignoreBuilder::new(&canonical);
+    let _ = builder.add(canonical.join(".gitignore"));
+    let _ = builder.add(canonical.join(".ignore"));
+    for exclude in excludes {
+        let _ = builder.add_line(None, exclude);
+    }
+    builder.build().unwrap_or_else(|_| Gitignore::empty())
+}
+
 pub(crate) fn collect_python_files(root: &Path, excludes: &[String]) -> Vec<PathBuf> {
     let exclude_matcher = build_excludes(root, excludes);
     WalkBuilder::new(root)

--- a/crates/tryke_server/src/change.rs
+++ b/crates/tryke_server/src/change.rs
@@ -51,6 +51,19 @@ pub(crate) async fn apply_change(
         let modules = guard.affected_modules(paths);
         guard.rediscover_changed(paths);
         let tests = guard.tests_for_changed(paths);
+        // Set `dirty` *inside* the disc.lock critical section. Paired
+        // with `execute_run`'s drain (which also happens inside its
+        // disc.lock guard), this serialises the "discovery is updated
+        // AND workers need restart" transition: a concurrent run can't
+        // read tests refreshed by this apply_change while observing
+        // dirty=false. Without this ordering, a run could acquire
+        // disc.lock between our release and the dirty.store, snapshot
+        // the new tests, and dispatch on workers whose `sys.modules`
+        // still reflect the *previous* discovery — exactly the race
+        // the in-band `did_change` is here to close.
+        if !modules.is_empty() {
+            dirty.store(true, Ordering::Release);
+        }
         (modules, tests)
     };
 
@@ -62,10 +75,6 @@ pub(crate) async fn apply_change(
             modules.len(),
             modules.join(", ")
         );
-        // Release on the store pairs with the AcqRel swap in
-        // execute_run: any per-connection `run` whose handler reads
-        // `dirty` after this point is guaranteed to observe `true`.
-        dirty.store(true, Ordering::Release);
     }
 
     debug!("apply_change: {} affected tests", tests.len());

--- a/crates/tryke_server/src/change.rs
+++ b/crates/tryke_server/src/change.rs
@@ -48,28 +48,31 @@ pub(crate) async fn apply_change(
 
     let (modules, tests) = {
         let mut guard = disc.lock().await;
-        // Two filters on the way in:
-        //   1. Drop anything outside the project root. The FS watcher
-        //      already emits only in-tree paths, so this is a no-op
-        //      for that caller; for `did_change` (which accepts
-        //      client-supplied paths over TCP) it stops a local
-        //      process from polluting the import graph with files
-        //      outside the workspace.
-        //   2. Drop non-`.py` files. `Discoverer::rediscover_changed`
-        //      silently ignores them, but `affected_modules` doesn't
-        //      know about extensions — it would turn `README.md` into
-        //      a "module" entry, making `modules.is_empty()` false and
-        //      spuriously marking the pool dirty (→ unnecessary worker
-        //      restart on the next run). The FS watcher filters at
-        //      watcher.rs:42, so again this is a no-op for that path
-        //      and a correctness fix for `did_change`.
+        // Three filters on the way in. All three are no-ops for the
+        // FS watcher caller (it filters upstream); they're a
+        // correctness fix for the `did_change` caller, which takes
+        // client-supplied paths over TCP and must defend itself.
+        //   1. In-root. Stops `/etc/passwd` and similar from reaching
+        //      discovery, where `path_to_module` would otherwise turn
+        //      it into a phantom module entry.
+        //   2. `.py` extension. `rediscover_changed` already silently
+        //      ignores non-Python files, but `affected_modules` would
+        //      turn `README.md` into a bogus module name, spuriously
+        //      marking the pool dirty (→ unnecessary worker restart).
+        //   3. Not excluded by gitignore / .ignore / [tool.tryke]
+        //      exclude. `.venv/`, vendored deps, etc. — same matcher
+        //      the FS watcher applies at watcher.rs:43-47. Without
+        //      this a client could ingest `.venv/whatever.py` into
+        //      discovery (and any subsequent `run` would try to
+        //      import + execute it).
         let paths: Vec<PathBuf> = guard
             .filter_in_root(paths)
             .into_iter()
             .filter(|p| p.extension().is_some_and(|ext| ext == "py"))
+            .filter(|p| !guard.is_excluded(p))
             .collect();
         if paths.is_empty() {
-            debug!("apply_change: no in-root Python paths — skipping");
+            debug!("apply_change: no eligible paths — skipping");
             return;
         }
         let modules = guard.affected_modules(&paths);

--- a/crates/tryke_server/src/change.rs
+++ b/crates/tryke_server/src/change.rs
@@ -48,16 +48,28 @@ pub(crate) async fn apply_change(
 
     let (modules, tests) = {
         let mut guard = disc.lock().await;
-        // Drop anything outside the project root before doing any
-        // discovery work. The FS watcher already emits only in-tree
-        // paths, so this is a no-op for that caller; for `did_change`
-        // (which accepts client-supplied paths over TCP) it stops a
-        // local process from polluting the import graph with arbitrary
-        // files. `Discoverer::filter_in_root` does the canonicalisation
-        // both sides need.
-        let paths = guard.filter_in_root(paths);
+        // Two filters on the way in:
+        //   1. Drop anything outside the project root. The FS watcher
+        //      already emits only in-tree paths, so this is a no-op
+        //      for that caller; for `did_change` (which accepts
+        //      client-supplied paths over TCP) it stops a local
+        //      process from polluting the import graph with files
+        //      outside the workspace.
+        //   2. Drop non-`.py` files. `Discoverer::rediscover_changed`
+        //      silently ignores them, but `affected_modules` doesn't
+        //      know about extensions — it would turn `README.md` into
+        //      a "module" entry, making `modules.is_empty()` false and
+        //      spuriously marking the pool dirty (→ unnecessary worker
+        //      restart on the next run). The FS watcher filters at
+        //      watcher.rs:42, so again this is a no-op for that path
+        //      and a correctness fix for `did_change`.
+        let paths: Vec<PathBuf> = guard
+            .filter_in_root(paths)
+            .into_iter()
+            .filter(|p| p.extension().is_some_and(|ext| ext == "py"))
+            .collect();
         if paths.is_empty() {
-            debug!("apply_change: all paths outside project root — skipping");
+            debug!("apply_change: no in-root Python paths — skipping");
             return;
         }
         let modules = guard.affected_modules(&paths);

--- a/crates/tryke_server/src/change.rs
+++ b/crates/tryke_server/src/change.rs
@@ -48,9 +48,21 @@ pub(crate) async fn apply_change(
 
     let (modules, tests) = {
         let mut guard = disc.lock().await;
-        let modules = guard.affected_modules(paths);
-        guard.rediscover_changed(paths);
-        let tests = guard.tests_for_changed(paths);
+        // Drop anything outside the project root before doing any
+        // discovery work. The FS watcher already emits only in-tree
+        // paths, so this is a no-op for that caller; for `did_change`
+        // (which accepts client-supplied paths over TCP) it stops a
+        // local process from polluting the import graph with arbitrary
+        // files. `Discoverer::filter_in_root` does the canonicalisation
+        // both sides need.
+        let paths = guard.filter_in_root(paths);
+        if paths.is_empty() {
+            debug!("apply_change: all paths outside project root — skipping");
+            return;
+        }
+        let modules = guard.affected_modules(&paths);
+        guard.rediscover_changed(&paths);
+        let tests = guard.tests_for_changed(&paths);
         // Set `dirty` *inside* the disc.lock critical section. Paired
         // with `execute_run`'s drain (which also happens inside its
         // disc.lock guard), this serialises the "discovery is updated

--- a/crates/tryke_server/src/change.rs
+++ b/crates/tryke_server/src/change.rs
@@ -1,0 +1,81 @@
+//! Shared "apply a file-change batch" helper used by both the FS watcher
+//! task (`server.rs`) and the `did_change` RPC handler (`handler.rs`).
+//!
+//! Centralises the steps that must happen for every accepted change set:
+//!   1. ask `Discoverer::affected_modules` which Python modules the change
+//!      reaches
+//!   2. `rediscover_changed` to refresh the discovery cache for those files
+//!   3. compute `tests_for_changed` for the broadcast payload
+//!   4. mark the worker pool `dirty` (next `run` will drain → restart)
+//!   5. broadcast `discover_complete` so connected clients can refresh
+//!
+//! Keeping these steps in one place guarantees the FS path and the RPC
+//! path stay semantically identical — important because the RPC path is
+//! what closes the race for cooperating clients, and the FS path is what
+//! covers everyone else.
+
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use bytes::Bytes;
+use log::debug;
+use tokio::sync::{Mutex, broadcast};
+use tryke_discovery::Discoverer;
+
+use crate::protocol::{DiscoverCompleteParams, Notification};
+
+/// Apply an accepted file-change batch to the shared discovery cache and
+/// signal that the worker pool needs to be restarted before the next
+/// dispatch.
+///
+/// Idempotent: calling twice with the same paths (e.g. once from
+/// `did_change`, once from the FS watcher a few ms later) is harmless —
+/// `rediscover_changed` re-reads the same files, the atomic store is a
+/// no-op when `dirty` is already `true`, and the second
+/// `discover_complete` broadcast is a duplicate that client-side
+/// suppression can drop.
+pub(crate) async fn apply_change(
+    disc: &Mutex<Discoverer>,
+    bcast_tx: &broadcast::Sender<Bytes>,
+    dirty: &AtomicBool,
+    paths: &[PathBuf],
+) {
+    if paths.is_empty() {
+        return;
+    }
+
+    let (modules, tests) = {
+        let mut guard = disc.lock().await;
+        let modules = guard.affected_modules(paths);
+        guard.rediscover_changed(paths);
+        let tests = guard.tests_for_changed(paths);
+        (modules, tests)
+    };
+
+    if modules.is_empty() {
+        debug!("apply_change: no modules affected — skipping dirty mark");
+    } else {
+        debug!(
+            "apply_change: marking pool dirty for {} module(s): {}",
+            modules.len(),
+            modules.join(", ")
+        );
+        // Release on the store pairs with the AcqRel swap in
+        // execute_run: any per-connection `run` whose handler reads
+        // `dirty` after this point is guaranteed to observe `true`.
+        dirty.store(true, Ordering::Release);
+    }
+
+    debug!("apply_change: {} affected tests", tests.len());
+    let notif = Notification {
+        jsonrpc: "2.0".to_string(),
+        method: "discover_complete".to_string(),
+        params: DiscoverCompleteParams { tests },
+    };
+    if let Ok(mut bytes) = serde_json::to_vec(&notif) {
+        bytes.push(b'\n');
+        let _ = bcast_tx.send(Bytes::from(bytes));
+    }
+}

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -785,6 +785,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn did_change_excluded_paths_do_not_reach_discovery() {
+        // The FS watcher applies `.gitignore` + `[tool.tryke] exclude`
+        // before calling apply_change. Without parity in the
+        // `did_change` path, a cooperating-but-misconfigured (or
+        // malicious-local) client could ingest a `.venv/whatever.py`
+        // into the import graph — and a subsequent `run` would try
+        // to import + execute it.
+        let dir = make_root();
+        // Discoverer constructed with an explicit exclude (mirroring
+        // `[tool.tryke] exclude = ["vendored/**"]`). The path we send
+        // lives under that excluded prefix.
+        let excluded_dir = dir.path().join("vendored");
+        fs::create_dir(&excluded_dir).expect("mkdir");
+        let excluded_file = excluded_dir.join("test_vendored.py");
+        fs::write(&excluded_file, "@test\ndef test_v(): pass\n").expect("write");
+
+        let (tx, _rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new_with_excludes(
+            dir.path(),
+            &["vendored/**".to_string()],
+        )));
+        disc.lock().await.rediscover();
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+
+        let req = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "did_change",
+            "params": { "paths": [excluded_file] },
+        }))
+        .unwrap();
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["result"], "ok");
+        assert!(
+            !dirty.load(std::sync::atomic::Ordering::Acquire),
+            "excluded path must not mark the pool dirty",
+        );
+    }
+
+    #[tokio::test]
     async fn did_change_non_py_paths_do_not_mark_dirty() {
         // A `did_change` for non-Python files (README.md, pyproject.toml,
         // config dotfiles) must NOT mark the pool dirty — those changes

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -1,6 +1,14 @@
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Instant,
+};
 
 use bytes::Bytes;
+use log::debug;
 use serde_json::Value;
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
@@ -13,9 +21,9 @@ use tryke_types::filter::TestFilter;
 use tryke_types::{RunSummary, TestOutcome};
 
 use crate::protocol::{
-    DiscoverCompleteParams, DiscoverParams, ErrorResponse, INVALID_PARAMS, METHOD_NOT_FOUND,
-    Notification, Request, Response, RpcError, RunCompleteParams, RunParams, RunResponse,
-    RunStartParams, TestCompleteParams,
+    DidChangeParams, DiscoverCompleteParams, DiscoverParams, ErrorResponse, INVALID_PARAMS,
+    METHOD_NOT_FOUND, Notification, Request, Response, RpcError, RunCompleteParams, RunParams,
+    RunResponse, RunStartParams, TestCompleteParams,
 };
 
 pub struct ConnectionHandler {
@@ -25,6 +33,14 @@ pub struct ConnectionHandler {
     broadcast_tx: broadcast::Sender<Bytes>,
     pool: Arc<WorkerPool>,
     run_lock: Arc<Mutex<()>>,
+    /// Set to `true` by the watcher whenever an accepted file-change
+    /// batch affects at least one module. `execute_run` swaps this to
+    /// `false` while holding `run_lock` and, if it was `true`, calls
+    /// `pool.restart_workers().await` before dispatching units. This
+    /// closes the race where a `run` request lands inside the watcher's
+    /// debounce window and would otherwise hit a worker whose cached
+    /// `sys.modules` predates the latest save.
+    dirty: Arc<AtomicBool>,
 }
 
 impl ConnectionHandler {
@@ -35,6 +51,7 @@ impl ConnectionHandler {
         broadcast_tx: broadcast::Sender<Bytes>,
         pool: Arc<WorkerPool>,
         run_lock: Arc<Mutex<()>>,
+        dirty: Arc<AtomicBool>,
     ) -> Self {
         Self {
             stream,
@@ -43,6 +60,7 @@ impl ConnectionHandler {
             broadcast_tx,
             pool,
             run_lock,
+            dirty,
         }
     }
 
@@ -78,9 +96,11 @@ impl ConnectionHandler {
                     let bcast_tx = self.broadcast_tx.clone();
                     let pool = Arc::clone(&self.pool);
                     let run_lock = Arc::clone(&self.run_lock);
+                    let dirty = Arc::clone(&self.dirty);
                     let line_owned = line.clone();
                     let response =
-                        handle_request(&line_owned, &disc, &bcast_tx, &pool, &run_lock).await;
+                        handle_request(&line_owned, &disc, &bcast_tx, &pool, &run_lock, &dirty)
+                            .await;
                     if let Some(bytes) = response {
                         let mut w = writer.lock().await;
                         if w.write_all(&bytes).await.is_err() || w.flush().await.is_err() {
@@ -139,12 +159,31 @@ async fn execute_run(
     bcast_tx: &broadcast::Sender<Bytes>,
     pool: &WorkerPool,
     run_lock: &Mutex<()>,
+    dirty: &AtomicBool,
 ) -> (String, RunSummary) {
     let run_id = rp.run_id.clone();
     // Serialize concurrent runs: only one run at a time may dispatch units
     // onto the shared pool, so per-module fixture state (and test_complete
     // notification ordering) is not interleaved across clients.
     let _run_guard = run_lock.lock().await;
+
+    // Drain the dirty flag before dispatching. The flag is set by:
+    //   - the FS watcher task (server.rs) on an accepted file-change batch,
+    //     for clients that don't proactively notify; and
+    //   - the `did_change` RPC handler (below), for cooperating clients
+    //     (neotest-tryke sends `did_change` on the same TCP connection
+    //     immediately before `run`).
+    // Cooperating clients are guaranteed to see `dirty=true` here because
+    // per-connection read+dispatch is serial (handler.rs:72-92): the
+    // `did_change` handler's `dirty.store(true, Release)` completes
+    // before the `run` line is even read off the socket.
+    // For non-cooperating clients, `dirty` may be false if their `run`
+    // raced the watcher's debounce — they'll see the same eventually-
+    // consistent behaviour as today's FS-only design.
+    if dirty.swap(false, Ordering::AcqRel) {
+        debug!("execute_run: dirty drained — restarting worker pool");
+        pool.restart_workers().await;
+    }
 
     let discovery_start = Instant::now();
     let guard = disc.lock().await;
@@ -248,6 +287,7 @@ pub async fn handle_request(
     bcast_tx: &broadcast::Sender<Bytes>,
     pool: &WorkerPool,
     run_lock: &Mutex<()>,
+    dirty: &AtomicBool,
 ) -> Option<Vec<u8>> {
     let req: Request = serde_json::from_str(line.trim()).ok()?;
     let id = req.id.clone().unwrap_or(Value::Null);
@@ -265,6 +305,42 @@ pub async fn handle_request(
                 },
             );
             serialize_response(id, serde_json::json!({ "tests": tests }))
+        }
+        "did_change" => {
+            // In-band signal from a cooperating client (e.g. neotest-tryke's
+            // BufWritePost autocmd) that the listed paths just changed on
+            // disk. Refresh discovery and mark `dirty` synchronously, so a
+            // subsequent `run` on the *same TCP connection* is guaranteed
+            // to drain a `true` flag and restart the worker pool before
+            // dispatch. See `crate::change::apply_change` for the shared
+            // body (also called by the FS watcher task).
+            let Some(params) = req.params else {
+                return serialize_error(
+                    req.id,
+                    INVALID_PARAMS,
+                    "method 'did_change' requires params with paths".to_string(),
+                );
+            };
+            let dc = match serde_json::from_value::<DidChangeParams>(params) {
+                Ok(dc) => dc,
+                Err(e) => {
+                    return serialize_error(
+                        req.id,
+                        INVALID_PARAMS,
+                        format!("invalid params for 'did_change': {e}"),
+                    );
+                }
+            };
+            if dc.paths.is_empty() {
+                // Panic-button form: client doesn't know what changed.
+                // Force a full rediscover and mark dirty.
+                let _ = disc.lock().await.rediscover();
+                dirty.store(true, std::sync::atomic::Ordering::Release);
+                debug!("did_change: empty paths — full rediscover + dirty mark");
+            } else {
+                crate::change::apply_change(disc, bcast_tx, dirty, &dc.paths).await;
+            }
+            serialize_response(id, "ok")
         }
         "run" => {
             let Some(params) = req.params else {
@@ -284,7 +360,7 @@ pub async fn handle_request(
                     );
                 }
             };
-            let (run_id, summary) = execute_run(rp, disc, bcast_tx, pool, run_lock).await;
+            let (run_id, summary) = execute_run(rp, disc, bcast_tx, pool, run_lock, dirty).await;
             serialize_response(id, RunResponse { run_id, summary })
         }
         _ => serialize_error(
@@ -331,6 +407,10 @@ mod tests {
         Arc::new(Mutex::new(()))
     }
 
+    fn make_dirty() -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(false))
+    }
+
     #[tokio::test]
     async fn ping_returns_pong() {
         let dir = make_root();
@@ -338,12 +418,14 @@ mod tests {
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
         let resp = handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#,
             &disc,
             &tx,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await
         .unwrap();
@@ -360,12 +442,14 @@ mod tests {
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
         let resp = handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"discover","params":{"root":"/ignored"}}"#,
             &disc,
             &tx,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await
         .unwrap();
@@ -380,12 +464,14 @@ mod tests {
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
         handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"root":"/ignored","tests":null,"run_id":"r1"}}"#,
             &disc,
             &tx,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await;
 
@@ -407,12 +493,14 @@ mod tests {
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
         let resp = handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"tests":null}}"#,
             &disc,
             &tx,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await
         .unwrap();
@@ -427,12 +515,14 @@ mod tests {
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
         let resp = handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"run_id":"test-run-xyz","tests":null}}"#,
             &disc,
             &tx,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await
         .unwrap();
@@ -462,12 +552,14 @@ mod tests {
         let (tx, _rx) = broadcast::channel(64);
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
         handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"discover","params":{"root":"/ignored"}}"#,
             &disc,
             &tx,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await;
 
@@ -483,6 +575,7 @@ mod tests {
             &tx2,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await;
 
@@ -501,18 +594,122 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn did_change_sets_dirty_and_broadcasts() {
+        // `did_change` is the in-band signal that makes server mode
+        // race-free for cooperating clients. Verify the three observable
+        // side-effects:
+        //   1. It returns "ok"
+        //   2. It flips `dirty` to true (which the subsequent `run`'s
+        //      `execute_run` will drain into a `restart_workers`)
+        //   3. It broadcasts a `discover_complete` so other clients
+        //      refresh their UI
+        let dir = make_root();
+        let test_file = dir.path().join("test_x.py");
+        fs::write(&test_file, "@test\ndef test_x(): pass\n").expect("write test file");
+        let (tx, mut rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        // Populate discovery so `affected_modules` returns non-empty.
+        disc.lock().await.rediscover();
+
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+
+        let req = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"did_change","params":{{"paths":["{}"]}}}}"#,
+            test_file.display(),
+        );
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["result"], "ok");
+        assert!(
+            dirty.load(std::sync::atomic::Ordering::Acquire),
+            "did_change must set dirty=true for an affected module",
+        );
+
+        let mut saw_discover_complete = false;
+        while let Ok(bytes) = rx.try_recv() {
+            let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            if v["method"] == "discover_complete" {
+                saw_discover_complete = true;
+            }
+        }
+        assert!(
+            saw_discover_complete,
+            "did_change must broadcast a discover_complete notification",
+        );
+    }
+
+    #[tokio::test]
+    async fn did_change_empty_paths_triggers_full_rediscover() {
+        // Panic-button form: client doesn't know which files changed.
+        // Server should re-scan everything and mark dirty.
+        let dir = make_root();
+        fs::write(dir.path().join("test_y.py"), "@test\ndef test_y(): pass\n")
+            .expect("write test file");
+        let (tx, _rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+
+        let resp = handle_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"did_change","params":{"paths":[]}}"#,
+            &disc,
+            &tx,
+            &pool,
+            &run_lock,
+            &dirty,
+        )
+        .await
+        .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["result"], "ok");
+        assert!(
+            dirty.load(std::sync::atomic::Ordering::Acquire),
+            "did_change with empty paths must still mark dirty",
+        );
+    }
+
+    #[tokio::test]
+    async fn did_change_without_params_returns_invalid_params() {
+        let dir = make_root();
+        let (tx, _rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+        let resp = handle_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"did_change"}"#,
+            &disc,
+            &tx,
+            &pool,
+            &run_lock,
+            &dirty,
+        )
+        .await
+        .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["error"]["code"], INVALID_PARAMS);
+    }
+
+    #[tokio::test]
     async fn unknown_method_returns_error() {
         let dir = make_root();
         let (tx, _rx) = broadcast::channel(16);
         let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
         let resp = handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"unknown_method"}"#,
             &disc,
             &tx,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await
         .unwrap();
@@ -540,6 +737,8 @@ mod tests {
 
         let run_lock = make_run_lock();
         let run_lock_clone = Arc::clone(&run_lock);
+        let dirty = make_dirty();
+        let dirty_clone = Arc::clone(&dirty);
         tokio::spawn(async move {
             for _ in 0..2u8 {
                 let (stream, _) = listener.accept().await.unwrap();
@@ -548,8 +747,9 @@ mod tests {
                 let d = Arc::clone(&disc_clone);
                 let p = Arc::clone(&pool_clone);
                 let rl = Arc::clone(&run_lock_clone);
+                let dy = Arc::clone(&dirty_clone);
                 tokio::spawn(async move {
-                    ConnectionHandler::new(stream, d, bcast_rx, bcast_tx_conn, p, rl)
+                    ConnectionHandler::new(stream, d, bcast_rx, bcast_tx_conn, p, rl, dy)
                         .run()
                         .await;
                 });
@@ -595,12 +795,14 @@ mod tests {
         disc.lock().await.rediscover();
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
         handle_request(
             r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"filter":"alpha","run_id":"r1"}}"#,
             &disc,
             &tx,
             &pool,
             &run_lock,
+            &dirty,
         )
         .await;
 
@@ -635,11 +837,13 @@ mod tests {
         disc.lock().await.rediscover();
         let pool = make_pool();
         let run_lock = make_run_lock();
+        let dirty = make_dirty();
 
         let disc_a = Arc::clone(&disc);
         let tx_a = tx.clone();
         let pool_a = Arc::clone(&pool);
         let run_lock_a = Arc::clone(&run_lock);
+        let dirty_a = Arc::clone(&dirty);
         let handle_a = tokio::spawn(async move {
             handle_request(
                 r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"run_id":"A","tests":null}}"#,
@@ -647,6 +851,7 @@ mod tests {
                 &tx_a,
                 &pool_a,
                 &run_lock_a,
+                &dirty_a,
             )
             .await;
         });
@@ -657,6 +862,7 @@ mod tests {
                 &tx,
                 &pool,
                 &run_lock,
+                &dirty,
             )
             .await;
         });

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashSet,
-    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -42,22 +41,9 @@ pub struct ConnectionHandler {
     /// debounce window and would otherwise hit a worker whose cached
     /// `sys.modules` predates the latest save.
     dirty: Arc<AtomicBool>,
-    /// Project root, captured at server start. The `did_change` handler
-    /// filters incoming paths against this so a local process that
-    /// reaches the server's 127.0.0.1 socket can't trigger reads or
-    /// import-graph pollution for files outside the workspace.
-    root: Arc<PathBuf>,
 }
 
 impl ConnectionHandler {
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "Each Arc is a piece of per-server shared state \
-                  (discovery, broadcast tx/rx, worker pool, run-lock, \
-                  dirty flag, project root) that the connection needs \
-                  read access to — bundling them into a struct just \
-                  adds an indirection layer with no clarity win."
-    )]
     pub fn new(
         stream: TcpStream,
         disc: Arc<tokio::sync::Mutex<tryke_discovery::Discoverer>>,
@@ -66,7 +52,6 @@ impl ConnectionHandler {
         pool: Arc<WorkerPool>,
         run_lock: Arc<Mutex<()>>,
         dirty: Arc<AtomicBool>,
-        root: Arc<PathBuf>,
     ) -> Self {
         Self {
             stream,
@@ -76,7 +61,6 @@ impl ConnectionHandler {
             pool,
             run_lock,
             dirty,
-            root,
         }
     }
 
@@ -113,18 +97,10 @@ impl ConnectionHandler {
                     let pool = Arc::clone(&self.pool);
                     let run_lock = Arc::clone(&self.run_lock);
                     let dirty = Arc::clone(&self.dirty);
-                    let root = Arc::clone(&self.root);
                     let line_owned = line.clone();
-                    let response = handle_request(
-                        &line_owned,
-                        &disc,
-                        &bcast_tx,
-                        &pool,
-                        &run_lock,
-                        &dirty,
-                        &root,
-                    )
-                    .await;
+                    let response =
+                        handle_request(&line_owned, &disc, &bcast_tx, &pool, &run_lock, &dirty)
+                            .await;
                     if let Some(bytes) = response {
                         let mut w = writer.lock().await;
                         if w.write_all(&bytes).await.is_err() || w.flush().await.is_err() {
@@ -314,27 +290,6 @@ async fn execute_run(
     (run_id, summary)
 }
 
-/// Keep only paths whose canonicalised form lies under `root`.
-///
-/// Used by the `did_change` handler to guard against a misbehaving (or
-/// hostile) local client sending paths outside the project tree. We
-/// canonicalise *both* sides so that symlinks, `.` / `..` segments, and
-/// case-insensitive filesystems all compare correctly. Paths that can't
-/// be canonicalised (e.g. the file was just deleted) fall back to the
-/// literal input — they still have to start with the project root to
-/// pass.
-fn filter_paths_in_root(root: &Path, paths: &[PathBuf]) -> Vec<PathBuf> {
-    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    paths
-        .iter()
-        .filter(|p| {
-            let canon = p.canonicalize().unwrap_or_else(|_| (*p).clone());
-            canon.starts_with(&canonical_root)
-        })
-        .cloned()
-        .collect()
-}
-
 pub async fn handle_request(
     line: &str,
     disc: &tokio::sync::Mutex<tryke_discovery::Discoverer>,
@@ -342,7 +297,6 @@ pub async fn handle_request(
     pool: &WorkerPool,
     run_lock: &Mutex<()>,
     dirty: &AtomicBool,
-    root: &Path,
 ) -> Option<Vec<u8>> {
     let req: Request = serde_json::from_str(line.trim()).ok()?;
     let id = req.id.clone().unwrap_or(Value::Null);
@@ -412,27 +366,15 @@ pub async fn handle_request(
                     DiscoverCompleteParams { tests },
                 );
             } else {
-                // Filter out paths outside the project root before
-                // mutating discovery — `did_change` accepts arbitrary
-                // client input and the server binds to 127.0.0.1, but
-                // any local process can still reach it. Validating here
-                // prevents accidental (or intentional) pollution of the
-                // import graph with files outside the workspace.
-                let filtered = filter_paths_in_root(root, &dc.paths);
-                if filtered.is_empty() {
-                    debug!(
-                        "did_change: all {} path(s) outside project root — ignored",
-                        dc.paths.len()
-                    );
-                } else {
-                    if filtered.len() != dc.paths.len() {
-                        debug!(
-                            "did_change: filtered {} path(s) outside project root",
-                            dc.paths.len() - filtered.len()
-                        );
-                    }
-                    crate::change::apply_change(disc, bcast_tx, dirty, &filtered).await;
-                }
+                // `Discoverer::rediscover_changed` (inside apply_change)
+                // already canonicalises and drops anything outside its
+                // project root, so we can pass client-supplied paths
+                // through without an extra filter. The server binds to
+                // 127.0.0.1 but any local process can still reach it;
+                // pushing the root check into discovery keeps the
+                // guarantee in the single place that owns the project
+                // tree.
+                crate::change::apply_change(disc, bcast_tx, dirty, &dc.paths).await;
             }
             serialize_response(id, "ok")
         }
@@ -520,7 +462,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await
         .unwrap();
@@ -545,7 +486,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await
         .unwrap();
@@ -568,7 +508,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await;
 
@@ -598,7 +537,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await
         .unwrap();
@@ -621,7 +559,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await
         .unwrap();
@@ -659,7 +596,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await;
 
@@ -676,7 +612,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await;
 
@@ -726,7 +661,7 @@ mod tests {
             "params": { "paths": [test_file] },
         }))
         .unwrap();
-        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty, dir.path())
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
             .await
             .unwrap();
         let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
@@ -769,7 +704,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await
         .unwrap();
@@ -796,7 +730,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await
         .unwrap();
@@ -838,7 +771,7 @@ mod tests {
             "params": { "paths": [outside_file, inside_file] },
         }))
         .unwrap();
-        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty, dir.path())
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
             .await
             .unwrap();
         let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
@@ -873,7 +806,7 @@ mod tests {
             "params": { "paths": [outside_file] },
         }))
         .unwrap();
-        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty, dir.path())
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
             .await
             .unwrap();
         let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
@@ -881,6 +814,54 @@ mod tests {
         assert!(
             !dirty.load(std::sync::atomic::Ordering::Acquire),
             "all-outside-root did_change must not mark dirty",
+        );
+    }
+
+    #[tokio::test]
+    async fn did_change_accepts_just_deleted_file_under_root() {
+        // Regression: when a `did_change` arrives for a file the user
+        // just deleted, `p.canonicalize()` fails (no inode to resolve).
+        // The old fallback compared the literal input path against a
+        // canonical root, which silently dropped legitimate deletions
+        // when the workspace was under a symlinked prefix (macOS's
+        // `/var → /private/var` is the common trigger). New behaviour:
+        // canonicalise the parent and join the file name, so the
+        // workspace prefix is normalised even when the leaf is gone.
+        let dir = make_root();
+        // Create then delete a file so canonicalize(file) will fail
+        // but canonicalize(parent) succeeds. Discovery doesn't need
+        // to know about it — we're testing the filter, not discovery.
+        let test_file = dir.path().join("test_gone.py");
+        fs::write(&test_file, "x = 1\n").expect("write");
+        fs::remove_file(&test_file).expect("rm");
+
+        let (tx, _rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        disc.lock().await.rediscover();
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+
+        let req = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "did_change",
+            "params": { "paths": [test_file] },
+        }))
+        .unwrap();
+        // Pass the *non-canonical* dir.path() as root to simulate the
+        // symlinked-prefix case — the handler will canonicalise it via
+        // `filter_paths_in_root`'s caller (we pass canonicalised root
+        // in production via the server). But here we want to verify the
+        // filter survives a non-existent leaf, which is the bug the
+        // P2 review feedback was about.
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(
+            val["result"], "ok",
+            "deleted-file did_change must not be rejected by the filter"
         );
     }
 
@@ -907,7 +888,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await
         .unwrap();
@@ -942,7 +922,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await
         .unwrap();
@@ -972,8 +951,6 @@ mod tests {
         let run_lock_clone = Arc::clone(&run_lock);
         let dirty = make_dirty();
         let dirty_clone = Arc::clone(&dirty);
-        let root = Arc::new(dir.path().to_path_buf());
-        let root_clone = Arc::clone(&root);
         tokio::spawn(async move {
             for _ in 0..2u8 {
                 let (stream, _) = listener.accept().await.unwrap();
@@ -983,9 +960,8 @@ mod tests {
                 let p = Arc::clone(&pool_clone);
                 let rl = Arc::clone(&run_lock_clone);
                 let dy = Arc::clone(&dirty_clone);
-                let rt = Arc::clone(&root_clone);
                 tokio::spawn(async move {
-                    ConnectionHandler::new(stream, d, bcast_rx, bcast_tx_conn, p, rl, dy, rt)
+                    ConnectionHandler::new(stream, d, bcast_rx, bcast_tx_conn, p, rl, dy)
                         .run()
                         .await;
                 });
@@ -1039,7 +1015,6 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
-            dir.path(),
         )
         .await;
 
@@ -1076,14 +1051,11 @@ mod tests {
         let run_lock = make_run_lock();
         let dirty = make_dirty();
 
-        let root = Arc::new(dir.path().to_path_buf());
-
         let disc_a = Arc::clone(&disc);
         let tx_a = tx.clone();
         let pool_a = Arc::clone(&pool);
         let run_lock_a = Arc::clone(&run_lock);
         let dirty_a = Arc::clone(&dirty);
-        let root_a = Arc::clone(&root);
         let handle_a = tokio::spawn(async move {
             handle_request(
                 r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"run_id":"A","tests":null}}"#,
@@ -1092,7 +1064,6 @@ mod tests {
                 &pool_a,
                 &run_lock_a,
                 &dirty_a,
-                &root_a,
             )
             .await;
         });
@@ -1104,7 +1075,6 @@ mod tests {
                 &pool,
                 &run_lock,
                 &dirty,
-                &root,
             )
             .await;
         });

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashSet,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -41,9 +42,22 @@ pub struct ConnectionHandler {
     /// debounce window and would otherwise hit a worker whose cached
     /// `sys.modules` predates the latest save.
     dirty: Arc<AtomicBool>,
+    /// Project root, captured at server start. The `did_change` handler
+    /// filters incoming paths against this so a local process that
+    /// reaches the server's 127.0.0.1 socket can't trigger reads or
+    /// import-graph pollution for files outside the workspace.
+    root: Arc<PathBuf>,
 }
 
 impl ConnectionHandler {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Each Arc is a piece of per-server shared state \
+                  (discovery, broadcast tx/rx, worker pool, run-lock, \
+                  dirty flag, project root) that the connection needs \
+                  read access to — bundling them into a struct just \
+                  adds an indirection layer with no clarity win."
+    )]
     pub fn new(
         stream: TcpStream,
         disc: Arc<tokio::sync::Mutex<tryke_discovery::Discoverer>>,
@@ -52,6 +66,7 @@ impl ConnectionHandler {
         pool: Arc<WorkerPool>,
         run_lock: Arc<Mutex<()>>,
         dirty: Arc<AtomicBool>,
+        root: Arc<PathBuf>,
     ) -> Self {
         Self {
             stream,
@@ -61,6 +76,7 @@ impl ConnectionHandler {
             pool,
             run_lock,
             dirty,
+            root,
         }
     }
 
@@ -97,10 +113,18 @@ impl ConnectionHandler {
                     let pool = Arc::clone(&self.pool);
                     let run_lock = Arc::clone(&self.run_lock);
                     let dirty = Arc::clone(&self.dirty);
+                    let root = Arc::clone(&self.root);
                     let line_owned = line.clone();
-                    let response =
-                        handle_request(&line_owned, &disc, &bcast_tx, &pool, &run_lock, &dirty)
-                            .await;
+                    let response = handle_request(
+                        &line_owned,
+                        &disc,
+                        &bcast_tx,
+                        &pool,
+                        &run_lock,
+                        &dirty,
+                        &root,
+                    )
+                    .await;
                     if let Some(bytes) = response {
                         let mut w = writer.lock().await;
                         if w.write_all(&bytes).await.is_err() || w.flush().await.is_err() {
@@ -167,29 +191,38 @@ async fn execute_run(
     // notification ordering) is not interleaved across clients.
     let _run_guard = run_lock.lock().await;
 
-    // Drain the dirty flag before dispatching. The flag is set by:
-    //   - the FS watcher task (server.rs) on an accepted file-change batch,
-    //     for clients that don't proactively notify; and
+    // Snapshot tests AND drain the dirty flag in the SAME disc.lock
+    // critical section. This pairs with `apply_change`'s
+    // `dirty.store(true)` (also done inside its disc.lock guard): the
+    // two operations cannot interleave, so a concurrent watcher /
+    // `did_change` task can't update discovery between our dirty check
+    // and our tests snapshot. Without this serialisation, a watcher
+    // mid-flight could (a) acquire disc.lock first, (b) update
+    // discovery, (c) release the lock, while we grab the *new* tests
+    // but observe stale `dirty=false` because the store hadn't
+    // happened yet — dispatching on workers whose `sys.modules` predates
+    // the change.
+    //
+    // The flag is set by:
+    //   - the FS watcher task (server.rs) on an accepted file-change
+    //     batch, for non-cooperating clients; and
     //   - the `did_change` RPC handler (below), for cooperating clients
     //     (neotest-tryke sends `did_change` on the same TCP connection
     //     immediately before `run`).
-    // Cooperating clients are guaranteed to see `dirty=true` here because
-    // per-connection read+dispatch is serial (handler.rs:72-92): the
-    // `did_change` handler's `dirty.store(true, Release)` completes
-    // before the `run` line is even read off the socket.
-    // For non-cooperating clients, `dirty` may be false if their `run`
-    // raced the watcher's debounce — they'll see the same eventually-
-    // consistent behaviour as today's FS-only design.
-    if dirty.swap(false, Ordering::AcqRel) {
+    // Cooperating clients are also guaranteed to see `dirty=true`
+    // because per-connection reads are serial (handler.rs:72-92): the
+    // `did_change` handler's `apply_change` completes before the `run`
+    // line is even read off the socket.
+    let discovery_start = Instant::now();
+    let (dirty_was_set, all_tests, hooks) = {
+        let guard = disc.lock().await;
+        let was = dirty.swap(false, Ordering::AcqRel);
+        (was, guard.tests(), guard.hooks())
+    };
+    if dirty_was_set {
         debug!("execute_run: dirty drained — restarting worker pool");
         pool.restart_workers().await;
     }
-
-    let discovery_start = Instant::now();
-    let guard = disc.lock().await;
-    let all_tests = guard.tests();
-    let hooks = guard.hooks();
-    drop(guard);
     let mut tests = match &rp.tests {
         Some(ids) => all_tests
             .into_iter()
@@ -281,6 +314,27 @@ async fn execute_run(
     (run_id, summary)
 }
 
+/// Keep only paths whose canonicalised form lies under `root`.
+///
+/// Used by the `did_change` handler to guard against a misbehaving (or
+/// hostile) local client sending paths outside the project tree. We
+/// canonicalise *both* sides so that symlinks, `.` / `..` segments, and
+/// case-insensitive filesystems all compare correctly. Paths that can't
+/// be canonicalised (e.g. the file was just deleted) fall back to the
+/// literal input — they still have to start with the project root to
+/// pass.
+fn filter_paths_in_root(root: &Path, paths: &[PathBuf]) -> Vec<PathBuf> {
+    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    paths
+        .iter()
+        .filter(|p| {
+            let canon = p.canonicalize().unwrap_or_else(|_| (*p).clone());
+            canon.starts_with(&canonical_root)
+        })
+        .cloned()
+        .collect()
+}
+
 pub async fn handle_request(
     line: &str,
     disc: &tokio::sync::Mutex<tryke_discovery::Discoverer>,
@@ -288,6 +342,7 @@ pub async fn handle_request(
     pool: &WorkerPool,
     run_lock: &Mutex<()>,
     dirty: &AtomicBool,
+    root: &Path,
 ) -> Option<Vec<u8>> {
     let req: Request = serde_json::from_str(line.trim()).ok()?;
     let id = req.id.clone().unwrap_or(Value::Null);
@@ -333,12 +388,51 @@ pub async fn handle_request(
             };
             if dc.paths.is_empty() {
                 // Panic-button form: client doesn't know what changed.
-                // Force a full rediscover and mark dirty.
-                let _ = disc.lock().await.rediscover();
-                dirty.store(true, std::sync::atomic::Ordering::Release);
-                debug!("did_change: empty paths — full rediscover + dirty mark");
+                // Full rediscover; broadcast the resulting test list so
+                // other connected clients see the refresh (matches the
+                // non-empty path through `apply_change`, which also
+                // broadcasts `discover_complete`).
+                let tests = {
+                    let mut guard = disc.lock().await;
+                    let tests = guard.rediscover();
+                    // Set dirty inside the lock — pairs with the
+                    // drain inside `execute_run`'s disc.lock guard so
+                    // no run can read fresh tests without also
+                    // observing dirty=true.
+                    dirty.store(true, Ordering::Release);
+                    tests
+                };
+                debug!(
+                    "did_change: empty paths — full rediscover, {} tests, dirty mark",
+                    tests.len()
+                );
+                broadcast_notification(
+                    bcast_tx,
+                    "discover_complete",
+                    DiscoverCompleteParams { tests },
+                );
             } else {
-                crate::change::apply_change(disc, bcast_tx, dirty, &dc.paths).await;
+                // Filter out paths outside the project root before
+                // mutating discovery — `did_change` accepts arbitrary
+                // client input and the server binds to 127.0.0.1, but
+                // any local process can still reach it. Validating here
+                // prevents accidental (or intentional) pollution of the
+                // import graph with files outside the workspace.
+                let filtered = filter_paths_in_root(root, &dc.paths);
+                if filtered.is_empty() {
+                    debug!(
+                        "did_change: all {} path(s) outside project root — ignored",
+                        dc.paths.len()
+                    );
+                } else {
+                    if filtered.len() != dc.paths.len() {
+                        debug!(
+                            "did_change: filtered {} path(s) outside project root",
+                            dc.paths.len() - filtered.len()
+                        );
+                    }
+                    crate::change::apply_change(disc, bcast_tx, dirty, &filtered).await;
+                }
             }
             serialize_response(id, "ok")
         }
@@ -426,6 +520,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await
         .unwrap();
@@ -450,6 +545,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await
         .unwrap();
@@ -472,6 +568,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await;
 
@@ -501,6 +598,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await
         .unwrap();
@@ -523,6 +621,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await
         .unwrap();
@@ -560,6 +659,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await;
 
@@ -576,6 +676,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await;
 
@@ -625,7 +726,7 @@ mod tests {
             "params": { "paths": [test_file] },
         }))
         .unwrap();
-        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty, dir.path())
             .await
             .unwrap();
         let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
@@ -668,6 +769,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await
         .unwrap();
@@ -694,11 +796,135 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await
         .unwrap();
         let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
         assert_eq!(val["error"]["code"], INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn did_change_ignores_paths_outside_root() {
+        // Defence-in-depth: the server binds to 127.0.0.1 but any local
+        // process can still reach it. `did_change` MUST refuse to refresh
+        // discovery for files outside the configured project root —
+        // otherwise a hostile client could pollute the import graph or
+        // trigger arbitrary file parses.
+        //
+        // Setup: two tempdirs, one is the project root and contains a
+        // test file, the other is "outside" and also contains a test
+        // file. did_change sends both paths; only the in-root one
+        // should result in a dirty mark.
+        let dir = make_root();
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let inside_file = dir.path().join("test_inside.py");
+        let outside_file = outside.path().join("test_outside.py");
+        fs::write(&inside_file, "@test\ndef test_inside(): pass\n").expect("write inside");
+        fs::write(&outside_file, "@test\ndef test_outside(): pass\n").expect("write outside");
+
+        let (tx, _rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        disc.lock().await.rediscover();
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+
+        // Both paths in the request; only inside_file should survive.
+        let req = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "did_change",
+            "params": { "paths": [outside_file, inside_file] },
+        }))
+        .unwrap();
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty, dir.path())
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["result"], "ok");
+        // The inside path is a real module, so dirty MUST be set
+        // (proves the filter didn't drop everything).
+        assert!(
+            dirty.load(std::sync::atomic::Ordering::Acquire),
+            "in-root path should still trigger dirty mark",
+        );
+    }
+
+    #[tokio::test]
+    async fn did_change_all_paths_outside_root_is_noop() {
+        // The opposite of the above: when EVERY path is outside root,
+        // dirty must NOT be set and we must not mutate discovery.
+        let dir = make_root();
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("test_outside.py");
+        fs::write(&outside_file, "@test\ndef test_outside(): pass\n").expect("write outside");
+
+        let (tx, _rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+
+        let req = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "did_change",
+            "params": { "paths": [outside_file] },
+        }))
+        .unwrap();
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty, dir.path())
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["result"], "ok");
+        assert!(
+            !dirty.load(std::sync::atomic::Ordering::Acquire),
+            "all-outside-root did_change must not mark dirty",
+        );
+    }
+
+    #[tokio::test]
+    async fn did_change_empty_paths_broadcasts_discover_complete() {
+        // P2: empty-paths form does a full rediscover; it MUST also
+        // broadcast `discover_complete` so connected clients see the
+        // refresh. Without this, the empty-paths path leaves clients
+        // permanently stale until the FS watcher fires (which may
+        // never happen if changes are still pending).
+        let dir = make_root();
+        fs::write(dir.path().join("test_x.py"), "@test\ndef test_x(): pass\n")
+            .expect("write test file");
+        let (tx, mut rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+
+        let resp = handle_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"did_change","params":{"paths":[]}}"#,
+            &disc,
+            &tx,
+            &pool,
+            &run_lock,
+            &dirty,
+            dir.path(),
+        )
+        .await
+        .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["result"], "ok");
+
+        let mut saw_discover_complete = false;
+        while let Ok(bytes) = rx.try_recv() {
+            let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            if v["method"] == "discover_complete" {
+                saw_discover_complete = true;
+            }
+        }
+        assert!(
+            saw_discover_complete,
+            "empty-paths did_change must broadcast discover_complete",
+        );
     }
 
     #[tokio::test]
@@ -716,6 +942,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await
         .unwrap();
@@ -745,6 +972,8 @@ mod tests {
         let run_lock_clone = Arc::clone(&run_lock);
         let dirty = make_dirty();
         let dirty_clone = Arc::clone(&dirty);
+        let root = Arc::new(dir.path().to_path_buf());
+        let root_clone = Arc::clone(&root);
         tokio::spawn(async move {
             for _ in 0..2u8 {
                 let (stream, _) = listener.accept().await.unwrap();
@@ -754,8 +983,9 @@ mod tests {
                 let p = Arc::clone(&pool_clone);
                 let rl = Arc::clone(&run_lock_clone);
                 let dy = Arc::clone(&dirty_clone);
+                let rt = Arc::clone(&root_clone);
                 tokio::spawn(async move {
-                    ConnectionHandler::new(stream, d, bcast_rx, bcast_tx_conn, p, rl, dy)
+                    ConnectionHandler::new(stream, d, bcast_rx, bcast_tx_conn, p, rl, dy, rt)
                         .run()
                         .await;
                 });
@@ -809,6 +1039,7 @@ mod tests {
             &pool,
             &run_lock,
             &dirty,
+            dir.path(),
         )
         .await;
 
@@ -845,11 +1076,14 @@ mod tests {
         let run_lock = make_run_lock();
         let dirty = make_dirty();
 
+        let root = Arc::new(dir.path().to_path_buf());
+
         let disc_a = Arc::clone(&disc);
         let tx_a = tx.clone();
         let pool_a = Arc::clone(&pool);
         let run_lock_a = Arc::clone(&run_lock);
         let dirty_a = Arc::clone(&dirty);
+        let root_a = Arc::clone(&root);
         let handle_a = tokio::spawn(async move {
             handle_request(
                 r#"{"jsonrpc":"2.0","id":1,"method":"run","params":{"run_id":"A","tests":null}}"#,
@@ -858,6 +1092,7 @@ mod tests {
                 &pool_a,
                 &run_lock_a,
                 &dirty_a,
+                &root_a,
             )
             .await;
         });
@@ -869,6 +1104,7 @@ mod tests {
                 &pool,
                 &run_lock,
                 &dirty,
+                &root,
             )
             .await;
         });

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -785,6 +785,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn did_change_non_py_paths_do_not_mark_dirty() {
+        // A `did_change` for non-Python files (README.md, pyproject.toml,
+        // config dotfiles) must NOT mark the pool dirty — those changes
+        // can't affect any imported module, so triggering a worker
+        // restart on the next run is pure waste. Pre-fix:
+        // `affected_modules` happily turned `README.md` into a "README"
+        // module name (the wrapper at lib.rs:106-108 unwraps None to
+        // empty), making `modules.is_empty()` false and setting dirty.
+        let dir = make_root();
+        let readme = dir.path().join("README.md");
+        let pyproject = dir.path().join("pyproject.toml"); // already exists from make_root
+        fs::write(&readme, "# project\n").expect("write readme");
+
+        let (tx, _rx) = broadcast::channel(16);
+        let disc = Arc::new(Mutex::new(Discoverer::new(dir.path())));
+        disc.lock().await.rediscover();
+        let pool = make_pool();
+        let run_lock = make_run_lock();
+        let dirty = make_dirty();
+
+        let req = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "did_change",
+            "params": { "paths": [readme, pyproject] },
+        }))
+        .unwrap();
+        let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert_eq!(val["result"], "ok");
+        assert!(
+            !dirty.load(std::sync::atomic::Ordering::Acquire),
+            "non-.py did_change must not mark dirty (would force a needless worker restart)",
+        );
+    }
+
+    #[tokio::test]
     async fn did_change_all_paths_outside_root_is_noop() {
         // The opposite of the above: when EVERY path is outside root,
         // dirty must NOT be set and we must not mutate discovery.

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -615,10 +615,16 @@ mod tests {
         let run_lock = make_run_lock();
         let dirty = make_dirty();
 
-        let req = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"did_change","params":{{"paths":["{}"]}}}}"#,
-            test_file.display(),
-        );
+        // Build the request via serde so the path is JSON-escaped
+        // (Windows backslashes are escape characters in JSON strings —
+        // raw `r#"..."#` interpolation produces invalid input on CI).
+        let req = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "did_change",
+            "params": { "paths": [test_file] },
+        }))
+        .unwrap();
         let resp = handle_request(&req, &disc, &tx, &pool, &run_lock, &dirty)
             .await
             .unwrap();

--- a/crates/tryke_server/src/lib.rs
+++ b/crates/tryke_server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod change;
 pub mod client;
 pub mod handler;
 pub mod protocol;

--- a/crates/tryke_server/src/protocol.rs
+++ b/crates/tryke_server/src/protocol.rs
@@ -17,6 +17,21 @@ pub struct DiscoverParams {
     pub root: PathBuf,
 }
 
+/// Params for the `did_change` RPC. Clients (notably neotest-tryke) call
+/// this on their `BufWritePost` autocmd, *before* sending the next `run`,
+/// so the server can refresh discovery and mark the worker pool dirty in
+/// the same TCP connection as the run — closing the race window that
+/// exists between an editor save and the FS watcher's debounce.
+///
+/// `paths` is the list of absolute file paths just modified by the
+/// client. An empty list is treated as "I don't know which files
+/// changed — please rediscover everything." Use that sparingly, it's a
+/// full tree walk.
+#[derive(Debug, Deserialize)]
+pub struct DidChangeParams {
+    pub paths: Vec<PathBuf>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RunParams {
     pub tests: Option<Vec<String>>,

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::PathBuf,
+    sync::{Arc, atomic::AtomicBool},
+};
 
 use bytes::Bytes;
 use log::{LevelFilter, debug};
@@ -9,11 +12,7 @@ use tokio::{
 use tryke_discovery::Discoverer;
 use tryke_runner::WorkerPool;
 
-use crate::{
-    handler::ConnectionHandler,
-    protocol::{DiscoverCompleteParams, Notification},
-    watcher::spawn_watcher,
-};
+use crate::{change::apply_change, handler::ConnectionHandler, watcher::spawn_watcher};
 
 pub struct Server {
     port: u16,
@@ -62,6 +61,16 @@ impl Server {
         // clients don't interleave test execution on the shared pool.
         let run_lock = Arc::new(Mutex::new(()));
 
+        // Set by the watcher whenever a real file change is accepted;
+        // drained by `execute_run` under `run_lock` to force a worker pool
+        // restart before any unit is dispatched. Without this, a `run`
+        // request that arrives within the watcher's debounce window can
+        // be served by a worker whose cached `sys.modules` predates the
+        // on-disk content — the test then runs against stale module
+        // globals (the original symptom: server mode flakily honours a
+        // just-edited assertion).
+        let dirty = Arc::new(AtomicBool::new(false));
+
         let (bcast_tx, _) = broadcast::channel::<Bytes>(256);
         let disc = Arc::new(Mutex::new(Discoverer::new_with_excludes(
             &self.root,
@@ -82,7 +91,7 @@ impl Server {
 
         let disc_for_watcher = Arc::clone(&disc);
         let bcast_for_watcher = bcast_tx.clone();
-        let pool_for_watcher = Arc::clone(&pool);
+        let dirty_for_watcher = Arc::clone(&dirty);
         let mut change_filter = crate::watcher::ChangeFilter::new();
         tokio::spawn(async move {
             while let Some(first) = watcher_rx.recv().await {
@@ -108,33 +117,17 @@ impl Server {
                     continue;
                 }
 
-                let (modules, tests) = {
-                    let mut disc = disc_for_watcher.lock().await;
-                    let modules = disc.affected_modules(&paths);
-                    disc.rediscover_changed(&paths);
-                    let tests = disc.tests_for_changed(&paths);
-                    (modules, tests)
-                };
-                if modules.is_empty() {
-                    debug!("server: no modules affected by change — skipping worker restart");
-                } else {
-                    debug!(
-                        "server: restarting worker pool to pick up changes in {} module(s): {}",
-                        modules.len(),
-                        modules.join(", ")
-                    );
-                    pool_for_watcher.restart_workers().await;
-                }
-                debug!("file change: {} affected tests", tests.len());
-                let notif = Notification {
-                    jsonrpc: "2.0".to_string(),
-                    method: "discover_complete".to_string(),
-                    params: DiscoverCompleteParams { tests },
-                };
-                if let Ok(mut bytes) = serde_json::to_vec(&notif) {
-                    bytes.push(b'\n');
-                    let _ = bcast_for_watcher.send(Bytes::from(bytes));
-                }
+                // Shared with the `did_change` RPC handler (handler.rs)
+                // so the FS path and the in-band path stay semantically
+                // identical. The next `run` will drain `dirty` and
+                // restart the worker pool before dispatch.
+                apply_change(
+                    &disc_for_watcher,
+                    &bcast_for_watcher,
+                    &dirty_for_watcher,
+                    &paths,
+                )
+                .await;
             }
         });
 
@@ -146,6 +139,7 @@ impl Server {
             let disc_conn = Arc::clone(&disc);
             let pool_conn = Arc::clone(&pool);
             let run_lock_conn = Arc::clone(&run_lock);
+            let dirty_conn = Arc::clone(&dirty);
             tokio::spawn(async move {
                 ConnectionHandler::new(
                     stream,
@@ -154,6 +148,7 @@ impl Server {
                     bcast_tx_conn,
                     pool_conn,
                     run_lock_conn,
+                    dirty_conn,
                 )
                 .run()
                 .await;
@@ -230,5 +225,164 @@ mod tests {
             .unwrap();
         let v2: serde_json::Value = serde_json::from_str(line2.trim()).unwrap();
         assert!(v2.get("method").is_some(), "c2 should receive a broadcast");
+    }
+
+    fn match_body(value: &str) -> String {
+        format!(
+            "from tryke import describe, expect, test\n\
+             \n\
+             def match() -> str:\n\
+             {INDENT}return \"{value}\"\n\
+             \n\
+             with describe(\"match\"):\n\
+             {INDENT}@test(\"basic\")\n\
+             {INDENT}def basic():\n\
+             {INDENT}{INDENT}expect(match()).to_equal(\"set\")\n",
+            INDENT = "    ",
+        )
+    }
+
+    /// Read JSON-RPC lines from `r` until one with an `id` field (the
+    /// response — notifications have no `id`).
+    async fn read_response(r: &mut BufReader<tokio::net::tcp::OwnedReadHalf>) -> serde_json::Value {
+        loop {
+            let mut line = String::new();
+            time::timeout(Duration::from_secs(30), r.read_line(&mut line))
+                .await
+                .unwrap()
+                .unwrap();
+            let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+            if v.get("id").is_some() {
+                return v;
+            }
+        }
+    }
+
+    /// Send `did_change` then `run` on the SAME TCP connection — the
+    /// invariant that makes the in-band approach race-free.
+    async fn did_change_then_run(
+        port: u16,
+        file: &std::path::Path,
+        rid: &str,
+    ) -> serde_json::Value {
+        let s = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let (read, mut write) = s.into_split();
+        let mut r = BufReader::new(read);
+
+        let dc = format!(
+            "{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"did_change\",\"params\":{{\"paths\":[\"{}\"]}}}}\n",
+            file.display(),
+        );
+        write.write_all(dc.as_bytes()).await.unwrap();
+        let _dc_resp = read_response(&mut r).await;
+
+        let run = format!(
+            "{{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"run\",\"params\":{{\"run_id\":\"{rid}\"}}}}\n"
+        );
+        write.write_all(run.as_bytes()).await.unwrap();
+        read_response(&mut r).await
+    }
+
+    /// Send `run` only (no `did_change`) — simulates a non-cooperating
+    /// client. Used to verify the FS-watcher fallback path.
+    async fn run_only(port: u16, rid: &str) -> serde_json::Value {
+        let s = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let (read, mut write) = s.into_split();
+        let mut r = BufReader::new(read);
+        let run = format!(
+            "{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"run\",\"params\":{{\"run_id\":\"{rid}\"}}}}\n"
+        );
+        write.write_all(run.as_bytes()).await.unwrap();
+        read_response(&mut r).await
+    }
+
+    /// Regression: a `run` issued *immediately* after a save (no sleep
+    /// to let the FS watcher catch up) must see fresh `sys.modules`,
+    /// not the previous cycle's cache. Drives the same phase-1/phase-2
+    /// shape that catches stale-cache leaks across 16 workers — but
+    /// this time the client sends `did_change` first so the server can
+    /// flip `dirty` synchronously before the `run` line is read.
+    ///
+    /// Without the `did_change` step (or without the conditional drain
+    /// in `execute_run`), phase 2 sees passing runs because workers
+    /// dispatched against their phase-1 cached "set" body even though
+    /// the file is now "st" on disk.
+    #[tokio::test]
+    async fn run_after_did_change_uses_fresh_module() {
+        let (port, dir) = start_server().await;
+        let test_file = dir.path().join("test_match.py");
+
+        fs::write(&test_file, match_body("set")).unwrap();
+        // One settling pause so the *initial* discovery picks up the
+        // file. After this, every iteration uses `did_change` and does
+        // not wait.
+        time::sleep(Duration::from_millis(300)).await;
+
+        // Phase 1 — every worker imports the "set" body.
+        for i in 0..16 {
+            fs::write(&test_file, match_body("set")).unwrap();
+            let resp = did_change_then_run(port, &test_file, &format!("set{i}")).await;
+            let summary = &resp["result"]["summary"];
+            let passed = summary["passed"].as_u64().unwrap_or(0);
+            assert_eq!(
+                passed, 1,
+                "phase 1 iter {i}: 'set' baseline must pass — got summary={summary}",
+            );
+        }
+
+        // Phase 2 — flip to "st"; assertion stays "set", so every fresh
+        // import must FAIL. A `passed=1` here means a worker served its
+        // phase-1 cached module: exactly the staleness `did_change` →
+        // `dirty` → drain is here to prevent.
+        for i in 0..16 {
+            fs::write(&test_file, match_body("st")).unwrap();
+            let resp = did_change_then_run(port, &test_file, &format!("st{i}")).await;
+            let summary = &resp["result"]["summary"];
+            let passed = summary["passed"].as_u64().unwrap_or(0);
+            let failed = summary["failed"].as_u64().unwrap_or(0);
+            let errors = summary["errors"].as_u64().unwrap_or(0);
+            assert!(
+                passed == 0 && (failed + errors) >= 1,
+                "phase 2 iter {i}: file has match()->\"st\" but the run \
+                 reported passed={passed}; a worker served the stale \
+                 phase-1 cache. summary={summary}",
+            );
+        }
+    }
+
+    /// Companion to the test above: a non-cooperating client (just
+    /// sends `run`, no `did_change`) still eventually gets correct
+    /// results once the FS watcher's 50 ms debounce expires. This
+    /// documents the fallback path and ensures we haven't accidentally
+    /// removed it.
+    #[tokio::test]
+    async fn run_only_falls_back_to_fs_watcher() {
+        let (port, dir) = start_server().await;
+        let test_file = dir.path().join("test_match.py");
+
+        fs::write(&test_file, match_body("set")).unwrap();
+        time::sleep(Duration::from_millis(300)).await;
+        let resp = run_only(port, "warm").await;
+        assert_eq!(
+            resp["result"]["summary"]["passed"].as_u64().unwrap_or(0),
+            1,
+            "warm-up: 'set' body must pass — got {}",
+            resp["result"]["summary"]
+        );
+
+        fs::write(&test_file, match_body("st")).unwrap();
+        // Give the FS watcher its debounce + a comfortable margin to
+        // process the change and mark dirty. Non-cooperating clients
+        // accept this latency.
+        time::sleep(Duration::from_millis(300)).await;
+        let resp = run_only(port, "after_save").await;
+        let summary = &resp["result"]["summary"];
+        let passed = summary["passed"].as_u64().unwrap_or(0);
+        let failed = summary["failed"].as_u64().unwrap_or(0);
+        assert!(
+            passed == 0 && failed >= 1,
+            "after FS-watcher debounce: 'st' body should fail the 'set' assertion — \
+             got summary={summary}",
+        );
     }
 }

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -269,10 +269,16 @@ mod tests {
         let (read, mut write) = s.into_split();
         let mut r = BufReader::new(read);
 
-        let dc = format!(
-            "{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"did_change\",\"params\":{{\"paths\":[\"{}\"]}}}}\n",
-            file.display(),
-        );
+        // serde_json::to_string handles JSON escaping (Windows
+        // backslashes in the path would otherwise produce invalid JSON).
+        let mut dc = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "did_change",
+            "params": { "paths": [file] },
+        }))
+        .unwrap();
+        dc.push('\n');
         write.write_all(dc.as_bytes()).await.unwrap();
         let _dc_resp = read_response(&mut r).await;
 

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -71,13 +71,6 @@ impl Server {
         // just-edited assertion).
         let dirty = Arc::new(AtomicBool::new(false));
 
-        // Shared with every `ConnectionHandler` so the `did_change`
-        // handler can filter incoming paths and refuse to touch
-        // anything outside the project tree (defence-in-depth: the
-        // server already binds to 127.0.0.1, but any local process can
-        // still reach it).
-        let root = Arc::new(self.root.clone());
-
         let (bcast_tx, _) = broadcast::channel::<Bytes>(256);
         let disc = Arc::new(Mutex::new(Discoverer::new_with_excludes(
             &self.root,
@@ -147,7 +140,6 @@ impl Server {
             let pool_conn = Arc::clone(&pool);
             let run_lock_conn = Arc::clone(&run_lock);
             let dirty_conn = Arc::clone(&dirty);
-            let root_conn = Arc::clone(&root);
             tokio::spawn(async move {
                 ConnectionHandler::new(
                     stream,
@@ -157,7 +149,6 @@ impl Server {
                     pool_conn,
                     run_lock_conn,
                     dirty_conn,
-                    root_conn,
                 )
                 .run()
                 .await;

--- a/crates/tryke_server/src/server.rs
+++ b/crates/tryke_server/src/server.rs
@@ -71,6 +71,13 @@ impl Server {
         // just-edited assertion).
         let dirty = Arc::new(AtomicBool::new(false));
 
+        // Shared with every `ConnectionHandler` so the `did_change`
+        // handler can filter incoming paths and refuse to touch
+        // anything outside the project tree (defence-in-depth: the
+        // server already binds to 127.0.0.1, but any local process can
+        // still reach it).
+        let root = Arc::new(self.root.clone());
+
         let (bcast_tx, _) = broadcast::channel::<Bytes>(256);
         let disc = Arc::new(Mutex::new(Discoverer::new_with_excludes(
             &self.root,
@@ -140,6 +147,7 @@ impl Server {
             let pool_conn = Arc::clone(&pool);
             let run_lock_conn = Arc::clone(&run_lock);
             let dirty_conn = Arc::clone(&dirty);
+            let root_conn = Arc::clone(&root);
             tokio::spawn(async move {
                 ConnectionHandler::new(
                     stream,
@@ -149,6 +157,7 @@ impl Server {
                     pool_conn,
                     run_lock_conn,
                     dirty_conn,
+                    root_conn,
                 )
                 .run()
                 .await;

--- a/crates/tryke_server/src/watcher.rs
+++ b/crates/tryke_server/src/watcher.rs
@@ -5,10 +5,10 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use log::debug;
 use notify::RecommendedWatcher;
 use notify_debouncer_mini::{DebounceEventResult, Debouncer, new_debouncer};
+use tryke_discovery::build_change_set_ignore;
 
 // 50ms is enough to coalesce the burst of inotify events the kernel emits
 // for a single write syscall (typically sub-ms apart). We rely on
@@ -17,24 +17,19 @@ use notify_debouncer_mini::{DebounceEventResult, Debouncer, new_debouncer};
 // this window.
 const DEBOUNCE_DELAY: Duration = Duration::from_millis(50);
 
-fn build_gitignore(root: &Path, excludes: &[String]) -> Gitignore {
-    let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    let mut builder = GitignoreBuilder::new(&canonical);
-    let _ = builder.add(canonical.join(".gitignore"));
-    let _ = builder.add(canonical.join(".ignore"));
-    for exclude in excludes {
-        let _ = builder.add_line(None, exclude);
-    }
-    builder.build().unwrap_or_else(|_| Gitignore::empty())
-}
-
 #[expect(clippy::missing_errors_doc)]
 pub fn spawn_watcher(
     root: &Path,
     excludes: &[String],
     tx: mpsc::Sender<Vec<PathBuf>>,
 ) -> anyhow::Result<Debouncer<RecommendedWatcher>> {
-    let gitignore = build_gitignore(root, excludes);
+    // Shared with `did_change` (via `Discoverer::is_excluded`) so a
+    // change ingested through the in-band RPC path obeys the same
+    // .gitignore / .ignore / [tool.tryke] exclude rules as one picked
+    // up by this watcher. Built once here; rebuilt per-call in the
+    // discovery method (acceptable because that path is cold compared
+    // to this hot one).
+    let gitignore = build_change_set_ignore(root, excludes);
     let mut debouncer = new_debouncer(DEBOUNCE_DELAY, move |res: DebounceEventResult| {
         if let Ok(events) = res {
             let paths: Vec<PathBuf> = events

--- a/docs/guides/reporters.md
+++ b/docs/guides/reporters.md
@@ -20,9 +20,8 @@ Sample output (with `-v` to surface per-assertion lines):
 <!-- REPORTER:text:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.28[0m
+[1mtryke test[0m [2mv0.0.27[0m
 
-[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
 sample.py:
   users
     get
@@ -63,9 +62,8 @@ Sample output:
 <!-- REPORTER:dot:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.28[0m
+[1mtryke test[0m [2mv0.0.27[0m
 
-[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
 [32m.[39m[32m.[39m
 
  [2mTest Files[0m  [1m[32m1 passed[39m[0m [2m(1)[0m
@@ -152,9 +150,8 @@ Sample output:
 <!-- REPORTER:next:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.28[0m
+[1mtryke test[0m [2mv0.0.27[0m
 
-[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
      [1m[32mPASS [39m[0m [[2m  0.000s[0m] [1m[36msample[39m[0m [2m>[0m [36musers[39m [2m>[0m [36mget[39m [2m::[0m returns a stored user
      [1m[32mPASS [39m[0m [[2m  0.000s[0m] [1m[36msample[39m[0m [2m>[0m [36musers[39m [2m>[0m [36mset[39m [2m::[0m stores a new user
 
@@ -183,9 +180,8 @@ Sample output:
 <!-- REPORTER:sugar:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.28[0m
+[1mtryke test[0m [2mv0.0.27[0m
 
-[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
  [1msample.py[0m [32m✓[39m[32m✓[39m                                                [1m2[0m [1m100%[0m [37m████████████[39m
 
  [2mTest Files[0m  [1m[32m1 passed[39m[0m [2m(1)[0m

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,9 +105,8 @@ uvx tryke test
 <!-- REPORTER:text:START -->
 
 ```ansi
-[1mtryke test[0m [2mv0.0.28[0m
+[1mtryke test[0m [2mv0.0.27[0m
 
-[1m[33mwarning:[39m[0m scheduler: upgrading --dist test → file for 1 module(s) because of per="scope" fixtures (sample). Move the fixture into a describe() to keep finer-grained distribution.
 sample.py:
   users
     get


### PR DESCRIPTION
## Summary
- Adds a `did_change` JSON-RPC method that cooperating clients (neotest-tryke, soon) call on the **same TCP connection** before `run`. Per-connection reads are serial, so the dirty flag is guaranteed to be observed `true` by the subsequent `execute_run` → `restart_workers().await` → race closed.
- Extracts the watcher's body into `change::apply_change`, shared with the new RPC handler. FS watcher path stays as a fallback for non-cooperating clients.
- `execute_run`'s drain is conditional, so repeat runs without intervening edits cost ~2ms; only saves trigger a worker pool restart.

## Why
In server mode, a `run` request issued microseconds after a save (e.g. neotest's `BufWritePost` autocmd) could dispatch against workers whose `sys.modules` cache predated the save: the FS watcher's 50ms debounce hadn't yet propagated to a `restart_workers()` call. `tryke test --watch` doesn't suffer from this because its watcher and runner share one task; server mode's two-task topology is what exposes the race. The user-visible symptom was flaky outcomes that disagree with the buffer (`expect("st").to_equal("set")` sometimes passing because workers served the cached `"set"` body).

## Race walkthrough (pre-fix)
```
T=0       editor save returns
T=0.1ms   BufWritePost → TCP → server reads `run` line
T=1ms     execute_run dispatches Unit → worker returns stale-cache result
T=50ms+   watcher debouncer finally fires (too late)
```

## Race walkthrough (post-fix)
```
T=0       editor save returns
T=0.1ms   BufWritePost → TCP → server reads `did_change` line
T=0.2ms   apply_change: rediscover, dirty.store(true, Release)
T=0.3ms   "ok" response written, next read_line()
T=0.3ms   server reads `run` line
T=1ms     execute_run: dirty.swap(false, AcqRel) = true → restart_workers().await
T=80ms    dispatch on fresh workers
```

## Test plan
- [x] `cargo test -p tryke_server` — 45/45 pass, including new:
  - `run_after_did_change_uses_fresh_module` — 16+16 phase 1/2 iters no-sleep alternating file bodies, asserts deterministic outcomes
  - `run_only_falls_back_to_fs_watcher` — documents the FS-watcher fallback path for non-cooperating clients
  - `did_change_sets_dirty_and_broadcasts` / `did_change_empty_paths_triggers_full_rediscover` / `did_change_without_params_returns_invalid_params` — handler unit tests
- [x] `cargo test --workspace` — full workspace green
- [x] Manual: playground reproduction with `nc`-driven alternator confirms 0/6 stale results; same-test repeat runs without edits cost ~2ms (no restart)
- [ ] Client side (neotest-tryke) — companion PR

## Companion PR
`neotest-tryke` needs the matching client-side change to actually send `did_change` before `run`. Older neotest-tryke versions still work against this server — they hit the FS-watcher fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)