### PR TITLE
Centralize warning reporting

### DIFF
--- a/crates/tryke/src/execution.rs
+++ b/crates/tryke/src/execution.rs
@@ -5,7 +5,7 @@ use log::LevelFilter;
 use tokio_stream::StreamExt;
 use tryke_reporter::Reporter;
 use tryke_runner::{DistMode, WorkerPool, partition_with_hooks};
-use tryke_types::{ChangedSelectionSummary, HookItem, RunSummary, TestOutcome, DiscoveryWarning,DiscoveryWarningKind };
+use tryke_types::{ChangedSelectionSummary, HookItem, RunSummary, TestOutcome};
 
 pub fn worker_pool_size() -> usize {
     std::thread::available_parallelism().map_or(4, std::num::NonZero::get)
@@ -138,18 +138,8 @@ pub async fn report_cycle(
 
     let mut hit_maxfail = false;
     let partition = partition_with_hooks(run_tests, hooks, dist);
-    for w in &partition.warnings {
-        // Route through the reporter so TTY-facing reporters can
-        // flush any deferred watch-mode clear/header before the
-        // warning lands — otherwise the first `on_test_complete`'s
-        // clear would scrub it off the screen.
-
-        let warning = DiscoveryWarning {
-            file_path: PathBuf::new(), 
-            kind: DiscoveryWarningKind::Scheduler,
-            message: w.clone(),
-        };
-        reporter.on_discovery_warning(&warning);
+    for warning in &partition.warnings {
+        reporter.on_discovery_warning(warning);
     }
     let mut stream = pool.run(partition.units);
     while let Some(result) = stream.next().await {

--- a/crates/tryke/src/execution.rs
+++ b/crates/tryke/src/execution.rs
@@ -5,7 +5,7 @@ use log::LevelFilter;
 use tokio_stream::StreamExt;
 use tryke_reporter::Reporter;
 use tryke_runner::{DistMode, WorkerPool, partition_with_hooks};
-use tryke_types::{ChangedSelectionSummary, HookItem, RunSummary, TestOutcome};
+use tryke_types::{ChangedSelectionSummary, HookItem, RunSummary, TestOutcome, DiscoveryWarning,DiscoveryWarningKind };
 
 pub fn worker_pool_size() -> usize {
     std::thread::available_parallelism().map_or(4, std::num::NonZero::get)
@@ -143,7 +143,13 @@ pub async fn report_cycle(
         // flush any deferred watch-mode clear/header before the
         // warning lands — otherwise the first `on_test_complete`'s
         // clear would scrub it off the screen.
-        reporter.on_scheduler_warning(w);
+
+        let warning = DiscoveryWarning {
+            file_path: PathBuf::new(), 
+            kind: DiscoveryWarningKind::Scheduler,
+            message: w.clone(),
+        };
+        reporter.on_discovery_warning(&warning);
     }
     let mut stream = pool.run(partition.units);
     while let Some(result) = stream.next().await {

--- a/crates/tryke_reporter/src/dot.rs
+++ b/crates/tryke_reporter/src/dot.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use owo_colors::OwoColorize;
-use tryke_types::{RunSummary, TestItem, TestOutcome, TestResult};
+use tryke_types::{DiscoveryWarning, RunSummary, TestItem, TestOutcome, TestResult};
 
 use crate::Reporter;
 
@@ -124,9 +124,14 @@ impl<W: io::Write> Reporter for DotReporter<W> {
         self.clear_armed = true;
     }
 
-    fn on_scheduler_warning(&mut self, message: &str) {
+    fn on_discovery_warning(&mut self, warning: &DiscoveryWarning) {
         self.flush_pending_header();
-        let _ = writeln!(self.writer, "{} {message}", "warning:".yellow().bold());
+        let _ = writeln!(
+            self.writer,
+            "{} {}",
+            "warning:".yellow().bold(),
+            warning.message.yellow()
+        );
     }
 
     fn on_watch_idle(&mut self, info: &crate::reporter::WatchIdleInfo<'_>) {

--- a/crates/tryke_reporter/src/next.rs
+++ b/crates/tryke_reporter/src/next.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use owo_colors::OwoColorize;
-use tryke_types::{RunSummary, TestItem, TestOutcome, TestResult};
+use tryke_types::{DiscoveryWarning, RunSummary, TestItem, TestOutcome, TestResult};
 
 use crate::Reporter;
 use crate::diagnostic::{render_assertions, render_error_message, render_failure_message};
@@ -351,9 +351,13 @@ impl<W: Write> Reporter for NextReporter<W> {
         self.clear_armed = true;
     }
 
-    fn on_scheduler_warning(&mut self, message: &str) {
+    fn on_discovery_warning(&mut self, warning: &DiscoveryWarning) {
         self.flush_pending_header();
-        let line = format!("{} {message}", "warning:".yellow().bold());
+        let line = format!(
+            "{} {}",
+            "warning:".yellow().bold(),
+            warning.message.yellow()
+        );
         self.live.println(&mut self.writer, &line);
     }
 

--- a/crates/tryke_reporter/src/progress.rs
+++ b/crates/tryke_reporter/src/progress.rs
@@ -1,6 +1,8 @@
 use std::io::{self, Write};
 
-use tryke_types::{DiscoveryError, RunSummary, TestItem, TestOutcome, TestResult};
+use tryke_types::{
+    DiscoveryError, DiscoveryWarning, RunSummary, TestItem, TestOutcome, TestResult,
+};
 
 use crate::Reporter;
 
@@ -129,6 +131,10 @@ impl<R: Reporter> Reporter for ProgressReporter<R> {
         self.inner.on_discovery_error(error);
     }
 
+    fn on_discovery_warning(&mut self, warning: &DiscoveryWarning) {
+        self.inner.on_discovery_warning(warning);
+    }
+
     fn set_subcommand_label(&mut self, label: &'static str) {
         self.inner.set_subcommand_label(label);
     }
@@ -147,10 +153,6 @@ impl<R: Reporter> Reporter for ProgressReporter<R> {
 
     fn on_watch_results_cleared(&mut self, info: &crate::reporter::WatchIdleInfo<'_>) {
         self.inner.on_watch_results_cleared(info);
-    }
-
-    fn on_scheduler_warning(&mut self, message: &str) {
-        self.inner.on_scheduler_warning(message);
     }
 }
 

--- a/crates/tryke_reporter/src/reporter.rs
+++ b/crates/tryke_reporter/src/reporter.rs
@@ -18,9 +18,10 @@ pub trait Reporter {
     fn on_run_complete(&mut self, summary: &RunSummary);
     fn on_collect_complete(&mut self, _tests: &[TestItem]) {}
     fn on_discovery_error(&mut self, _error: &DiscoveryError) {}
-    /// Called once per file when dynamic imports are detected during discovery.
-    /// Implementations should surface this to the user so they understand why
-    /// those files are always included in `--changed` runs.
+    /// Surface a non-fatal warning discovered while collecting or planning a
+    /// run. Implementations that render visible output should flush any
+    /// deferred watch-mode clear/header before writing the warning so it is not
+    /// wiped by the next test event.
     fn on_discovery_warning(&mut self, _warning: &DiscoveryWarning) {}
     /// Lets the CLI tell the reporter which subcommand invoked it, so run
     /// headers can read "tryke test --watch" instead of the generic "tryke test".
@@ -47,17 +48,6 @@ pub trait Reporter {
     /// reporters clear the screen and paint a compact IDLE frame;
     /// structured reporters can ignore this.
     fn on_watch_results_cleared(&mut self, _info: &WatchIdleInfo<'_>) {}
-    /// Surface a non-fatal scheduler warning emitted between
-    /// `on_run_start` and the first `on_test_complete` (e.g. dist
-    /// upgrades forced by per-scope fixtures). Routing through the
-    /// reporter — instead of `eprintln!` — lets watch-mode reporters
-    /// flush any deferred clear/header *before* writing the warning,
-    /// so it isn't wiped from the screen when the first test event
-    /// triggers the clear. Default impl preserves the historical
-    /// behavior for non-TTY reporters: write to stderr.
-    fn on_scheduler_warning(&mut self, message: &str) {
-        eprintln!("warning: {message}");
-    }
 }
 
 #[cfg(test)]

--- a/crates/tryke_reporter/src/sugar.rs
+++ b/crates/tryke_reporter/src/sugar.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 use std::io::{self, Write};
 
 use owo_colors::OwoColorize;
-use tryke_types::{RunSummary, TestItem, TestOutcome, TestResult};
+use tryke_types::{DiscoveryWarning, RunSummary, TestItem, TestOutcome, TestResult};
 
 use crate::Reporter;
 use crate::diagnostic::{render_assertions, render_error_message, render_failure_message};
@@ -368,9 +368,13 @@ impl<W: Write> Reporter for SugarReporter<W> {
         self.clear_armed = true;
     }
 
-    fn on_scheduler_warning(&mut self, message: &str) {
+    fn on_discovery_warning(&mut self, warning: &DiscoveryWarning) {
         self.flush_pending_header();
-        let line = format!("{} {message}", "warning:".yellow().bold());
+        let line = format!(
+            "{} {}",
+            "warning:".yellow().bold(),
+            warning.message.yellow()
+        );
         self.live.println(&mut self.writer, &line);
     }
 

--- a/crates/tryke_reporter/src/text.rs
+++ b/crates/tryke_reporter/src/text.rs
@@ -565,6 +565,14 @@ impl<W: io::Write> Reporter for TextReporter<W> {
                     warning.message.yellow(),
                 );
             }
+            DiscoveryWarningKind::Scheduler => {
+                let _ = writeln!(
+                    self.writer,
+                    "{} {}",
+                    "warning:".yellow().bold(),
+                    warning.message.yellow(),
+                 );
+            }
         }
     }
 }

--- a/crates/tryke_reporter/src/text.rs
+++ b/crates/tryke_reporter/src/text.rs
@@ -510,14 +510,6 @@ impl<W: io::Write> Reporter for TextReporter<W> {
         self.clear_armed = true;
     }
 
-    fn on_scheduler_warning(&mut self, message: &str) {
-        // Drain the deferred clear + header so the warning lands on
-        // the same fresh screen as the upcoming run output, instead
-        // of being wiped by the first `on_test_complete`.
-        self.flush_pending_header();
-        let _ = writeln!(self.writer, "{} {message}", "warning:".yellow().bold());
-    }
-
     fn on_watch_idle(&mut self, info: &crate::reporter::WatchIdleInfo<'_>) {
         // Honor any pending clear (and only then). Discovery warnings
         // emitted just before this call already flushed the clear and
@@ -540,7 +532,11 @@ impl<W: io::Write> Reporter for TextReporter<W> {
     }
 
     fn on_discovery_warning(&mut self, warning: &DiscoveryWarning) {
-        self.flush_pending_clear();
+        if self.header_pending {
+            self.flush_pending_header();
+        } else {
+            self.flush_pending_clear();
+        }
         match warning.kind {
             DiscoveryWarningKind::DynamicImports => {
                 let _ = writeln!(
@@ -557,21 +553,14 @@ impl<W: io::Write> Reporter for TextReporter<W> {
                     "__import__()".dimmed(),
                 );
             }
-            DiscoveryWarningKind::TestingGuardHasElseBranch => {
+            DiscoveryWarningKind::TestingGuardHasElseBranch
+            | DiscoveryWarningKind::DistModeUpgrade => {
                 let _ = writeln!(
                     self.writer,
                     "{} {}",
                     "warning:".yellow().bold(),
                     warning.message.yellow(),
                 );
-            }
-            DiscoveryWarningKind::Scheduler => {
-                let _ = writeln!(
-                    self.writer,
-                    "{} {}",
-                    "warning:".yellow().bold(),
-                    warning.message.yellow(),
-                 );
             }
         }
     }
@@ -669,6 +658,25 @@ mod tests {
         r.on_run_start(&[]);
         assert!(!r.header_pending, "header should write inline, not defer");
         assert!(output(&r).contains("tryke test"));
+    }
+
+    #[test]
+    fn dist_mode_upgrade_warning_flushes_pending_header() {
+        let mut r = reporter();
+        r.arm_clear();
+        r.on_run_start(&[]);
+        assert!(r.header_pending);
+
+        r.on_discovery_warning(&tryke_types::DiscoveryWarning {
+            file_path: PathBuf::new(),
+            kind: tryke_types::DiscoveryWarningKind::DistModeUpgrade,
+            message: "scheduler: upgrading --dist test → file".into(),
+        });
+
+        let out = output(&r);
+        assert!(!r.header_pending);
+        assert!(out.contains("tryke test"), "warning should flush header");
+        assert!(out.contains("--dist test"), "warning message should render");
     }
 
     #[test]

--- a/crates/tryke_runner/src/schedule.rs
+++ b/crates/tryke_runner/src/schedule.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use indexmap::IndexMap;
-use tryke_types::{HookItem, TestItem};
+use tryke_types::{DiscoveryWarning, DiscoveryWarningKind, HookItem, TestItem};
 
 /// How tests are partitioned into work units for distribution across workers.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -37,16 +37,20 @@ pub fn partition(tests: Vec<TestItem>, mode: DistMode) -> Vec<WorkUnit> {
     partition_with_hooks(tests, &[], mode).units
 }
 
-/// The result of [`partition_with_hooks`]: the work units plus any
-/// warnings produced while planning. Warnings cover situations where
-/// the requested `mode` had to be upgraded for correctness (e.g. a
-/// file-scope `per="scope"` fixture forced file-level grouping), and
-/// should be surfaced to the user so they understand why the
-/// distribution differs from what they asked for on the CLI.
+/// The result of the scheduler's allocation of a set of tests to a worker
 #[derive(Debug)]
 pub struct PartitionResult {
+    /// A set of `WorkUnit`s allocated to a worker
+    ///
+    /// `WorkUnit` is a set of tests to be run together
     pub units: Vec<WorkUnit>,
-    pub warnings: Vec<String>,
+
+    /// Warnings produced while planning. Warnings cover situations where
+    /// the requested `mode` had to be upgraded for correctness (e.g. a
+    /// file-scope `per="scope"` fixture forced file-level grouping), and
+    /// should be surfaced to the user so they understand why the
+    /// distribution differs from what they asked for on the CLI.
+    pub warnings: Vec<DiscoveryWarning>,
 }
 
 /// Like [`partition`], but attaches discovered hooks to each work unit.
@@ -114,7 +118,7 @@ pub fn partition_with_hooks(
         .filter(|m| in_run_modules.contains(m))
         .collect();
 
-    let mut warnings: Vec<String> = Vec::new();
+    let mut warnings: Vec<DiscoveryWarning> = Vec::new();
     let mut units: Vec<WorkUnit> = if mode == DistMode::Test && !constrained_modules.is_empty() {
         // Test mode: upgrade constrained modules to group or file level.
         let (constrained, free): (Vec<_>, Vec<_>) = tests
@@ -128,13 +132,17 @@ pub fn partition_with_hooks(
         } else {
             "file"
         };
-        warnings.push(format!(
-            "scheduler: upgrading --dist test → {upgraded_to} for {n} module(s) \
-             because of per=\"scope\" fixtures ({mods}). Move the fixture into \
-             a describe() to keep finer-grained distribution.",
-            n = affected.len(),
-            mods = affected.join(", "),
-        ));
+        warnings.push(DiscoveryWarning {
+            file_path: PathBuf::new(),
+            kind: DiscoveryWarningKind::DistModeUpgrade,
+            message: format!(
+                "scheduler: upgrading --dist test → {upgraded_to} for {n} module(s) \
+                 because of per=\"scope\" fixtures ({mods}). Move the fixture into \
+                 a describe() to keep finer-grained distribution.",
+                n = affected.len(),
+                mods = affected.join(", "),
+            ),
+        });
 
         let mut result: Vec<WorkUnit> = free
             .into_iter()
@@ -158,13 +166,17 @@ pub fn partition_with_hooks(
 
         let mut affected: Vec<&str> = file_constrained_modules.iter().copied().collect();
         affected.sort_unstable();
-        warnings.push(format!(
-            "scheduler: upgrading --dist group → file for {n} module(s) \
-             because of file-scope per=\"scope\" fixtures ({mods}). Move the \
-             fixture into a describe() to keep group-level distribution.",
-            n = affected.len(),
-            mods = affected.join(", "),
-        ));
+        warnings.push(DiscoveryWarning {
+            file_path: PathBuf::new(),
+            kind: DiscoveryWarningKind::DistModeUpgrade,
+            message: format!(
+                "scheduler: upgrading --dist group → file for {n} module(s) \
+                 because of file-scope per=\"scope\" fixtures ({mods}). Move the \
+                 fixture into a describe() to keep group-level distribution.",
+                n = affected.len(),
+                mods = affected.join(", "),
+            ),
+        });
 
         let mut result = group_by_describe(free);
         result.extend(group_by_file(constrained));
@@ -203,7 +215,7 @@ pub fn partition_with_hooks(
 
 #[cfg(test)]
 mod tests {
-    use tryke_types::FixturePer;
+    use tryke_types::{DiscoveryWarningKind, FixturePer};
 
     use super::*;
 
@@ -459,9 +471,13 @@ mod tests {
         let result = partition_with_hooks(tests, &hooks, DistMode::Test);
         assert_eq!(result.warnings.len(), 1, "expected one upgrade warning");
         let w = &result.warnings[0];
-        assert!(w.contains("--dist test"), "warning text: {w}");
-        assert!(w.contains("→ file"), "warning text: {w}");
-        assert!(w.contains("(a)"), "warning should name module 'a': {w}");
+        assert_eq!(w.kind, DiscoveryWarningKind::DistModeUpgrade);
+        assert!(w.message.contains("--dist test"), "warning text: {w:?}");
+        assert!(w.message.contains("→ file"), "warning text: {w:?}");
+        assert!(
+            w.message.contains("(a)"),
+            "warning should name module 'a': {w:?}"
+        );
     }
 
     #[test]
@@ -474,8 +490,9 @@ mod tests {
         let result = partition_with_hooks(tests, &hooks, DistMode::Group);
         assert_eq!(result.warnings.len(), 1);
         let w = &result.warnings[0];
-        assert!(w.contains("--dist group"), "warning text: {w}");
-        assert!(w.contains("→ file"), "warning text: {w}");
+        assert_eq!(w.kind, DiscoveryWarningKind::DistModeUpgrade);
+        assert!(w.message.contains("--dist group"), "warning text: {w:?}");
+        assert!(w.message.contains("→ file"), "warning text: {w:?}");
     }
 
     #[test]

--- a/crates/tryke_server/src/handler.rs
+++ b/crates/tryke_server/src/handler.rs
@@ -233,8 +233,8 @@ async fn execute_run(
     let test_start = Instant::now();
     // Server uses test-level distribution by default.
     let partition = partition_with_hooks(tests, &hooks, DistMode::Test);
-    for w in &partition.warnings {
-        log::warn!("{w}");
+    for warning in &partition.warnings {
+        log::warn!("{}", warning.message);
     }
     let mut stream = pool.run(partition.units);
     let mut passed = 0usize;

--- a/crates/tryke_types/src/lib.rs
+++ b/crates/tryke_types/src/lib.rs
@@ -224,6 +224,8 @@ pub enum DiscoveryWarningKind {
     /// Discovery does not descend into guards with alternative branches, so
     /// any tests inside would be silently dropped; surface it instead.
     TestingGuardHasElseBranch,
+
+    Scheduler,
 }
 
 /// A non-fatal issue detected during test discovery that may degrade

--- a/crates/tryke_types/src/lib.rs
+++ b/crates/tryke_types/src/lib.rs
@@ -613,6 +613,8 @@ pub enum DiscoveryWarningKind {
     /// Discovery does not descend into guards with alternative branches, so
     /// any tests inside would be silently dropped; surface it instead.
     TestingGuardHasElseBranch,
+
+    Scheduler,
 }
 
 /// A non-fatal issue detected during test discovery that may degrade

--- a/crates/tryke_types/src/lib.rs
+++ b/crates/tryke_types/src/lib.rs
@@ -602,19 +602,22 @@ pub struct DiscoveryError {
 }
 
 /// The kind of issue detected during test discovery.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DiscoveryWarningKind {
     /// File contains `importlib.import_module()` or `__import__()` calls.
     /// tryke cannot statically trace these imports, so the file is always
     /// included in `--changed` runs regardless of what actually changed.
     DynamicImports,
+
     /// File contains `if __TRYKE_TESTING__:` with an `elif` or `else` branch.
     /// Discovery does not descend into guards with alternative branches, so
     /// any tests inside would be silently dropped; surface it instead.
     TestingGuardHasElseBranch,
 
-    Scheduler,
+    /// The requested distribution mode was upgraded to preserve fixture
+    /// semantics, so execution may be less granular than requested.
+    DistModeUpgrade,
 }
 
 /// A non-fatal issue detected during test discovery that may degrade
@@ -711,6 +714,18 @@ mod tests {
         let json = serde_json::to_string(&warning).expect("serialize");
         assert!(json.contains("dynamic_imports"));
         assert!(json.contains("loader.py"));
+    }
+
+    #[test]
+    fn dist_mode_upgrade_warning_serializes() {
+        let warning = DiscoveryWarning {
+            file_path: PathBuf::new(),
+            kind: DiscoveryWarningKind::DistModeUpgrade,
+            message: "scheduler upgraded distribution".into(),
+        };
+        let json = serde_json::to_string(&warning).expect("serialize");
+        assert!(json.contains("dist_mode_upgrade"));
+        assert!(json.contains("scheduler upgraded distribution"));
     }
 
     #[test]


### PR DESCRIPTION
## Context
<!--
Links, related issues, or brief background.
-->

This was done as work for the bug #75


## Changes

<!--
Concise summary of what changed.
-->
1. I routed scheduler warnings through on_discovery_warning
This was done to use the same flow as the discovery warnings
2. I had to wrap the scheduler warning strings into a DiscoveryWarning object
I got an error after changing reporter.on_scheduler_warning(w) to on_discovery_warning(w)
It was trying to pass a string but need an object
3. Added Scheduler to on_discovery_warning to handle this error 
DiscoveryWarningKind::Scheduler` not covered
4. Used AI for this part - Added handling for DiscoveryWarningKind::Scheduler in the text reporter. This lets the scheduler warnings print correctly 
## Test plan
Cargo Test
They all passed
<!--
Commands run and any rollout notes.
-->
