### PR TITLE
Fix multiline CLI diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ cargo nextest run --workspace --all-features
 - get your tests to pass. if you didn't run the tests, your code does not work.
 - follow existing code style. check neighboring files for patterns.
 - always run uvx prek run -a at the end of a task.
+- when making changes that affect CLI output, render the ANSI output and
+  share a screenshot with the user for review.
 - When opening a PR, use `.github/pull_request_template.md` and keep each section concise.
 - When opening a PR, do not add any title prefix such as `[codex]`, `[claude]`,
 or a category tag; use the plain title.

--- a/crates/tryke_discovery/src/lib.rs
+++ b/crates/tryke_discovery/src/lib.rs
@@ -17,7 +17,7 @@ use ignore::WalkBuilder;
 use ruff_python_ast::{Expr, Stmt};
 use ruff_python_parser::parse_module;
 use ruff_source_file::LineIndex;
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange, TextSize};
 use tryke_types::{ExpectedAssertion, FixturePer, HookItem, ParsedFile, TestItem};
 
 pub(crate) fn find_project_root(start: &Path) -> Option<PathBuf> {
@@ -1056,20 +1056,60 @@ fn src_text(source: &str, range: ruff_text_size::TextRange) -> String {
     source[start..end].to_owned()
 }
 
+fn source_line(line_index: &LineIndex, offset: TextSize) -> u32 {
+    u32::try_from(line_index.line_index(offset).get()).unwrap_or(0)
+}
+
+fn source_column(line_index: &LineIndex, source: &str, offset: TextSize) -> Option<u32> {
+    u32::try_from(
+        line_index
+            .line_column(offset, source)
+            .column
+            .to_zero_indexed(),
+    )
+    .ok()
+}
+
+fn relative_span(outer: TextRange, inner: TextRange) -> Option<(usize, usize)> {
+    let outer_start: usize = outer.start().into();
+    let inner_start: usize = inner.start().into();
+    let inner_end: usize = inner.end().into();
+    Some((
+        inner_start.checked_sub(outer_start)?,
+        inner_end.checked_sub(inner_start)?,
+    ))
+}
+
 fn extract_expect_call_info(
     call: &ruff_python_ast::ExprCall,
     source: &str,
-) -> Option<(String, Option<String>)> {
+) -> Option<(String, TextRange, Option<String>)> {
     let is_expect = match call.func.as_ref() {
         Expr::Name(n) => n.id.as_str() == "expect",
         Expr::Attribute(a) => a.attr.id.as_str() == "expect",
         _ => return None,
     };
     let nargs = call.arguments.args.len();
-    if !is_expect || nargs == 0 || nargs > 2 {
+    let expr_keywords: Vec<_> = call
+        .arguments
+        .keywords
+        .iter()
+        .filter(|kw| kw.arg.as_ref().is_some_and(|k| k.id.as_str() == "expr"))
+        .collect();
+    if !is_expect
+        || nargs > 2
+        || expr_keywords.len() > 1
+        || (nargs > 0 && !expr_keywords.is_empty())
+    {
         return None;
     }
-    let subject = src_text(source, call.arguments.args[0].range());
+    let subject_range = if let Some(arg) = call.arguments.args.first() {
+        arg.range()
+    } else {
+        let kw = expr_keywords.first()?;
+        kw.value.range()
+    };
+    let subject = src_text(source, subject_range);
     let label = call
         .arguments
         .keywords
@@ -1089,7 +1129,18 @@ fn extract_expect_call_info(
                 None
             }
         });
-    Some((subject, label))
+    Some((subject, subject_range, label))
+}
+
+fn src_keyword_text(source: &str, keyword: &ruff_python_ast::Keyword) -> String {
+    src_text(source, keyword.range())
+}
+
+struct MatcherArg {
+    start: TextSize,
+    range: TextRange,
+    text: String,
+    value: String,
 }
 
 fn try_extract_assertion(
@@ -1109,27 +1160,48 @@ fn try_extract_assertion(
         return None;
     };
     let matcher = outer_attr.attr.id.as_str().to_owned();
-    let (subject, negated, label) = match outer_attr.value.as_ref() {
+    let (subject, subject_range, negated, label) = match outer_attr.value.as_ref() {
         Expr::Call(inner_call) => {
-            let (subject, label) = extract_expect_call_info(inner_call, source)?;
-            (subject, false, label)
+            let (subject, subject_range, label) = extract_expect_call_info(inner_call, source)?;
+            (subject, subject_range, false, label)
         }
         Expr::Attribute(inner_attr) if inner_attr.attr.id.as_str() == "not_" => {
             let Expr::Call(inner_call) = inner_attr.value.as_ref() else {
                 return None;
             };
-            let (subject, label) = extract_expect_call_info(inner_call, source)?;
-            (subject, true, label)
+            let (subject, subject_range, label) = extract_expect_call_info(inner_call, source)?;
+            (subject, subject_range, true, label)
         }
         _ => return None,
     };
-    let args = call
+    if call.arguments.keywords.iter().any(|kw| kw.arg.is_none()) {
+        return None;
+    }
+    let call_range = call.range();
+    let mut args = call
         .arguments
         .args
         .iter()
-        .map(|a| src_text(source, a.range()))
-        .collect();
-    let line = u32::try_from(line_index.line_index(call.range.start()).get()).unwrap_or(0);
+        .map(|a| MatcherArg {
+            start: a.range().start(),
+            range: a.range(),
+            text: src_text(source, a.range()),
+            value: src_text(source, a.range()),
+        })
+        .collect::<Vec<_>>();
+    args.extend(call.arguments.keywords.iter().map(|kw| MatcherArg {
+        start: kw.range().start(),
+        range: kw.range(),
+        text: src_keyword_text(source, kw),
+        value: src_text(source, kw.value.range()),
+    }));
+    args.sort_by_key(|arg| arg.start);
+    let expected_arg_span = args
+        .first()
+        .and_then(|arg| relative_span(call_range, arg.range));
+    let expected_arg_value = args.first().map(|arg| arg.value.clone());
+    let args = args.into_iter().map(|arg| arg.text).collect();
+    let line = source_line(line_index, call_range.start());
     Some(ExpectedAssertion {
         subject,
         matcher,
@@ -1137,6 +1209,13 @@ fn try_extract_assertion(
         args,
         line,
         label,
+        end_line: source_line(line_index, call_range.end()),
+        start_column: source_column(line_index, source, call_range.start()),
+        end_column: source_column(line_index, source, call_range.end()),
+        expression: src_text(source, call_range),
+        subject_span: relative_span(call_range, subject_range),
+        expected_arg_span,
+        expected_arg_value,
     })
 }
 
@@ -2445,6 +2524,18 @@ def test_fn():
         assert_eq!(assertions[0].matcher, "to_equal");
         assert!(!assertions[0].negated);
         assert_eq!(assertions[0].args, vec!["2"]);
+        assert_eq!(assertions[0].line, 3);
+        assert_eq!(assertions[0].end_line, 3);
+        assert_eq!(assertions[0].expression, "expect(add(1, 1)).to_equal(2)");
+        assert_eq!(assertions[0].subject_span, Some((7, "add(1, 1)".len())));
+        assert_eq!(
+            assertions[0].expected_arg_span,
+            assertions[0]
+                .expression
+                .rfind('2')
+                .map(|offset| (offset, 1))
+        );
+        assert_eq!(assertions[0].expected_arg_value.as_deref(), Some("2"));
     }
 
     #[test]
@@ -2498,6 +2589,90 @@ def test_fn():
         let items = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file).tests;
         assert_eq!(items[0].expected_assertions.len(), 1);
         assert_eq!(items[0].expected_assertions[0].line, 4);
+    }
+
+    #[test]
+    fn extracts_multiline_keyword_assertion() {
+        let source = "@test
+def test_fn():
+    expect(
+        expr=x,
+        name=\"label\",
+    ).to_equal(other=1)
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file).tests;
+        assert_eq!(items[0].expected_assertions.len(), 1);
+        let a = &items[0].expected_assertions[0];
+        assert_eq!(a.subject, "x");
+        assert_eq!(a.matcher, "to_equal");
+        assert_eq!(a.args, vec!["other=1"]);
+        assert_eq!(a.label.as_deref(), Some("label"));
+        assert_eq!(a.line, 3);
+        assert_eq!(a.end_line, 6);
+        assert_eq!(
+            a.expression,
+            "expect(\n        expr=x,\n        name=\"label\",\n    ).to_equal(other=1)"
+        );
+        assert_eq!(
+            a.subject_span,
+            a.expression
+                .find("expr=x")
+                .map(|offset| (offset + "expr=".len(), 1))
+        );
+        assert_eq!(
+            a.expected_arg_span,
+            a.expression
+                .find("other=1")
+                .map(|offset| (offset, "other=1".len()))
+        );
+        assert_eq!(a.expected_arg_value.as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn rejects_expect_call_mixing_positional_and_expr_keyword() {
+        let source = "@test
+def test_fn():
+    expect(x, expr=y).to_equal(1)
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file).tests;
+        assert_eq!(items[0].expected_assertions.len(), 0);
+    }
+
+    #[test]
+    fn rejects_expect_call_with_duplicate_expr_keywords() {
+        let source = "@test
+def test_fn():
+    expect(expr=x, expr=y).to_equal(1)
+";
+        let (dir, file) = write_source(source);
+        let parsed = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file);
+        assert_eq!(parsed.tests.len(), 0);
+        assert!(parsed.errors.is_empty());
+    }
+
+    #[test]
+    fn preserves_matcher_keyword_arg_source_order() {
+        let source = "@test
+def test_fn():
+    expect(x).to_equal(second=2, first=1)
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file).tests;
+        let args = &items[0].expected_assertions[0].args;
+        assert_eq!(args, &vec!["second=2".to_owned(), "first=1".to_owned()]);
+    }
+
+    #[test]
+    fn rejects_matcher_with_kwargs_expansion() {
+        let source = "@test
+def test_fn():
+    expect(x).to_equal(**expected)
+";
+        let (dir, file) = write_source(source);
+        let items = parse_tests_from_file(dir.path(), &[dir.path().to_path_buf()], &file).tests;
+        assert_eq!(items[0].expected_assertions.len(), 0);
     }
 
     #[test]

--- a/crates/tryke_reporter/src/text.rs
+++ b/crates/tryke_reporter/src/text.rs
@@ -1025,6 +1025,7 @@ mod tests {
             args: args.into_iter().map(String::from).collect(),
             line: 1,
             label: None,
+            ..Default::default()
         }
     }
 
@@ -1126,6 +1127,7 @@ mod tests {
                 args: vec![],
                 line: 1,
                 label: None,
+                ..Default::default()
             }],
         ));
         let out = String::from_utf8_lossy(&r.into_writer()).into_owned();
@@ -1212,6 +1214,7 @@ mod tests {
                 args: vec!["1".into()],
                 line: 1,
                 label: Some("sum check".into()),
+                ..Default::default()
             }],
         ));
         let out = String::from_utf8_lossy(&r.into_writer()).into_owned();
@@ -1234,6 +1237,7 @@ mod tests {
                     args: vec!["1".into()],
                     line: 5,
                     label: None,
+                    ..Default::default()
                 }],
                 ..Default::default()
             },
@@ -1275,6 +1279,7 @@ mod tests {
                     args: vec!["1".into()],
                     line: 5,
                     label: None,
+                    ..Default::default()
                 }],
                 file_path: Some(PathBuf::from("tests/m.py")),
                 ..Default::default()
@@ -1320,6 +1325,7 @@ mod tests {
                         args: vec!["1".into()],
                         line: 5,
                         label: Some("first check".into()),
+                        ..Default::default()
                     },
                     tryke_types::ExpectedAssertion {
                         subject: "b".into(),
@@ -1328,6 +1334,7 @@ mod tests {
                         args: vec!["2".into()],
                         line: 5,
                         label: Some("second check".into()),
+                        ..Default::default()
                     },
                 ],
                 file_path: Some(PathBuf::from("tests/m.py")),
@@ -1398,6 +1405,7 @@ mod tests {
                         args: vec!["1".into()],
                         line: 3,
                         label: None,
+                        ..Default::default()
                     },
                     tryke_types::ExpectedAssertion {
                         subject: "b".into(),
@@ -1406,6 +1414,7 @@ mod tests {
                         args: vec!["2".into()],
                         line: 4,
                         label: None,
+                        ..Default::default()
                     },
                 ],
                 ..Default::default()
@@ -1454,6 +1463,7 @@ mod tests {
                         args: vec!["1".into()],
                         line: 3,
                         label: None,
+                        ..Default::default()
                     },
                     tryke_types::ExpectedAssertion {
                         subject: "\"hello\"".into(),
@@ -1462,6 +1472,7 @@ mod tests {
                         args: vec!["\"hello\"".into()],
                         line: 4,
                         label: None,
+                        ..Default::default()
                     },
                 ],
                 ..Default::default()

--- a/crates/tryke_runner/src/protocol.rs
+++ b/crates/tryke_runner/src/protocol.rs
@@ -176,7 +176,10 @@ pub struct AssertionWire {
     pub expression: String,
     pub expected: String,
     pub received: String,
+    #[serde(default)]
     pub line: u32,
+    #[serde(default)]
+    pub column: Option<u32>,
     #[serde(default)]
     pub file: Option<String>,
 }

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -378,8 +378,20 @@ fn build_pythonpath(extra: &[&Path]) -> String {
     parts.join(sep)
 }
 
-fn convert_assertion(wire: AssertionWire, expected_arg_span: Option<(usize, usize)>) -> Assertion {
-    let (span_offset, span_length) = compute_subject_span(&wire.expression);
+fn convert_assertion(
+    wire: AssertionWire,
+    expected_assertion: Option<&ExpectedAssertion>,
+) -> Assertion {
+    let expression = expected_assertion
+        .and_then(|ea| (!ea.expression.is_empty()).then(|| ea.expression.clone()))
+        .unwrap_or(wire.expression);
+    let (span_offset, span_length) = expected_assertion
+        .and_then(|ea| ea.subject_span)
+        .unwrap_or_else(|| compute_subject_span(&expression));
+    let expected_arg_span = expected_assertion
+        .and_then(|ea| ea.expected_arg_span)
+        .or_else(|| expected_assertion.and_then(|ea| find_arg_span(&expression, ea)));
+    let line = expected_assertion.map_or(wire.line as usize, |ea| ea.line as usize);
     // Make absolute paths relative to cwd so diagnostics show short paths.
     let file = wire.file.map(|f| {
         std::env::current_dir()
@@ -393,9 +405,9 @@ fn convert_assertion(wire: AssertionWire, expected_arg_span: Option<(usize, usiz
             .unwrap_or(f)
     });
     Assertion {
-        expression: wire.expression,
+        expression,
         file,
-        line: wire.line as usize,
+        line,
         span_offset,
         span_length,
         expected: wire.expected,
@@ -427,24 +439,210 @@ fn find_arg_span(expression: &str, ea: &ExpectedAssertion) -> Option<(usize, usi
 /// Stops at the first top-level comma so that optional arguments like the
 /// label in `expect(val, "label")` are excluded from the span.
 fn compute_subject_span(expression: &str) -> (usize, usize) {
-    let Some(pos) = expression.find("expect(") else {
+    let Some((start, end)) = find_expect_first_arg_bounds(expression) else {
         return (0, expression.len().max(1));
     };
-    let start = pos + 7; // len("expect(")
-    let mut depth: u32 = 1;
-    for (i, ch) in expression[start..].char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' if depth == 1 => return (start, i.max(1)),
-            ')' => depth -= 1,
-            ',' if depth == 1 => {
-                let len = expression[start..start + i].trim_end().len();
-                return (start, len.max(1));
+    normalize_subject_span(expression, start, end)
+}
+
+fn find_expect_first_arg_bounds(expression: &str) -> Option<(usize, usize)> {
+    let pos = expression.find("expect(")?;
+    let start = pos + "expect(".len();
+    let bytes = expression.as_bytes();
+    let mut closers = vec![b')'];
+    let mut index = start;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' => {
+                index = skip_python_string_literal(bytes, index);
+                continue;
+            }
+            b'(' => closers.push(b')'),
+            b'[' => closers.push(b']'),
+            b'{' => closers.push(b'}'),
+            b',' | b')' if closers.len() == 1 => return Some((start, index)),
+            b')' | b']' | b'}' if closers.last().copied() == Some(bytes[index]) => {
+                closers.pop();
             }
             _ => {}
         }
+        index += 1;
     }
-    (start, expression.len().saturating_sub(start).max(1))
+    Some((start, expression.len()))
+}
+
+fn skip_python_string_literal(bytes: &[u8], start: usize) -> usize {
+    let quote = bytes[start];
+    let triple = start + 2 < bytes.len() && bytes[start + 1] == quote && bytes[start + 2] == quote;
+    let mut index = start + if triple { 3 } else { 1 };
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+        } else if triple
+            && index + 2 < bytes.len()
+            && bytes[index] == quote
+            && bytes[index + 1] == quote
+            && bytes[index + 2] == quote
+        {
+            return index + 3;
+        } else if !triple && bytes[index] == quote {
+            return index + 1;
+        } else {
+            index += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn normalize_subject_span(expression: &str, raw_start: usize, raw_end: usize) -> (usize, usize) {
+    let bytes = expression.as_bytes();
+    let mut start = raw_start;
+    while start < raw_end && bytes[start].is_ascii_whitespace() {
+        start += 1;
+    }
+
+    let mut end = raw_end;
+    while end > start && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+
+    (start, end.saturating_sub(start).max(1))
+}
+
+fn expected_end_line(ea: &ExpectedAssertion) -> u32 {
+    ea.end_line.max(ea.line)
+}
+
+fn expected_contains_line(ea: &ExpectedAssertion, line: u32) -> bool {
+    ea.line <= line && line <= expected_end_line(ea)
+}
+
+fn expected_contains_position(ea: &ExpectedAssertion, line: u32, column: Option<u32>) -> bool {
+    if !expected_contains_line(ea, line) {
+        return false;
+    }
+    let Some(column) = column else {
+        return true;
+    };
+    if line == ea.line
+        && let Some(start_column) = ea.start_column
+        && column < start_column
+    {
+        return false;
+    }
+    if line == expected_end_line(ea)
+        && let Some(end_column) = ea.end_column
+        && column > end_column
+    {
+        return false;
+    }
+    true
+}
+
+fn expected_rank(ea: &ExpectedAssertion) -> (u32, usize, u32) {
+    (
+        expected_end_line(ea) - ea.line,
+        ea.expression.len(),
+        ea.start_column.unwrap_or(u32::MAX),
+    )
+}
+
+fn expected_arg_value(ea: &ExpectedAssertion) -> Option<&str> {
+    if let Some(value) = ea.expected_arg_value.as_deref() {
+        return Some(value.trim());
+    }
+    let arg = ea.args.first()?.trim();
+    if let Some((name, value)) = split_keyword_arg_value(arg) {
+        debug_assert!(!name.is_empty());
+        Some(value.trim())
+    } else {
+        Some(arg)
+    }
+}
+
+fn split_keyword_arg_value(arg: &str) -> Option<(&str, &str)> {
+    let (name, value) = arg.split_once('=')?;
+    let name = name.trim();
+    let value = value.trim();
+    if name.is_empty() || value.starts_with('=') || !is_ascii_python_identifier(name) {
+        return None;
+    }
+    Some((name, value))
+}
+
+fn is_ascii_python_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn expected_arg_matches_wire(ea: &ExpectedAssertion, wire: &AssertionWire) -> bool {
+    expected_arg_value(ea).is_some_and(|arg| arg == wire.expected.trim())
+}
+
+fn select_expected_assertion<'a>(
+    expected_assertions: &'a [ExpectedAssertion],
+    wire: &AssertionWire,
+) -> Option<&'a ExpectedAssertion> {
+    let line_matches = expected_assertions
+        .iter()
+        .filter(|ea| expected_contains_line(ea, wire.line))
+        .collect::<Vec<_>>();
+    if wire.column.is_some() {
+        return line_matches
+            .iter()
+            .copied()
+            .filter(|ea| expected_contains_position(ea, wire.line, wire.column))
+            .min_by_key(|ea| expected_rank(ea))
+            .or_else(|| {
+                line_matches
+                    .iter()
+                    .copied()
+                    .min_by_key(|ea| expected_rank(ea))
+            });
+    }
+
+    let expected_matches = line_matches
+        .iter()
+        .copied()
+        .filter(|ea| expected_arg_matches_wire(ea, wire))
+        .collect::<Vec<_>>();
+    if let [ea] = expected_matches.as_slice() {
+        return Some(*ea);
+    }
+
+    let expression_matches = line_matches
+        .iter()
+        .copied()
+        .filter(|ea| !ea.expression.is_empty() && ea.expression == wire.expression)
+        .collect::<Vec<_>>();
+    if let [ea] = expression_matches.as_slice() {
+        return Some(*ea);
+    }
+
+    if let [ea] = line_matches.as_slice() {
+        Some(*ea)
+    } else {
+        None
+    }
+}
+
+fn map_executed_lines(lines: Vec<u32>, expected_assertions: &[ExpectedAssertion]) -> Vec<u32> {
+    lines
+        .into_iter()
+        .map(|line| {
+            let mut matches = expected_assertions
+                .iter()
+                .filter(|ea| expected_contains_line(ea, line));
+            match (matches.next(), matches.next()) {
+                (Some(ea), None) => ea.line,
+                _ => line,
+            }
+        })
+        .collect()
 }
 
 fn convert_result(test: TestItem, wire: RunTestResultWire) -> TestResult {
@@ -469,19 +667,13 @@ fn convert_result(test: TestItem, wire: RunTestResultWire) -> TestResult {
             stdout,
             stderr,
         } => {
-            let expected_by_line: std::collections::HashMap<u32, &ExpectedAssertion> = test
-                .expected_assertions
-                .iter()
-                .map(|ea| (ea.line, ea))
-                .collect();
-
+            let executed_lines = map_executed_lines(executed_lines, &test.expected_assertions);
             let assertions = assertions
                 .into_iter()
                 .map(|wire| {
-                    let expected_arg_span = expected_by_line
-                        .get(&wire.line)
-                        .and_then(|ea| find_arg_span(&wire.expression, ea));
-                    convert_assertion(wire, expected_arg_span)
+                    let expected_assertion =
+                        select_expected_assertion(&test.expected_assertions, &wire);
+                    convert_assertion(wire, expected_assertion)
                 })
                 .collect();
 
@@ -661,9 +853,17 @@ mod tests {
             expected: "2".into(),
             received: "3".into(),
             line: 10,
+            column: None,
             file: Some("tests/test_math.py".into()),
         };
-        let a = convert_assertion(wire, Some((19, 1)));
+        let expected = ExpectedAssertion {
+            subject: "x".into(),
+            matcher: "to_equal".into(),
+            args: vec!["2".into()],
+            line: 10,
+            ..Default::default()
+        };
+        let a = convert_assertion(wire, Some(&expected));
         assert_eq!(a.expression, "expect(x).to_equal(2)");
         assert_eq!(a.expected, "2");
         assert_eq!(a.received, "3");
@@ -673,6 +873,280 @@ mod tests {
         assert_eq!(a.span_offset, 7);
         assert_eq!(a.span_length, 1);
         assert_eq!(a.expected_arg_span, Some((19, 1)));
+    }
+
+    #[test]
+    fn convert_result_uses_discovered_multiline_assertion_source() {
+        let expression =
+            "t.expect(\n    expr=actual,\n    name=\"actual should be one\",\n).to_equal(other=1)";
+        let test = TestItem {
+            expected_assertions: vec![ExpectedAssertion {
+                subject: "actual".into(),
+                matcher: "to_equal".into(),
+                negated: false,
+                args: vec!["other=1".into()],
+                line: 7,
+                label: Some("actual should be one".into()),
+                end_line: 10,
+                start_column: Some(4),
+                end_column: Some(18),
+                expression: expression.into(),
+                subject_span: expression
+                    .find("actual")
+                    .map(|offset| (offset, "actual".len())),
+                expected_arg_span: expression
+                    .find("other=1")
+                    .map(|offset| (offset, "other=1".len())),
+                expected_arg_value: Some("1".into()),
+            }],
+            ..Default::default()
+        };
+        let result = convert_result(
+            test,
+            RunTestResultWire::Failed {
+                duration_ms: 1,
+                message: "assertion failed".into(),
+                traceback: None,
+                assertions: vec![AssertionWire {
+                    expression: ".to_equal(other=1)".into(),
+                    expected: "1".into(),
+                    received: "0".into(),
+                    line: 10,
+                    column: Some(6),
+                    file: Some("tests/test_multiline.py".into()),
+                }],
+                executed_lines: vec![10],
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+        );
+        let TestOutcome::Failed {
+            assertions,
+            executed_lines,
+            ..
+        } = result.outcome
+        else {
+            panic!("expected failed outcome");
+        };
+        let assertion = &assertions[0];
+        assert_eq!(assertion.expression, expression);
+        assert_eq!(assertion.line, 7);
+        assert_eq!(assertion.span_offset, expression.find("actual").unwrap());
+        assert_eq!(
+            assertion.expected_arg_span,
+            expression.find("other=1").map(|offset| (offset, 7))
+        );
+        assert_eq!(executed_lines, vec![7]);
+    }
+
+    #[test]
+    fn convert_result_selects_inner_assertion_by_column() {
+        let test = TestItem {
+            expected_assertions: vec![
+                ExpectedAssertion {
+                    subject: "expect(0).to_equal(1)".into(),
+                    matcher: "to_be_truthy".into(),
+                    negated: false,
+                    args: vec![],
+                    line: 3,
+                    end_line: 3,
+                    start_column: Some(4),
+                    end_column: Some(45),
+                    expression: "expect(expect(0).to_equal(1)).to_be_truthy()".into(),
+                    subject_span: Some((7, 21)),
+                    expected_arg_span: None,
+                    expected_arg_value: None,
+                    label: None,
+                },
+                ExpectedAssertion {
+                    subject: "0".into(),
+                    matcher: "to_equal".into(),
+                    negated: false,
+                    args: vec!["1".into()],
+                    line: 3,
+                    end_line: 3,
+                    start_column: Some(11),
+                    end_column: Some(32),
+                    expression: "expect(0).to_equal(1)".into(),
+                    subject_span: Some((7, 1)),
+                    expected_arg_span: Some((19, 1)),
+                    expected_arg_value: Some("1".into()),
+                    label: None,
+                },
+            ],
+            ..Default::default()
+        };
+        let result = convert_result(
+            test,
+            RunTestResultWire::Failed {
+                duration_ms: 1,
+                message: "assertion failed".into(),
+                traceback: None,
+                assertions: vec![AssertionWire {
+                    expression: "expect(expect(0).to_equal(1)).to_be_truthy()".into(),
+                    expected: "1".into(),
+                    received: "0".into(),
+                    line: 3,
+                    column: Some(21),
+                    file: None,
+                }],
+                executed_lines: vec![3],
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+        );
+        let TestOutcome::Failed { assertions, .. } = result.outcome else {
+            panic!("expected failed outcome");
+        };
+        assert_eq!(assertions[0].expression, "expect(0).to_equal(1)");
+        assert_eq!(assertions[0].span_offset, 7);
+        assert_eq!(assertions[0].expected_arg_span, Some((19, 1)));
+    }
+
+    #[test]
+    fn convert_result_matches_same_line_assertion_by_expected_value_without_column() {
+        let second_expression = "expect(b).to_equal(other=2)";
+        let test = TestItem {
+            expected_assertions: vec![
+                ExpectedAssertion {
+                    subject: "a".into(),
+                    matcher: "to_equal".into(),
+                    negated: false,
+                    args: vec!["1".into()],
+                    line: 5,
+                    end_line: 5,
+                    expression: "expect(a).to_equal(1)".into(),
+                    subject_span: Some((7, 1)),
+                    expected_arg_span: Some((19, 1)),
+                    label: None,
+                    ..Default::default()
+                },
+                ExpectedAssertion {
+                    subject: "b".into(),
+                    matcher: "to_equal".into(),
+                    negated: false,
+                    args: vec!["other=2".into()],
+                    line: 5,
+                    end_line: 5,
+                    expression: second_expression.into(),
+                    subject_span: Some((7, 1)),
+                    expected_arg_span: second_expression
+                        .find("other=2")
+                        .map(|offset| (offset, "other=2".len())),
+                    label: None,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let result = convert_result(
+            test,
+            RunTestResultWire::Failed {
+                duration_ms: 1,
+                message: "assertion failed".into(),
+                traceback: None,
+                assertions: vec![AssertionWire {
+                    expression: "expect(a).to_equal(1); expect(b).to_equal(other=2)".into(),
+                    expected: "2".into(),
+                    received: "0".into(),
+                    line: 5,
+                    column: None,
+                    file: None,
+                }],
+                executed_lines: vec![5],
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+        );
+        let TestOutcome::Failed { assertions, .. } = result.outcome else {
+            panic!("expected failed outcome");
+        };
+        assert_eq!(assertions[0].expression, second_expression);
+        assert_eq!(
+            assertions[0].expected_arg_span,
+            second_expression
+                .find("other=2")
+                .map(|offset| (offset, "other=2".len()))
+        );
+    }
+
+    #[test]
+    fn convert_result_keeps_runtime_expression_for_ambiguous_same_line_without_column() {
+        let runtime_expression = "expect(a).to_equal(1); expect(b).to_equal(1)";
+        let test = TestItem {
+            expected_assertions: vec![
+                ExpectedAssertion {
+                    subject: "a".into(),
+                    matcher: "to_equal".into(),
+                    negated: false,
+                    args: vec!["1".into()],
+                    line: 5,
+                    end_line: 5,
+                    expression: "expect(a).to_equal(1)".into(),
+                    subject_span: Some((7, 1)),
+                    label: None,
+                    ..Default::default()
+                },
+                ExpectedAssertion {
+                    subject: "b".into(),
+                    matcher: "to_equal".into(),
+                    negated: false,
+                    args: vec!["1".into()],
+                    line: 5,
+                    end_line: 5,
+                    expression: "expect(b).to_equal(1)".into(),
+                    subject_span: Some((7, 1)),
+                    label: None,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let result = convert_result(
+            test,
+            RunTestResultWire::Failed {
+                duration_ms: 1,
+                message: "assertion failed".into(),
+                traceback: None,
+                assertions: vec![AssertionWire {
+                    expression: runtime_expression.into(),
+                    expected: "1".into(),
+                    received: "0".into(),
+                    line: 5,
+                    column: None,
+                    file: None,
+                }],
+                executed_lines: vec![5],
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+        );
+        let TestOutcome::Failed { assertions, .. } = result.outcome else {
+            panic!("expected failed outcome");
+        };
+        assert_eq!(assertions[0].expression, runtime_expression);
+    }
+
+    #[test]
+    fn expected_arg_value_only_splits_keyword_arguments() {
+        let positional = ExpectedAssertion {
+            args: vec!["x == y".into()],
+            ..Default::default()
+        };
+        assert_eq!(expected_arg_value(&positional), Some("x == y"));
+
+        let keyword = ExpectedAssertion {
+            args: vec!["other = 1".into()],
+            ..Default::default()
+        };
+        assert_eq!(expected_arg_value(&keyword), Some("1"));
+
+        let discovered_value = ExpectedAssertion {
+            args: vec!["other=x == y".into()],
+            expected_arg_value: Some("x == y".into()),
+            ..Default::default()
+        };
+        assert_eq!(expected_arg_value(&discovered_value), Some("x == y"));
     }
 
     #[test]
@@ -711,10 +1185,86 @@ mod tests {
     }
 
     #[test]
+    fn compute_subject_span_nested_list_with_label() {
+        let expression = "expect([1, {\"two\": (2, 3)}], \"label\")";
+        let (off, len) = compute_subject_span(expression);
+        let expected = "[1, {\"two\": (2, 3)}]";
+        let expected_off = expression.find(expected).expect("list subject");
+        assert_eq!(off, expected_off);
+        assert_eq!(len, expected.len());
+    }
+
+    #[test]
+    fn compute_subject_span_ignores_commas_inside_strings() {
+        let expression = "expect(\"a, b\", \"label\").to_equal(\"a, b\")";
+        let (off, len) = compute_subject_span(expression);
+        let expected = "\"a, b\"";
+        let expected_off = expression.find(expected).expect("string subject");
+        assert_eq!(off, expected_off);
+        assert_eq!(len, expected.len());
+    }
+
+    #[test]
+    fn compute_subject_span_ignores_parens_inside_triple_quoted_strings() {
+        let expression = "expect('''a) b''', \"label\").to_equal(\"a) b\")";
+        let (off, len) = compute_subject_span(expression);
+        let expected = "'''a) b'''";
+        let expected_off = expression.find(expected).expect("string subject");
+        assert_eq!(off, expected_off);
+        assert_eq!(len, expected.len());
+    }
+
+    #[test]
+    fn compute_subject_span_ignores_commas_inside_raw_strings() {
+        let expression = "expect(r\"a, b\", \"label\").to_equal(r\"a, b\")";
+        let (off, len) = compute_subject_span(expression);
+        let expected = "r\"a, b\"";
+        let expected_off = expression.find(expected).expect("raw string subject");
+        assert_eq!(off, expected_off);
+        assert_eq!(len, expected.len());
+    }
+
+    #[test]
     fn compute_subject_span_whitespace_before_comma() {
         let (off, len) = compute_subject_span("expect(val  , \"label\")");
         assert_eq!(off, 7);
         assert_eq!(len, 3); // "val" (trailing whitespace trimmed)
+    }
+
+    #[test]
+    fn compute_subject_span_multiline_keyword_expr_falls_back_to_keyword_arg() {
+        let expression = "t.expect(\n    expr=ctx.module_lines_call_count,\n    name=\"2nd call\"\n).to_equal(other=1)";
+        let (off, len) = compute_subject_span(expression);
+        let expected_off = expression
+            .find("expr=ctx.module_lines_call_count")
+            .expect("keyword subject in expression");
+        assert_eq!(off, expected_off);
+        assert_eq!(len, "expr=ctx.module_lines_call_count".len());
+    }
+
+    #[test]
+    fn compute_subject_span_uses_expected_subject_for_keyword_expr() {
+        let expression = "t.expect(\n    expr=ctx.module_lines_call_count,\n    name=\"2nd call\"\n).to_equal(other=1)";
+        let expected = ExpectedAssertion {
+            subject: "ctx.module_lines_call_count".into(),
+            matcher: "to_equal".into(),
+            negated: false,
+            args: vec!["other=1".into()],
+            line: 10,
+            label: Some("2nd call".into()),
+            subject_span: expression
+                .find("ctx.module_lines_call_count")
+                .map(|offset| (offset, "ctx.module_lines_call_count".len())),
+            ..Default::default()
+        };
+        let (off, len) = expected
+            .subject_span
+            .unwrap_or_else(|| compute_subject_span(expression));
+        let expected_off = expression
+            .find("ctx.module_lines_call_count")
+            .expect("subject in expression");
+        assert_eq!(off, expected_off);
+        assert_eq!(len, "ctx.module_lines_call_count".len());
     }
 
     fn make_expected(matcher: &str, args: &[&str], line: u32) -> ExpectedAssertion {
@@ -725,6 +1275,7 @@ mod tests {
             args: args.iter().map(|s| (*s).to_string()).collect(),
             line,
             label: None,
+            ..Default::default()
         }
     }
 
@@ -751,6 +1302,7 @@ mod tests {
             args: vec!["42".into()],
             line: 10,
             label: None,
+            ..Default::default()
         };
         let span = find_arg_span("expect(foo(bar(1))).to_equal(42)", &ea);
         assert_eq!(span, Some((29, 2)));
@@ -761,6 +1313,15 @@ mod tests {
         let ea = make_expected("to_equal", &["\"hello\""], 10);
         let span = find_arg_span("expect(x).to_equal(\"hello\")", &ea);
         assert_eq!(span, Some((19, 7)));
+    }
+
+    #[test]
+    fn find_arg_span_keyword_arg() {
+        let ea = make_expected("to_equal", &["other=1"], 10);
+        let expression = "expect(x).to_equal(other=1)";
+        let span = find_arg_span(expression, &ea);
+        let expected_offset = expression.find("other=1").expect("arg in expression");
+        assert_eq!(span, Some((expected_offset, 7)));
     }
 
     #[test]

--- a/crates/tryke_types/src/lib.rs
+++ b/crates/tryke_types/src/lib.rs
@@ -21,7 +21,7 @@ pub fn path_to_module(root: &Path, path: &Path) -> Option<String> {
     Some(parts.join("."))
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ExpectedAssertion {
     pub subject: String,
     pub matcher: String,
@@ -29,6 +29,20 @@ pub struct ExpectedAssertion {
     pub args: Vec<String>,
     pub line: u32,
     pub label: Option<String>,
+    #[serde(default)]
+    pub end_line: u32,
+    #[serde(default)]
+    pub start_column: Option<u32>,
+    #[serde(default)]
+    pub end_column: Option<u32>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub expression: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_span: Option<(usize, usize)>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_arg_span: Option<(usize, usize)>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_arg_value: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/python/tryke/expect.py
+++ b/python/tryke/expect.py
@@ -807,7 +807,13 @@ class ExpectationError(AssertionError):
         received: String describing what was actually received.
     """
 
-    def __init__(self, message: str, *, expected: str, received: str) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        expected: str,
+        received: str,
+    ) -> None:
         super().__init__(message)
         self.expected = expected
         self.received = received
@@ -909,7 +915,12 @@ class Expectation[T]:
         ```
     """
 
-    def __init__(self, value: T, *, negated: bool = False) -> None:
+    def __init__(
+        self,
+        value: T,
+        *,
+        negated: bool = False,
+    ) -> None:
         self._value: T = value
         self._negated: bool = negated
 
@@ -927,7 +938,10 @@ class Expectation[T]:
 
             ```
         """
-        return Expectation(self._value, negated=not self._negated)
+        return Expectation(
+            self._value,
+            negated=not self._negated,
+        )
 
     def _assert(
         self,
@@ -939,8 +953,6 @@ class Expectation[T]:
     ) -> MatchResult:
         ok = (not passed) if self._negated else passed
         ctx = _soft_ctx.value
-        # Resolve the caller frame once so we can record the line for the
-        # executed-lines tracker and reuse it in the failure path.
         frame = _caller_frame() if ctx is not None else None
         if ctx is not None and frame is not None and frame.lineno is not None:
             ctx.executed_lines.append(frame.lineno)
@@ -949,7 +961,9 @@ class Expectation[T]:
         prefix = "expected not " if self._negated else "expected "
         actual_expected = ("not " + expected) if self._negated else expected
         err = ExpectationError(
-            prefix + message, expected=actual_expected, received=received
+            prefix + message,
+            expected=actual_expected,
+            received=received,
         )
         if ctx is not None:
             ctx.failures.append(SoftFailure(err, frame))

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -112,6 +112,7 @@ class _AssertionWire(TypedDict):
     expected: str
     received: str
     line: NotRequired[int]
+    column: NotRequired[int]
     file: NotRequired[str]
 
 
@@ -294,6 +295,8 @@ def _make_assertion_wire(
     if frame is not None:
         if frame.lineno is not None:
             wire["line"] = frame.lineno
+        if frame.colno is not None:
+            wire["column"] = frame.colno
         wire["file"] = frame.filename
     return wire
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import io
 import json
 import sys
@@ -173,6 +174,96 @@ with describe("run_test outcomes"):
         result = _run_test_fn(fn)
         expect(result["outcome"], "soft failures fail the test").to_equal("failed")
         expect(result["assertions"], "both soft failures collected").to_have_length(2)
+
+    @test(name="multiline soft assertion reports the runtime frame")
+    def test_multiline_soft_failure_expression() -> None:
+        def fn() -> None:
+            actual = 0
+            expect(
+                actual,
+                "actual should be one",
+            ).to_equal(1)
+
+        source_lines, start_line = inspect.getsourcelines(fn)
+        matcher_line = next(
+            start_line + i for i, line in enumerate(source_lines) if ".to_equal" in line
+        )
+        result = _run_test_fn(fn)
+        assertion = result["assertions"][0]
+        expect(
+            assertion["line"], "failure line is the runtime assertion line"
+        ).to_equal(matcher_line)
+        expect(
+            assertion["expression"], "failure expression includes the runtime line"
+        ).to_contain(".to_equal(1)")
+
+    @test(name="keyword multiline assertion reports the runtime frame")
+    def test_keyword_multiline_soft_failure_expression() -> None:
+        def fn() -> None:
+            actual = 0
+            expect(
+                expr=actual,
+                name="actual should be one",
+            ).to_equal(other=1)
+
+        source_lines, start_line = inspect.getsourcelines(fn)
+        matcher_line = next(
+            start_line + i for i, line in enumerate(source_lines) if ".to_equal" in line
+        )
+        result = _run_test_fn(fn)
+        assertion = result["assertions"][0]
+        expect(assertion["line"], "keyword failure line is the runtime line").to_equal(
+            matcher_line
+        )
+        expect(
+            assertion["expression"], "keyword expression includes matcher argument"
+        ).to_contain(".to_equal(other=1)")
+
+    @test(name="stored expectation reports the assertion line")
+    def test_stored_expectation_reports_assertion_line() -> None:
+        def fn() -> None:
+            actual = 0
+            assertion = expect(actual, "stored expectation")
+            assertion.to_equal(1)
+
+        source_lines, start_line = inspect.getsourcelines(fn)
+        assertion_line = next(
+            start_line + i
+            for i, line in enumerate(source_lines)
+            if "assertion.to_equal" in line
+        )
+        result = _run_test_fn(fn)
+        assertion = result["assertions"][0]
+        expect(assertion["line"], "failure line is the assertion line").to_equal(
+            assertion_line
+        )
+        expect(
+            assertion["expression"], "failure expression is the assertion call"
+        ).to_equal("assertion.to_equal(1)")
+
+    @test(name="stored multiline expectation reports assertion line")
+    def test_stored_multiline_expectation_reports_full_assertion() -> None:
+        def fn() -> None:
+            actual = 0
+            assertion = expect(actual, "stored expectation")
+            assertion.to_equal(
+                1,
+            )
+
+        source_lines, start_line = inspect.getsourcelines(fn)
+        assertion_line = next(
+            start_line + i
+            for i, line in enumerate(source_lines)
+            if "assertion.to_equal" in line
+        )
+        result = _run_test_fn(fn)
+        assertion = result["assertions"][0]
+        expect(assertion["line"], "failure line is the assertion line").to_equal(
+            assertion_line
+        )
+        expect(
+            assertion["expression"], "failure expression includes assertion call"
+        ).to_contain("assertion.to_equal(")
 
     @test(name="general exception")
     def test_general_exception() -> None:


### PR DESCRIPTION
## Context
Fixes assertion diagnostics when `to_equal` is chained on a different line from the actual value, especially keyword-style calls such as `expect(expr=...).to_equal(other=...)`.

The branch is rebased on current `main`. Latest review feedback is addressed by moving source-shape ownership into discovery instead of re-parsing test files in the Python worker.

## Changes
- Store discovered assertion expression, line range, columns, subject span, and first matcher-arg span on `ExpectedAssertion`.
- Keep the Python worker focused on runtime failure facts: frame line, column, file, expected, and received values.
- Join runtime failures back to discovered assertions in the runner by line/column, including nested and multiline assertions.
- Use discovery-provided spans for subject and expected-value highlighting, with a bracket/string-aware fallback only when no discovered assertion is available.
- Preserve matcher argument source order and reject unsupported matcher `**kwargs` spreads in discovery.
- Clarify the CLI-output ANSI screenshot note in `AGENTS.md`.

## Test plan
- `uv run cargo run -- test tests/test_worker.py --reporter llm`
- `cargo test -p tryke_runner`
- `cargo test -p tryke_discovery`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `uv run cargo run -- test --reporter llm`
- `cargo nextest run --workspace --all-features`
- `uvx prek run -a`
- Rendered ANSI CLI output and captured a screenshot for review.
