### PR TITLE
Mention uvx quickstart and playground in README and getting started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,36 @@ out of sync with the Rust code.
 `cargo insta accept`
 3. commit the `.snap` files alongside code changes
 
+## playground
+
+the browser playground lives in `playground/`. to run it locally:
+
+```bash
+cd playground
+bun install
+bun run dev
+```
+
+to deploy manually to Cloudflare Pages:
+
+```bash
+cd playground
+bun run build
+bunx wrangler pages deploy dist --project-name=tryke-playground
+```
+
+this creates a preview deployment at a unique URL (e.g.
+`<hash>.tryke-playground.pages.dev`). to deploy straight to production, add
+`--branch main` — this is just metadata passed to Cloudflare and works from
+any local branch:
+
+```bash
+bunx wrangler pages deploy dist --project-name=tryke-playground --branch main
+```
+
+pushes to `main` that touch the playground or WASM crates deploy automatically
+to production via the `playground` GitHub Actions workflow.
+
 ## manual release
 
 1. bump version in both `crates/tryke/Cargo.toml` and `pyproject.toml`

--- a/README.md
+++ b/README.md
@@ -33,14 +33,12 @@
 Run tryke with [uvx](https://docs.astral.sh/uv/guides/tools/) to get started quickly:
 
 ```bash
-uvx tryke test
+uvx tryke
 ```
 
 Or, check out the [tryke playground](https://playground.tryke.dev) to try it out in your browser.
 
 To learn more about using tryke, see the [documentation](https://tryke.dev/).
-
-Write a test.
 
 ```python
 from typing import Annotated

--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@
 
 ## Getting started
 
-For more information, see the [documentation](https://tryke.dev/).
+Run tryke with [uvx](https://docs.astral.sh/uv/guides/tools/) to get started quickly:
+
+```bash
+uvx tryke test
+```
+
+Or, check out the [tryke playground](https://playground.tryke.dev) to try it out in your browser.
+
+To learn more about using tryke, see the [documentation](https://tryke.dev/).
 
 Write a test.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,4 +118,4 @@ This repository is licensed under the [MIT License](https://github.com/thejchap/
 
 ## Installation
 
-See the [installation](guides/installation.md) documentation.
+See the [installation](./guides/installation.md) documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,14 @@ A Rust-based Python test runner with a Jest-style API.
 
 ## Getting started
 
+Run tryke with [uvx](https://docs.astral.sh/uv/guides/tools/) to get started quickly:
+
+```bash
+uvx tryke test
+```
+
+Or, check out the [tryke playground](https://playground.tryke.dev) to try it out in your browser.
+
 ```python
 from typing import Annotated
 


### PR DESCRIPTION
## Context

Split out the documentation-only changes from #126 so they can land independently of the playground/WASM work.

## Changes

- `README.md` and `docs/index.md`: highlight the `uvx tryke test` quickstart and link to `playground.tryke.dev`.
- `CONTRIBUTING.md`: add a "playground" section covering local dev and manual Cloudflare Pages deploys.

## Test plan

- Docs-only change; no code or config affected.
- Rendered diff inspected for both Markdown files.


---
_Generated by [Claude Code](https://claude.ai/code/session_018JL6RbRS18GtjdokqhAgVk)_