### PR TITLE
Add watch shortcut to clear results

### DIFF
--- a/crates/tryke/src/cli.rs
+++ b/crates/tryke/src/cli.rs
@@ -216,8 +216,8 @@ pub enum Commands {
         /// Enters an interactive loop: tryke watches all `.py` files
         /// (respecting `.gitignore`), and on each save it walks the import
         /// graph from the modified file forward to find affected tests,
-        /// restarts the worker pool, and reruns just those tests. Press
-        /// `q` to quit.
+        /// restarts the worker pool, and reruns just those tests. Press `q`
+        /// to quit, `enter` to run all tests, or `c` to clear results.
         #[arg(short = 'w', long = "watch")]
         watch: bool,
 

--- a/crates/tryke/src/watch.rs
+++ b/crates/tryke/src/watch.rs
@@ -29,12 +29,32 @@ const QUIT_POLL_INTERVAL: Duration = Duration::from_millis(150);
 struct WatchKeys {
     quit: AtomicBool,
     run_all: AtomicBool,
+    clear_results: AtomicBool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WatchKeyAction {
+    Quit,
+    RunAll,
+    ClearResults,
+    Ignore,
+}
+
+fn watch_key_action(key: Key) -> WatchKeyAction {
+    match key {
+        Key::Char('q' | 'Q') | Key::Escape => WatchKeyAction::Quit,
+        Key::Enter => WatchKeyAction::RunAll,
+        Key::Char('c' | 'C') => WatchKeyAction::ClearResults,
+        _ => WatchKeyAction::Ignore,
+    }
 }
 
 /// Spawn a thread that reads single keypresses from stdin and flips
 /// `keys` accordingly: `q`/`Q`/Escape sets `quit`; Enter sets
 /// `run_all` (consumed once by the watch loop to trigger an explicit
-/// full-suite run). No-op when stdin isn't a TTY (CI, piped input).
+/// full-suite run); `c`/`C` sets `clear_results` (consumed once by
+/// the watch loop to clear the displayed run output). No-op when
+/// stdin isn't a TTY (CI, piped input).
 fn spawn_key_listener(keys: Arc<WatchKeys>) {
     use std::io::IsTerminal;
     if !std::io::stdin().is_terminal() {
@@ -42,17 +62,19 @@ fn spawn_key_listener(keys: Arc<WatchKeys>) {
     }
     let term = Term::stdout();
     std::thread::spawn(move || {
-        loop {
-            match term.read_key() {
-                Ok(Key::Char('q' | 'Q') | Key::Escape) => {
+        while let Ok(key) = term.read_key() {
+            match watch_key_action(key) {
+                WatchKeyAction::Quit => {
                     keys.quit.store(true, Ordering::SeqCst);
                     break;
                 }
-                Ok(Key::Enter) => {
+                WatchKeyAction::RunAll => {
                     keys.run_all.store(true, Ordering::SeqCst);
                 }
-                Err(_) => break,
-                Ok(_) => continue,
+                WatchKeyAction::ClearResults => {
+                    keys.clear_results.store(true, Ordering::SeqCst);
+                }
+                WatchKeyAction::Ignore => continue,
             }
         }
     });
@@ -82,6 +104,14 @@ fn emit_discovery_warnings(reporter: &mut dyn Reporter, discoverer: &Discoverer)
             message,
         });
     }
+}
+
+fn clear_watch_results(reporter: &mut dyn Reporter) {
+    reporter.on_watch_results_cleared(&WatchIdleInfo {
+        hint: "Results cleared. Waiting for file changes...",
+        start_time: None,
+        discovery_duration: None,
+    });
 }
 
 /// Run a single watch cycle. Test failures are non-fatal here: in watch
@@ -205,6 +235,7 @@ pub async fn run_watch(
         // after, then run the full discovered set against fresh
         // workers.
         if keys.run_all.swap(false, Ordering::SeqCst) {
+            keys.clear_results.store(false, Ordering::SeqCst);
             while rx.try_recv().is_ok() {}
             pool.restart_workers().await;
             reporter.arm_clear();
@@ -216,6 +247,10 @@ pub async fn run_watch(
             let disc_dur = Some(disc_start.elapsed());
             emit_discovery_warnings(reporter, &discoverer);
             run_watch_cycle(reporter, tests, &hooks, &pool, maxfail, dist, disc_dur).await;
+            continue;
+        }
+        if keys.clear_results.swap(false, Ordering::SeqCst) {
+            clear_watch_results(reporter);
             continue;
         }
         let first = match rx.recv_timeout(QUIT_POLL_INTERVAL) {
@@ -408,5 +443,22 @@ mod tests {
         assert_eq!(reporter.run_starts, 1, "exactly one initial run expected");
         assert_eq!(reporter.test_completes, 1);
         assert_eq!(reporter.run_completes, 1);
+    }
+
+    #[test]
+    fn watch_keys_map_to_actions() {
+        assert_eq!(watch_key_action(Key::Char('q')), WatchKeyAction::Quit);
+        assert_eq!(watch_key_action(Key::Char('Q')), WatchKeyAction::Quit);
+        assert_eq!(watch_key_action(Key::Escape), WatchKeyAction::Quit);
+        assert_eq!(watch_key_action(Key::Enter), WatchKeyAction::RunAll);
+        assert_eq!(
+            watch_key_action(Key::Char('c')),
+            WatchKeyAction::ClearResults
+        );
+        assert_eq!(
+            watch_key_action(Key::Char('C')),
+            WatchKeyAction::ClearResults
+        );
+        assert_eq!(watch_key_action(Key::Char('x')), WatchKeyAction::Ignore);
     }
 }

--- a/crates/tryke_reporter/src/dot.rs
+++ b/crates/tryke_reporter/src/dot.rs
@@ -135,6 +135,14 @@ impl<W: io::Write> Reporter for DotReporter<W> {
         self.write_header();
         crate::summary::write_idle_summary(&mut self.writer, info);
     }
+
+    fn on_watch_results_cleared(&mut self, info: &crate::reporter::WatchIdleInfo<'_>) {
+        self.clear_armed = true;
+        self.flush_pending_clear();
+        self.header_pending = false;
+        self.write_header();
+        crate::summary::write_cleared_summary(&mut self.writer, info);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tryke_reporter/src/next.rs
+++ b/crates/tryke_reporter/src/next.rs
@@ -367,6 +367,16 @@ impl<W: Write> Reporter for NextReporter<W> {
         self.write_header();
         summary::write_idle_summary(&mut self.writer, info);
     }
+
+    fn on_watch_results_cleared(&mut self, info: &crate::reporter::WatchIdleInfo<'_>) {
+        self.live.finish_and_clear();
+        self.clear_armed = true;
+        self.flush_pending_clear();
+        self.header_pending = false;
+        self.started = false;
+        self.write_header();
+        summary::write_cleared_summary(&mut self.writer, info);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tryke_reporter/src/progress.rs
+++ b/crates/tryke_reporter/src/progress.rs
@@ -145,6 +145,10 @@ impl<R: Reporter> Reporter for ProgressReporter<R> {
         self.inner.on_watch_idle(info);
     }
 
+    fn on_watch_results_cleared(&mut self, info: &crate::reporter::WatchIdleInfo<'_>) {
+        self.inner.on_watch_results_cleared(info);
+    }
+
     fn on_scheduler_warning(&mut self, message: &str) {
         self.inner.on_scheduler_warning(message);
     }

--- a/crates/tryke_reporter/src/reporter.rs
+++ b/crates/tryke_reporter/src/reporter.rs
@@ -42,6 +42,11 @@ pub trait Reporter {
     /// reporters paint a header + IDLE badge with the supplied hint;
     /// non-TTY reporters can ignore this.
     fn on_watch_idle(&mut self, _info: &WatchIdleInfo<'_>) {}
+    /// Render the watch-mode frame shown after the user clears the
+    /// previous run's results with the keyboard shortcut. TTY-facing
+    /// reporters clear the screen and paint a compact IDLE frame;
+    /// structured reporters can ignore this.
+    fn on_watch_results_cleared(&mut self, _info: &WatchIdleInfo<'_>) {}
     /// Surface a non-fatal scheduler warning emitted between
     /// `on_run_start` and the first `on_test_complete` (e.g. dist
     /// upgrades forced by per-scope fixtures). Routing through the

--- a/crates/tryke_reporter/src/sugar.rs
+++ b/crates/tryke_reporter/src/sugar.rs
@@ -385,6 +385,19 @@ impl<W: Write> Reporter for SugarReporter<W> {
         self.write_header();
         summary::write_idle_summary(&mut self.writer, info);
     }
+
+    fn on_watch_results_cleared(&mut self, info: &crate::reporter::WatchIdleInfo<'_>) {
+        self.live.finish_and_clear();
+        self.clear_armed = true;
+        self.flush_pending_clear();
+        self.header_pending = false;
+        self.started = false;
+        self.current_file = None;
+        self.current_marks.clear();
+        self.failures.clear();
+        self.write_header();
+        summary::write_cleared_summary(&mut self.writer, info);
+    }
 }
 
 fn write_failure<W: Write>(live: &LiveArea, writer: &mut W, fail: &TestResult) {

--- a/crates/tryke_reporter/src/summary.rs
+++ b/crates/tryke_reporter/src/summary.rs
@@ -10,7 +10,11 @@ use crate::reporter::WatchIdleInfo;
 /// mode. Stacked vertically with keys right-aligned in the same
 /// column as the `Tests` / `Discovery` labels so the footer reads as
 /// a continuation of the summary block.
-const WATCH_KEYBINDINGS: &[(&str, &str)] = &[("q / esc", "Quit"), ("enter", "Run all tests")];
+const WATCH_KEYBINDINGS: &[(&str, &str)] = &[
+    ("q / esc", "Quit"),
+    ("enter", "Run all tests"),
+    ("c", "Clear results"),
+];
 
 /// Width of the right-aligned label column shared by `Tests`,
 /// `Start at`, `Duration`, and the watch keybinding keys.
@@ -194,6 +198,34 @@ pub fn write_idle_summary<W: io::Write>(writer: &mut W, info: &WatchIdleInfo<'_>
         "Tests".dimmed(),
         "No tests run yet".dimmed(),
         "(0)".dimmed()
+    );
+
+    if let Some(t) = info.start_time {
+        let _ = writeln!(writer, "   {}  {}", "Start at".dimmed(), t);
+    }
+
+    if let Some(d) = info.discovery_duration {
+        let _ = writeln!(writer, "  {}  {}", "Discovery".dimmed(), format_duration(d));
+    }
+
+    let _ = writeln!(writer);
+    let _ = writeln!(writer, " {badge} {}", info.hint.dimmed());
+    write_watch_keybindings(writer);
+}
+
+/// Render the watch frame shown after the user clears prior run
+/// results. It uses the same badge/keybinding footer as the startup
+/// idle frame, but avoids saying "No tests run yet" after a run has
+/// already completed.
+pub fn write_cleared_summary<W: io::Write>(writer: &mut W, info: &WatchIdleInfo<'_>) {
+    let badge = format!("{}", " IDLE ".on_blue().black().bold());
+
+    let _ = writeln!(writer);
+    let _ = writeln!(
+        writer,
+        "      {}  {}",
+        "Tests".dimmed(),
+        "Results cleared".dimmed()
     );
 
     if let Some(t) = info.start_time {
@@ -761,6 +793,25 @@ mod tests {
         // Keybindings render on a separate line below the badge.
         assert!(out.contains("Quit"));
         assert!(out.contains("Run all tests"));
+        assert!(out.contains("Clear results"));
+    }
+
+    #[test]
+    fn cleared_summary_shows_results_cleared_state() {
+        let mut buf = Vec::new();
+        write_cleared_summary(
+            &mut buf,
+            &WatchIdleInfo {
+                hint: "Results cleared. Waiting for file changes...",
+                start_time: None,
+                discovery_duration: None,
+            },
+        );
+        let out = String::from_utf8(buf).expect("utf-8");
+        assert!(out.contains("IDLE"));
+        assert!(out.contains("Results cleared"));
+        assert!(out.contains("Waiting for file changes"));
+        assert!(!out.contains("No tests run yet"));
     }
 
     #[test]

--- a/crates/tryke_reporter/src/text.rs
+++ b/crates/tryke_reporter/src/text.rs
@@ -529,6 +529,16 @@ impl<W: io::Write> Reporter for TextReporter<W> {
         crate::summary::write_idle_summary(&mut self.writer, info);
     }
 
+    fn on_watch_results_cleared(&mut self, info: &crate::reporter::WatchIdleInfo<'_>) {
+        self.clear_armed = true;
+        self.flush_pending_clear();
+        self.header_pending = false;
+        self.current_file = None;
+        self.current_groups.clear();
+        self.write_header();
+        crate::summary::write_cleared_summary(&mut self.writer, info);
+    }
+
     fn on_discovery_warning(&mut self, warning: &DiscoveryWarning) {
         self.flush_pending_clear();
         match warning.kind {

--- a/docs/guides/watch-mode.md
+++ b/docs/guides/watch-mode.md
@@ -33,6 +33,7 @@ Watch mode listens for keypresses while it waits between runs:
 | ------------- | ----------------------------------------------------------------------- |
 | `q` / `esc`   | Quit                                                                    |
 | `enter`       | Run all discovered tests against fresh workers (ignores affected-only). |
+| `c`           | Clear the current test results and keep watching.                       |
 
 ## How affected tests are determined
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -319,7 +319,7 @@ tryke test [OPTIONS] [PATHS]...
 
   Watch the project and rerun affected tests on each change.
 
-  Enters an interactive loop: tryke watches all `.py` files (respecting `.gitignore`), and on each save it walks the import graph from the modified file forward to find affected tests, restarts the worker pool, and reruns just those tests. Press `q` to quit.
+  Enters an interactive loop: tryke watches all `.py` files (respecting `.gitignore`), and on each save it walks the import graph from the modified file forward to find affected tests, restarts the worker pool, and reruns just those tests. Press `q` to quit, `enter` to run all tests, or `c` to clear results.
 
 - `-j`, `--workers` `<WORKERS>`
 


### PR DESCRIPTION
## Context

Watch mode already supports keyboard shortcuts for quitting and running all tests. This adds a shortcut for clearing the visible result output while keeping the watcher alive.

## Changes

- Adds `c` / `C` handling in watch mode to clear current test results.
- Adds a reporter hook and cleared-results idle frame for TTY reporters.
- Updates watch-mode keybinding docs and generated CLI reference docs.

## Test plan

- `uvx prek run -a`
- `cargo nextest run --workspace --all-features`
- `uv run cargo run -- test --reporter llm`