### PR TITLE
Refactor RPC method definition

### DIFF
--- a/crates/tryke_runner/src/protocol.rs
+++ b/crates/tryke_runner/src/protocol.rs
@@ -32,23 +32,33 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize)]
-pub struct RpcRequest {
+#[serde(rename_all = "snake_case")]
+pub enum RPCRequestMethod {
+    RegisterHooks,
+    FinalizeHooks,
+    RunTest,
+    RunDoctest,
+    Ping,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RPCRequest {
     pub jsonrpc: &'static str,
     pub id: u64,
-    pub method: String,
+    pub method: RPCRequestMethod,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct RpcResponse {
+pub struct RPCResponse {
     pub id: u64,
     pub result: Option<serde_json::Value>,
-    pub error: Option<RpcErrorDetail>,
+    pub error: Option<RPCErrorDetail>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct RpcErrorDetail {
+pub struct RPCErrorDetail {
     pub code: i32,
     pub message: String,
     #[serde(default)]

--- a/crates/tryke_runner/src/worker.rs
+++ b/crates/tryke_runner/src/worker.rs
@@ -10,8 +10,8 @@ use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tryke_types::{TestItem, TestResult, convert_wire_result};
 
 use crate::protocol::{
-    FinalizeHooksParams, RegisterHooksParams, RpcRequest, RpcResponse, RunDoctestParams,
-    RunTestParams, RunTestResultWire,
+    FinalizeHooksParams, RPCRequest, RPCRequestMethod, RPCResponse, RegisterHooksParams,
+    RunDoctestParams, RunTestParams, RunTestResultWire,
 };
 
 /// Cap on retained worker-stderr bytes. Beyond this we keep the most recent
@@ -107,15 +107,15 @@ impl WorkerProcess {
 
     async fn call<R: for<'de> serde::Deserialize<'de>>(
         &mut self,
-        method: &str,
+        method: RPCRequestMethod,
         params: Option<serde_json::Value>,
     ) -> Result<R> {
         let id = self.next_id;
         self.next_id += 1;
-        let req = RpcRequest {
+        let req = RPCRequest {
             jsonrpc: "2.0",
             id,
-            method: method.to_string(),
+            method,
             params,
         };
         let mut line = serde_json::to_string(&req)?;
@@ -127,7 +127,7 @@ impl WorkerProcess {
         // library may have written to fd 1 during import (e.g. weasyprint via
         // cffi).  Collect leaked lines so we can surface them in errors.
         let mut leaked_stdout: Vec<String> = Vec::new();
-        let resp: RpcResponse = loop {
+        let resp: RPCResponse = loop {
             let mut resp_line = String::new();
             let n = self.stdout.read_line(&mut resp_line).await?;
             if n == 0 {
@@ -145,7 +145,7 @@ impl WorkerProcess {
             trace!("worker rpc <- {}", resp_line.trim());
             let trimmed = resp_line.trim();
             if !trimmed.is_empty()
-                && let Ok(resp) = serde_json::from_str::<RpcResponse>(trimmed)
+                && let Ok(resp) = serde_json::from_str::<RPCResponse>(trimmed)
             {
                 if !leaked_stdout.is_empty() {
                     trace!(
@@ -194,7 +194,7 @@ impl WorkerProcess {
             groups: test.groups.clone(),
             case_label: test.case_label.clone(),
         })?;
-        let wire: RunTestResultWire = self.call("run_test", Some(params)).await?;
+        let wire: RunTestResultWire = self.call(RPCRequestMethod::RunTest, Some(params)).await?;
         Ok(convert_wire_result(test.clone(), wire))
     }
 
@@ -206,7 +206,7 @@ impl WorkerProcess {
     /// rejects the registration request.
     pub async fn register_hooks(&mut self, params: RegisterHooksParams) -> Result<()> {
         let value = serde_json::to_value(params)?;
-        self.call::<serde_json::Value>("register_hooks", Some(value))
+        self.call::<serde_json::Value>(RPCRequestMethod::RegisterHooks, Some(value))
             .await?;
         Ok(())
     }
@@ -220,7 +220,7 @@ impl WorkerProcess {
     /// worker reports a teardown failure.
     pub async fn finalize_hooks(&mut self, module: String) -> Result<()> {
         let value = serde_json::to_value(FinalizeHooksParams { module })?;
-        self.call::<serde_json::Value>("finalize_hooks", Some(value))
+        self.call::<serde_json::Value>(RPCRequestMethod::FinalizeHooks, Some(value))
             .await?;
         Ok(())
     }
@@ -230,7 +230,9 @@ impl WorkerProcess {
             module: test.module_path.clone(),
             object_path: object_path.to_owned(),
         })?;
-        let wire: RunTestResultWire = self.call("run_doctest", Some(params)).await?;
+        let wire: RunTestResultWire = self
+            .call(RPCRequestMethod::RunDoctest, Some(params))
+            .await?;
         Ok(convert_wire_result(test.clone(), wire))
     }
 
@@ -240,7 +242,7 @@ impl WorkerProcess {
     /// Returns an error if the ping RPC fails or if the worker returns an
     /// unexpected response.
     pub async fn ping(&mut self) -> Result<()> {
-        let result: String = self.call("ping", None).await?;
+        let result: String = self.call(RPCRequestMethod::Ping, None).await?;
         if result == "pong" {
             Ok(())
         } else {

--- a/crates/tryke_server/src/protocol.rs
+++ b/crates/tryke_server/src/protocol.rs
@@ -101,7 +101,7 @@ impl<T: Serialize> Response<T> {
 pub struct ErrorResponse {
     pub jsonrpc: String,
     pub id: Option<Value>,
-    pub error: RpcError,
+    pub error: RPCError,
 }
 
 impl ErrorResponse {
@@ -110,7 +110,7 @@ impl ErrorResponse {
         Self {
             jsonrpc: "2.0".to_string(),
             id,
-            error: RpcError { code, message },
+            error: RPCError { code, message },
         }
     }
 
@@ -126,7 +126,7 @@ impl ErrorResponse {
 }
 
 #[derive(Debug, Serialize)]
-pub struct RpcError {
+pub struct RPCError {
     pub code: i32,
     pub message: String,
 }
@@ -236,7 +236,7 @@ mod tests {
         let resp = ErrorResponse {
             jsonrpc: "2.0".to_string(),
             id: None,
-            error: RpcError {
+            error: RPCError {
                 code: METHOD_NOT_FOUND,
                 message: "not found".to_string(),
             },

--- a/python/tryke/worker.py
+++ b/python/tryke/worker.py
@@ -57,7 +57,14 @@ import logging
 import os
 import sys
 import traceback
-from typing import TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    NotRequired,
+    TypedDict,
+    assert_never,
+)
 
 import tryke_guard
 from tryke.runner import (
@@ -93,6 +100,39 @@ type _DispatchResult = TestResult | str | None
 
 class _InvalidParamsError(Exception):
     """Missing or invalid JSON-RPC method parameter."""
+
+
+_Method = Literal["ping", "register_hooks", "finalize_hooks", "run_test", "run_doctest"]
+"""Tryke RPC methods"""
+
+_JSONRPCErrorCode = Literal[-32700, -32600, -32601, -32602, -32603]
+"""
+code	message	meaning
+-32700	Parse error	Invalid JSON was received by the server.
+An error occurred on the server while parsing the JSON text.
+-32600	Invalid Request	The JSON sent is not a valid Request object.
+-32601	Method not found	The method does not exist / is not available.
+-32602	Invalid params	Invalid method parameter(s).
+-32603	Internal error	Internal JSON-RPC error.
+-32000 to -32099	Server error	Reserved for implementation-defined server-errors.
+The remainder of the space is available for application defined errors.
+"""
+
+
+class _JSONRPCError(TypedDict):
+    code: _JSONRPCErrorCode
+    message: str
+    data: NotRequired[Any]
+    traceback: NotRequired[str]
+
+
+class _JSONRPCResponse(TypedDict):
+    """https://www.jsonrpc.org/specification#response_object"""
+
+    id: NotRequired[int | str | None]
+    jsonrpc: Literal["2.0"]
+    result: NotRequired[Any]
+    error: NotRequired[_JSONRPCError]
 
 
 class Worker:
@@ -161,12 +201,13 @@ class Worker:
                         "error": {
                             "code": -32603,
                             "message": str(exc),
+                            # TODO(thejchap) change to data # noqa: FIX002, TD003, TD004
                             "traceback": traceback.format_exc(),
                         },
                     }
                 )
 
-    def _write(self, obj: dict[str, object]) -> None:
+    def _write(self, obj: _JSONRPCResponse) -> None:
         self._output.write(json.dumps(obj) + "\n")
         self._output.flush()
 
@@ -190,42 +231,42 @@ class Worker:
 
     def _dispatch(
         self,
-        method: str,
+        method: _Method,
         params: dict[str, object],
     ) -> _DispatchResult:
-        if method == "ping":
-            return "pong"
-        if method == "register_hooks":
-            return self._register_hooks(
-                self._require_str(params, "module", method),
-                params.get("hooks", []),
-            )
-        if method == "finalize_hooks":
-            return self._finalize_hooks(
-                self._require_str(params, "module", method),
-            )
-        if method == "run_test":
-            xfail_raw = params.get("xfail")
-            raw_groups = params.get("groups", [])
-            groups = (
-                [str(g) for g in raw_groups] if isinstance(raw_groups, list) else []
-            )
-            case_label_raw = params.get("case_label")
-            case_label = str(case_label_raw) if case_label_raw is not None else None
-            return self._run_test(
-                self._require_str(params, "module", method),
-                self._require_str(params, "function", method),
-                xfail=(str(xfail_raw) if xfail_raw is not None else None),
-                groups=groups,
-                case_label=case_label,
-            )
-        if method == "run_doctest":
-            return self._run_doctest(
-                self._require_str(params, "module", method),
-                str(params.get("object_path", "")),
-            )
-        msg = f"unknown method: {method}"
-        raise ValueError(msg)
+        match method:
+            case "ping":
+                return "pong"
+            case "register_hooks":
+                return self._register_hooks(
+                    self._require_str(params, "module", method),
+                    params.get("hooks", []),
+                )
+            case "finalize_hooks":
+                return self._finalize_hooks(
+                    self._require_str(params, "module", method),
+                )
+            case "run_test":
+                xfail_raw = params.get("xfail")
+                raw_groups = params.get("groups", [])
+                groups = (
+                    [str(g) for g in raw_groups] if isinstance(raw_groups, list) else []
+                )
+                case_label_raw = params.get("case_label")
+                case_label = str(case_label_raw) if case_label_raw is not None else None
+                return self._run_test(
+                    self._require_str(params, "module", method),
+                    self._require_str(params, "function", method),
+                    xfail=(str(xfail_raw) if xfail_raw is not None else None),
+                    groups=groups,
+                    case_label=case_label,
+                )
+            case "run_doctest":
+                return self._run_doctest(
+                    self._require_str(params, "module", method),
+                    str(params.get("object_path", "")),
+                )
+        assert_never(method)
 
     def _get_module(self, module_name: str) -> ModuleType:
         if module_name not in self._modules:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -100,8 +100,8 @@ with describe("json-rpc envelope"):
     def test_unknown_method() -> None:
         resp = _send(_rpc("bogus"))
         expect(resp["error"]["code"], "internal error code").to_equal(-32603)
-        expect(resp["error"]["message"], "error mentions unknown method").to_contain(
-            "unknown method",
+        expect(resp["error"]["message"], "unknown method").to_contain(
+            "Expected code to be unreachable",
         )
 
     @test(name="missing required param returns -32602")


### PR DESCRIPTION
## Context
Minor refactor of RPC method definition

## Changes
Changes strings to `Literal` Python-side and `enum` Rust-side

## Test plan
Yep